### PR TITLE
build and publish base image

### DIFF
--- a/.github/workflows/build-debian-base.yml
+++ b/.github/workflows/build-debian-base.yml
@@ -1,0 +1,58 @@
+name: Build Debian Base Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "images/debian/build/Dockerfile"
+      - ".github/workflows/build-debian-base.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-debian-base
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=long
+            type=raw,value={{date 'YYYYMMDD'}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: images/debian/build
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -1,0 +1,28 @@
+FROM buildpack-deps:bookworm-scm
+
+# Install any system deps that might be needed to build a language from source
+# Python: https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libssl-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libffi-dev \
+    liblzma-dev
+
+# Install mise
+ENV MISE_INSTALL_PATH=/usr/local/bin/mise \
+    MISE_DATA_DIR=/mise \
+    MISE_CONFIG_DIR=/mise \
+    MISE_CACHE_DIR=/mise/cache \
+    MISE_VERBOSE=1 \
+    PATH=/mise/shims:$PATH
+
+RUN curl -fsSL https://mise.run | sh


### PR DESCRIPTION
Build and publish a base image that

- Is based off buildpack-deps:bookworm-scm
- Installs several apt packages that are used when compiling language from source
- Installs mise

This can be used when installing mise packages to speed up build time
