### PR TITLE
properly use the version set by goreleaser

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -49,7 +49,7 @@ var BuildCommand = &cli.Command{
 			return cli.Exit(err, 1)
 		}
 
-		core.PrettyPrintBuildResult(buildResult)
+		core.PrettyPrintBuildResult(buildResult, core.PrintOptions{Version: Version})
 
 		serializedPlan, err := json.MarshalIndent(buildResult.Plan, "", "  ")
 		if err != nil {

--- a/cli/common.go
+++ b/cli/common.go
@@ -10,6 +10,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+var Version string // This will be set by main
+
 func commonPlanFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringSliceFlag{

--- a/cli/info.go
+++ b/cli/info.go
@@ -40,6 +40,7 @@ var InfoCommand = &cli.Command{
 		if format == "pretty" {
 			buildResultString = core.FormatBuildResult(buildResult, core.PrintOptions{
 				Metadata: true,
+				Version:  Version,
 			})
 		} else {
 			serializedResult, err := json.MarshalIndent(buildResult, "", "  ")

--- a/cli/prepare.go
+++ b/cli/prepare.go
@@ -34,7 +34,7 @@ var PrepareCommand = &cli.Command{
 		}
 
 		// Pretty print the result to stdout
-		core.PrettyPrintBuildResult(buildResult)
+		core.PrettyPrintBuildResult(buildResult, core.PrintOptions{Version: Version})
 
 		// Save plan if requested
 		if planOut := cmd.String("plan-out"); planOut != "" {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -11,9 +11,14 @@ import (
 	urfave "github.com/urfave/cli/v3"
 )
 
-var verbose bool
+var (
+	verbose bool
+	version = "dev" // This will be overwritten by goreleaser
+)
 
 func main() {
+	cli.Version = version
+
 	logger := log.Default()
 	logger.SetTimeFormat("")
 	urfaveLogWriter := logger.StandardLog(log.StandardLogOptions{
@@ -29,10 +34,10 @@ func main() {
 		Name:                  "railpack",
 		Usage:                 "Automatically analyze and generate build plans for applications",
 		EnableShellCompletion: true,
+		Version:               cli.Version,
 		Flags: []urfave.Flag{
 			&urfave.BoolFlag{
 				Name:        "verbose",
-				Aliases:     []string{"v"},
 				Usage:       "Enable verbose logging",
 				Value:       false,
 				Destination: &verbose,

--- a/core/prettyPrint.go
+++ b/core/prettyPrint.go
@@ -54,6 +54,7 @@ var (
 
 type PrintOptions struct {
 	Metadata bool
+	Version  string
 }
 
 func PrettyPrintBuildResult(buildResult *BuildResult, options ...PrintOptions) {
@@ -69,7 +70,7 @@ func FormatBuildResult(br *BuildResult, options ...PrintOptions) string {
 	var output strings.Builder
 
 	// Header section
-	header := "Railpack v0.0.1"
+	header := fmt.Sprintf("Railpack %s", opts.Version)
 	output.WriteString(headerStyle.Render(header))
 	output.WriteString("\n")
 


### PR DESCRIPTION
Correct version in the pretty output as well as in `railpack --version`
