### PR TITLE
remove mise binary from final image

### DIFF
--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -76,13 +76,13 @@
      "customName": "install mise packages: go, node, python"
     },
     {
+     "path": "/mise/installs/go/1.23.5/bin"
+    },
+    {
      "path": "/mise/installs/node/20.18.2/bin"
     },
     {
      "path": "/mise/installs/python/3.13.1/bin"
-    },
-    {
-     "path": "/mise/installs/go/1.23.5/bin"
     }
    ],
    "dependsOn": [

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -147,8 +147,8 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 
 	// Packages installed have binaries available at /mise/installs/{package}/{version}/bin
 	// We need to add these to the PATH
-	for _, pkg := range b.MisePackages {
-		resolved, ok := options.ResolvedPackages[pkg.Name]
+	for _, pkg := range b.sortedPackageNames() {
+		resolved, ok := options.ResolvedPackages[pkg]
 		if !ok || resolved.ResolvedVersion == nil {
 			continue
 		}
@@ -156,7 +156,7 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 		version := *resolved.ResolvedVersion
 
 		step.AddCommands([]plan.Command{
-			plan.NewPathCommand("/mise/installs/" + pkg.Name + "/" + version + "/bin"),
+			plan.NewPathCommand("/mise/installs/" + pkg + "/" + version + "/bin"),
 		})
 	}
 
@@ -183,4 +183,13 @@ func (b *MiseStepBuilder) GetSupportingMiseConfigFiles(path string) []string {
 	}
 
 	return files
+}
+
+func (b *MiseStepBuilder) sortedPackageNames() []string {
+	packages := make([]string, 0, len(b.MisePackages))
+	for _, pkg := range b.MisePackages {
+		packages = append(packages, pkg.Name)
+	}
+	sort.Strings(packages)
+	return packages
 }


### PR DESCRIPTION
The mise binary is ~46MB. We previously needed it because we were using [the shims](https://mise.jdx.dev/dev-tools/shims.html). I realized we don't actually need the shims because we know the full resolved version of each package that will be installed so we can instead add the path to the executables directly.

<img width="1380" alt="image" src="https://github.com/user-attachments/assets/0dfc4912-3c4b-46b2-ae65-822a4db9a195" />
