### PR TITLE
decrease size of mise binary by building from source

### DIFF
--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -1,3 +1,18 @@
+FROM rust:1-slim-bookworm AS builder
+
+# Compile mise from source with size optimizations
+RUN apt-get update && apt-get install -y \
+    git \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/jdx/mise.git /tmp/mise && \
+    cd /tmp/mise && \
+    RUSTFLAGS="-C opt-level=z -C link-arg=-s -C codegen-units=1" \
+    cargo build --profile serious \
+    --config debuginfo=0
+
 FROM buildpack-deps:bookworm-scm
 
 # Install any system deps that might be needed to build a language from source
@@ -17,15 +32,13 @@ RUN apt-get update && apt-get install -y \
     libffi-dev \
     liblzma-dev
 
-# Install mise
-# TODO: I don't think we need these envs here. Or we can remove from the mise_step
+# Mise config
 ENV MISE_INSTALL_PATH=/usr/local/bin/mise \
     MISE_DATA_DIR=/mise \
     MISE_CONFIG_DIR=/mise \
     MISE_CACHE_DIR=/mise/cache \
-    MISE_VERBOSE=1 \
     PATH=/mise/shims:$PATH
 
-# TODO: Install mise from source to get a smaller binary
-
-RUN curl -fsSL https://mise.run | sh
+# Copy mise binary from builder
+COPY --from=builder /tmp/mise/target/serious/mise /usr/local/bin/
+RUN chmod +x /usr/local/bin/mise


### PR DESCRIPTION
Ideally I'd like to remove the mise binary from the final image entirely. But for that we need to install packages with `mise install-into`. For now, this PR just decreases the size of the binary from 46MB to 27MB by compiling it from source with size optimizations.
