### PR TITLE
Add detected providers to build result

### DIFF
--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -82,6 +82,8 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, install *generate.Co
 
 		// Add caches for Next.JS apps
 		if nextApps, err := p.getNextApps(ctx); err == nil {
+			ctx.Metadata.SetBool("nextjs", true)
+
 			for _, nextApp := range nextApps {
 				nextCacheDir := path.Join("/app", nextApp, ".next/cache")
 				nextCache := ctx.Caches.AddCache(fmt.Sprintf("next-%s", nextApp), nextCacheDir)


### PR DESCRIPTION
- Always return auto-detected providers as part of build result
- Add if node app uses nextjs in metadata
