### PR TITLE
custom frontend uses `--build-arg:name=value`

### DIFF
--- a/buildkit/frontend.go
+++ b/buildkit/frontend.go
@@ -42,8 +42,10 @@ func StartFrontend() {
 
 func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 	opts := c.BuildOpts().Opts
-	cacheKey := opts[cacheKey]
-	secretsHash := opts[secretsHash]
+	buildArgs := parseBuildArgs(opts)
+
+	cacheKey := buildArgs[cacheKey]
+	secretsHash := buildArgs[secretsHash]
 
 	buildPlatform, err := validatePlatform(opts)
 	if err != nil {
@@ -175,4 +177,20 @@ func readFile(ctx context.Context, c client.Client, filename string) (string, er
 	fileContents := string(content)
 
 	return fileContents, nil
+}
+
+func parseBuildArgs(opts map[string]string) map[string]string {
+	buildArgs := make(map[string]string)
+
+	for key, arg := range opts {
+		if !strings.HasPrefix(key, "build-arg:") {
+			continue
+		}
+
+		// Remove the "build-arg:" prefix
+		name := strings.TrimPrefix(key, "build-arg:")
+		buildArgs[name] = arg
+	}
+
+	return buildArgs
 }

--- a/buildkit/frontend_test.go
+++ b/buildkit/frontend_test.go
@@ -1,0 +1,31 @@
+package buildkit
+
+import (
+	"testing"
+)
+
+func TestParseBuildArgs(t *testing.T) {
+	opts := map[string]string{
+		"build-arg:FOO": "bar",
+		"platform":      "linux/amd64",
+		"build-arg:BAZ": "qux",
+		"filename":      "Dockerfile",
+	}
+
+	got := parseBuildArgs(opts)
+
+	want := map[string]string{
+		"FOO": "bar",
+		"BAZ": "qux",
+	}
+
+	if len(got) != len(want) {
+		t.Errorf("got %d build args, want %d", len(got), len(want))
+	}
+
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("build arg %q = %q, want %q", k, got[k], v)
+		}
+	}
+}


### PR DESCRIPTION
This is the recommended way of passing options to the frontend so that they can also be used with `--build-arg` with the `docker buildx build` command
