### PR TITLE
copy entire app into context when using custom build command

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -150,7 +150,11 @@ func GenerateConfigFromEnvironment(app *app.App, env *app.Environment) *config.C
 
 	if buildCmdVar, _ := env.GetConfigVariable("BUILD_CMD"); buildCmdVar != "" {
 		buildStep := config.GetOrCreateStep("build")
-		buildStep.Commands = &[]plan.Command{plan.NewExecCommand(buildCmdVar)}
+		buildStep.Commands = &[]plan.Command{
+			// We want to run the build command with all the files in the current directory
+			plan.NewCopyCommand("."),
+			plan.NewExecCommand(buildCmdVar),
+		}
 		buildStep.DependsOn = append(buildStep.DependsOn, "install")
 	}
 
@@ -187,7 +191,10 @@ func GenerateConfigFromOptions(options *GenerateBuildPlanOptions) *config.Config
 
 	if options.BuildCommand != "" {
 		buildStep := config.GetOrCreateStep("build")
-		buildStep.Commands = &[]plan.Command{plan.NewExecCommand(options.BuildCommand)}
+		buildStep.Commands = &[]plan.Command{
+			plan.NewCopyCommand("."),
+			plan.NewExecCommand(options.BuildCommand),
+		}
 		buildStep.DependsOn = append(buildStep.DependsOn, "install")
 	}
 


### PR DESCRIPTION
If you set a custom build command with either the CLI flag or environment variable, we now automatically copy the entire app into the build context since it you will 99% of time need it.
