### PR TITLE
Caches and variables at step level

### DIFF
--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -329,8 +329,8 @@ func (g *BuildGraph) convertExecCommandToLLB(node *StepNode, cmd plan.ExecComman
 		}
 	}
 
-	if len(cmd.Caches) > 0 {
-		cacheOpts, err := g.getCacheMountOptions(cmd.Caches)
+	if len(node.Step.Caches) > 0 {
+		cacheOpts, err := g.getCacheMountOptions(node.Step.Caches)
 		if err != nil {
 			return state, err
 		}

--- a/buildkit/build_llb/step_node.go
+++ b/buildkit/build_llb/step_node.go
@@ -49,7 +49,3 @@ func (node *StepNode) getPathList() []string {
 	pathList = append(pathList, node.OutputEnv.PathList...)
 	return pathList
 }
-
-func (node *StepNode) appendPath(path string) {
-	node.OutputEnv.AddPath(path)
-}

--- a/buildkit/convert.go
+++ b/buildkit/convert.go
@@ -106,13 +106,13 @@ func getStartState(buildState llb.State, plan *p.BuildPlan, platform specs.Platf
 }
 
 func getImageEnv(graphOutput *build_llb.BuildGraphOutput, plan *p.BuildPlan) []string {
-	paths := []string{system.DefaultPathEnvUnix}
+	paths := []string{}
 	paths = append(paths, graphOutput.GraphEnv.PathList...)
 	paths = append(paths, plan.Start.Paths...)
+	paths = append(paths, system.DefaultPathEnvUnix)
 	pathString := strings.Join(paths, ":")
 
 	envMap := make(map[string]string)
-
 	for k, v := range graphOutput.GraphEnv.EnvVars {
 		envMap[k] = v
 	}

--- a/core/__snapshots__/core_test.snap
+++ b/core/__snapshots__/core_test.snap
@@ -243,6 +243,7 @@
   },
   {
    "caches": [
+    "go-build",
     "root"
    ],
    "commands": [
@@ -269,6 +270,7 @@
   },
   {
    "caches": [
+    "go-build",
     "root"
    ],
    "commands": [
@@ -357,6 +359,7 @@
   },
   {
    "caches": [
+    "go-build",
     "root"
    ],
    "commands": [
@@ -383,6 +386,7 @@
   },
   {
    "caches": [
+    "go-build",
     "root"
    ],
    "commands": [
@@ -510,6 +514,7 @@
   },
   {
    "caches": [
+    "bun-install",
     "root"
    ],
    "commands": [
@@ -533,6 +538,7 @@
   },
   {
    "caches": [
+    "node-modules",
     "root"
    ],
    "commands": [
@@ -681,6 +687,7 @@
   },
   {
    "caches": [
+    "pnpm-install",
     "root"
    ],
    "commands": [
@@ -705,6 +712,7 @@
   },
   {
    "caches": [
+    "node-modules",
     "root"
    ],
    "commands": [
@@ -729,6 +737,10 @@
 {
  "baseImage": "ghcr.io/railwayapp/railpack-runtime-base:latest",
  "caches": {
+  "node-modules": {
+   "directory": "/app/node_modules/.cache",
+   "type": "shared"
+  },
   "root": {
    "directory": "/root/.cache",
    "type": "shared"
@@ -820,6 +832,17 @@
     "packages:mise"
    ],
    "name": "setup"
+  },
+  {
+   "caches": [
+    "node-modules",
+    "root"
+   ],
+   "commands": [],
+   "dependsOn": [
+    "setup"
+   ],
+   "name": "build"
   }
  ]
 }
@@ -1108,6 +1131,7 @@
   },
   {
    "caches": [
+    "pip",
     "root"
    ],
    "commands": [
@@ -1425,6 +1449,7 @@
   },
   {
    "caches": [
+    "pip",
     "root"
    ],
    "commands": [
@@ -2017,6 +2042,7 @@
   },
   {
    "caches": [
+    "npm-install",
     "root"
    ],
    "commands": [
@@ -2036,6 +2062,7 @@
   },
   {
    "caches": [
+    "node-modules",
     "root"
    ],
    "commands": [
@@ -2060,6 +2087,10 @@
 {
  "baseImage": "ghcr.io/railwayapp/railpack-runtime-base:latest",
  "caches": {
+  "node-modules": {
+   "directory": "/app/node_modules/.cache",
+   "type": "shared"
+  },
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
@@ -2158,6 +2189,7 @@
   },
   {
    "caches": [
+    "npm-install",
     "root"
    ],
    "commands": [
@@ -2178,6 +2210,17 @@
     "setup"
    ],
    "name": "install"
+  },
+  {
+   "caches": [
+    "node-modules",
+    "root"
+   ],
+   "commands": [],
+   "dependsOn": [
+    "install"
+   ],
+   "name": "build"
   }
  ]
 }
@@ -2187,6 +2230,10 @@
 {
  "baseImage": "ghcr.io/railwayapp/railpack-runtime-base:latest",
  "caches": {
+  "node-modules": {
+   "directory": "/app/node_modules/.cache",
+   "type": "shared"
+  },
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
@@ -2285,6 +2332,7 @@
   },
   {
    "caches": [
+    "npm-install",
     "root"
    ],
    "commands": [
@@ -2313,6 +2361,17 @@
     "setup"
    ],
    "name": "install"
+  },
+  {
+   "caches": [
+    "node-modules",
+    "root"
+   ],
+   "commands": [],
+   "dependsOn": [
+    "install"
+   ],
+   "name": "build"
   }
  ]
 }
@@ -2382,6 +2441,7 @@
   },
   {
    "caches": [
+    "composer",
     "root"
    ],
    "commands": [
@@ -2483,6 +2543,7 @@
   },
   {
    "caches": [
+    "npm-install",
     "root"
    ],
    "commands": [
@@ -2506,6 +2567,7 @@
   },
   {
    "caches": [
+    "node-modules",
     "root"
    ],
    "commands": [
@@ -2719,6 +2781,7 @@
   },
   {
    "caches": [
+    "composer",
     "root"
    ],
    "commands": [
@@ -2899,6 +2962,7 @@
   },
   {
    "caches": [
+    "npm-install",
     "root"
    ],
    "commands": [
@@ -2922,6 +2986,8 @@
   },
   {
    "caches": [
+    "node-modules",
+    "next-",
     "root"
    ],
    "commands": [
@@ -3077,6 +3143,7 @@
   },
   {
    "caches": [
+    "npm-install",
     "root"
    ],
    "commands": [
@@ -3125,6 +3192,9 @@
   },
   {
    "caches": [
+    "node-modules",
+    "next-apps-docs",
+    "next-apps-web",
     "root"
    ],
    "commands": [

--- a/core/__snapshots__/core_test.snap
+++ b/core/__snapshots__/core_test.snap
@@ -10,6 +10,10 @@
   "apt-lists": {
    "directory": "/var/lib/apt/lists",
    "type": "locked"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -23,11 +27,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -44,10 +47,6 @@
      "path": "/mise/shims"
     },
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y neofetch'",
      "customName": "install apt packages: neofetch"
     },
@@ -73,6 +72,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "PIP_CACHE_DIR",
@@ -112,6 +114,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [],
    "dependsOn": [
     "packages:mise",
@@ -121,12 +126,13 @@
    "name": "install"
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y pkg-config'",
      "customName": "install apt packages: pkg-config"
     }
@@ -135,12 +141,13 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y neofetch'",
      "customName": "install apt packages: neofetch"
     }
@@ -149,6 +156,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "cmd": "sh -c 'neofetch'"
@@ -170,6 +180,10 @@
   "go-build": {
    "directory": "/root/.cache/go-build",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -187,11 +201,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -229,6 +242,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "go.mod",
@@ -239,9 +255,6 @@
      "src": "go.sum"
     },
     {
-     "caches": [
-      "go-build"
-     ],
      "cmd": "go mod download"
     },
     {
@@ -255,15 +268,15 @@
    "name": "install"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "go-build"
-     ],
      "cmd": "go build -o out ./cmd/server"
     }
    ],
@@ -284,6 +297,10 @@
   "go-build": {
    "directory": "/root/.cache/go-build",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -298,11 +315,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -340,6 +356,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "go.mod",
@@ -350,9 +369,6 @@
      "src": "go.sum"
     },
     {
-     "caches": [
-      "go-build"
-     ],
      "cmd": "go mod download"
     },
     {
@@ -366,15 +382,15 @@
    "name": "install"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "go-build"
-     ],
      "cmd": "go build -o out"
     }
    ],
@@ -399,6 +415,10 @@
   "node-modules": {
    "directory": "/app/node_modules/.cache",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -418,11 +438,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -460,6 +479,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -487,6 +509,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -497,9 +522,6 @@
      "src": "bun.lockb"
     },
     {
-     "caches": [
-      "bun-install"
-     ],
      "cmd": "bun install --frozen-lockfile"
     }
    ],
@@ -510,15 +532,15 @@
    "name": "install"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "node-modules"
-     ],
      "cmd": "bun run build"
     }
    ],
@@ -542,6 +564,10 @@
   "pnpm-install": {
    "directory": "/root/.local/share/pnpm/store/v3",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -561,11 +587,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -603,6 +628,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -630,6 +658,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -649,6 +680,9 @@
    "name": "corepack"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -659,9 +693,6 @@
      "src": "pnpm-lock.yaml"
     },
     {
-     "caches": [
-      "pnpm-install"
-     ],
      "cmd": "pnpm install --frozen-lockfile --prod=false"
     }
    ],
@@ -673,15 +704,15 @@
    "name": "install"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "node-modules"
-     ],
      "cmd": "pnpm run build"
     }
    ],
@@ -697,6 +728,12 @@
 [TestGenerateBuildPlanForExamples/node-pnpm-workspaces - 1]
 {
  "baseImage": "ghcr.io/railwayapp/railpack-runtime-base:latest",
+ "caches": {
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
+  }
+ },
  "start": {
   "cmd": "node index.js",
   "outputs": [
@@ -714,11 +751,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -756,6 +792,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -797,6 +836,10 @@
   "apt-lists": {
    "directory": "/var/lib/apt/lists",
    "type": "locked"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -810,11 +853,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -852,6 +894,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "PIP_CACHE_DIR",
@@ -891,6 +936,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "cmd": "pipx install pdm"
@@ -926,12 +974,13 @@
    "name": "install"
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y pkg-config'",
      "customName": "install apt packages: pkg-config"
     }
@@ -958,6 +1007,10 @@
   "pip": {
    "directory": "/opt/pip-cache",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -971,11 +1024,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -1013,6 +1065,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "PIP_CACHE_DIR",
@@ -1052,15 +1107,15 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "requirements.txt",
      "src": "requirements.txt"
     },
     {
-     "caches": [
-      "pip"
-     ],
      "cmd": "pip install -r requirements.txt"
     }
    ],
@@ -1072,12 +1127,13 @@
    "name": "install"
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y pkg-config'",
      "customName": "install apt packages: pkg-config"
     }
@@ -1100,6 +1156,10 @@
   "apt-lists": {
    "directory": "/var/lib/apt/lists",
    "type": "locked"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -1113,11 +1173,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -1155,6 +1214,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "PIP_CACHE_DIR",
@@ -1194,6 +1256,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "cmd": "pipx install poetry"
@@ -1221,12 +1286,13 @@
    "name": "install"
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y pkg-config'",
      "customName": "install apt packages: pkg-config"
     }
@@ -1253,6 +1319,10 @@
   "pip": {
    "directory": "/opt/pip-cache",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -1266,11 +1336,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -1313,6 +1382,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "PIP_CACHE_DIR",
@@ -1352,15 +1424,15 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "requirements.txt",
      "src": "requirements.txt"
     },
     {
-     "caches": [
-      "pip"
-     ],
      "cmd": "pip install -r requirements.txt"
     }
    ],
@@ -1372,12 +1444,13 @@
    "name": "install"
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y ffmpeg gcc pkg-config poppler-utils'",
      "customName": "install apt packages: ffmpeg gcc pkg-config poppler-utils"
     }
@@ -1400,6 +1473,10 @@
   "apt-lists": {
    "directory": "/var/lib/apt/lists",
    "type": "locked"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -1413,11 +1490,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -1460,6 +1536,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "PIP_CACHE_DIR",
@@ -1499,6 +1578,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "UV_COMPILE_BYTECODE",
@@ -1545,12 +1627,13 @@
    "name": "install"
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y pkg-config'",
      "customName": "install apt packages: pkg-config"
     }
@@ -1565,6 +1648,12 @@
 [TestGenerateBuildPlanForExamples/secrets - 1]
 {
  "baseImage": "ghcr.io/railwayapp/railpack-runtime-base:latest",
+ "caches": {
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
+  }
+ },
  "secrets": [
   "MY_SECRET",
   "MY_OTHER_SECRET",
@@ -1575,9 +1664,15 @@
  },
  "steps": [
   {
+   "caches": [
+    "root"
+   ],
    "name": "packages:mise"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "NOT_SECRET",
@@ -1597,6 +1692,9 @@
    "name": "defaultsToUsing"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
@@ -1613,6 +1711,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "NOT_SECRET",
@@ -1638,6 +1739,12 @@
 [TestGenerateBuildPlanForExamples/staticfile-config - 1]
 {
  "baseImage": "ghcr.io/railwayapp/railpack-runtime-base:latest",
+ "caches": {
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
+  }
+ },
  "start": {
   "cmd": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
   "outputs": [
@@ -1649,11 +1756,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -1694,6 +1800,9 @@
    "assets": {
     "Caddyfile": "{\n\tadmin off\n\tpersist_config off\n\tauto_https off\n\n\tlog {\n\t\tformat json\n\t}\n\n\tservers {\n\t\ttrusted_proxies static private_ranges\n\t}\n}\n\n:{$PORT:80} {\n\tlog {\n\t\tformat json\n\t}\n\n\trespond /health 200\n\n# Security headers\n\theader {\n\t\t# Enable cross-site filter (XSS) and tell browsers to block detected attacks\n\t\tX-XSS-Protection \"1; mode=block\"\n\t\t# Prevent some browsers from MIME-sniffing a response away from the declared Content-Type\n\t\tX-Content-Type-Options \"nosniff\"\n\t\t# Keep referrer data off of HTTP connections\n\t\tReferrer-Policy \"strict-origin-when-cross-origin\"\n\t\t# Enable strict Content Security Policy\n\t\tContent-Security-Policy \"default-src 'self'; img-src 'self' data: https: *; style-src 'self' 'unsafe-inline' https: *; script-src 'self' 'unsafe-inline' https: *; font-src 'self' data: https: *; connect-src 'self' https: *; media-src 'self' https: *; object-src 'none'; frame-src 'self' https: *;\"\n\t\t# Remove Server header\n\t\t-Server\n\t}\n\n\troot * hello\n\n\t# Handle static files\n\tfile_server {\n\t\thide .git\n\t\thide .env*\n\t}\n\n\t# Compression with more formats\n\tencode {\n\t\tgzip\n\t\tzstd\n\t}\n\n\t# Try files with HTML extension and handle SPA routing\n\ttry_files {path} {path}.html {path}/index.html /index.html\n\n\t# Handle 404 errors\n\thandle_errors {\n\t\trewrite * /{err.status_code}.html\n\t\tfile_server\n\t}\n}\n"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "Caddyfile",
@@ -1715,6 +1824,12 @@
 [TestGenerateBuildPlanForExamples/staticfile-index - 1]
 {
  "baseImage": "ghcr.io/railwayapp/railpack-runtime-base:latest",
+ "caches": {
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
+  }
+ },
  "start": {
   "cmd": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
   "outputs": [
@@ -1726,11 +1841,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -1771,6 +1885,9 @@
    "assets": {
     "Caddyfile": "{\n\tadmin off\n\tpersist_config off\n\tauto_https off\n\n\tlog {\n\t\tformat json\n\t}\n\n\tservers {\n\t\ttrusted_proxies static private_ranges\n\t}\n}\n\n:{$PORT:80} {\n\tlog {\n\t\tformat json\n\t}\n\n\trespond /health 200\n\n# Security headers\n\theader {\n\t\t# Enable cross-site filter (XSS) and tell browsers to block detected attacks\n\t\tX-XSS-Protection \"1; mode=block\"\n\t\t# Prevent some browsers from MIME-sniffing a response away from the declared Content-Type\n\t\tX-Content-Type-Options \"nosniff\"\n\t\t# Keep referrer data off of HTTP connections\n\t\tReferrer-Policy \"strict-origin-when-cross-origin\"\n\t\t# Enable strict Content Security Policy\n\t\tContent-Security-Policy \"default-src 'self'; img-src 'self' data: https: *; style-src 'self' 'unsafe-inline' https: *; script-src 'self' 'unsafe-inline' https: *; font-src 'self' data: https: *; connect-src 'self' https: *; media-src 'self' https: *; object-src 'none'; frame-src 'self' https: *;\"\n\t\t# Remove Server header\n\t\t-Server\n\t}\n\n\troot * .\n\n\t# Handle static files\n\tfile_server {\n\t\thide .git\n\t\thide .env*\n\t}\n\n\t# Compression with more formats\n\tencode {\n\t\tgzip\n\t\tzstd\n\t}\n\n\t# Try files with HTML extension and handle SPA routing\n\ttry_files {path} {path}.html {path}/index.html /index.html\n\n\t# Handle 404 errors\n\thandle_errors {\n\t\trewrite * /{err.status_code}.html\n\t\tfile_server\n\t}\n}\n"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "Caddyfile",
@@ -1800,6 +1917,10 @@
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -1819,11 +1940,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -1866,6 +1986,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -1893,15 +2016,15 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
      "src": "package.json"
     },
     {
-     "caches": [
-      "npm-install"
-     ],
      "cmd": "npm install"
     }
    ],
@@ -1912,15 +2035,15 @@
    "name": "install"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "node-modules"
-     ],
      "cmd": "npm run build"
     }
    ],
@@ -1939,6 +2062,10 @@
  "caches": {
   "npm-install": {
    "directory": "/root/.npm",
+   "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
    "type": "shared"
   }
  },
@@ -1959,11 +2086,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -2001,6 +2127,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -2028,6 +2157,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -2038,9 +2170,6 @@
      "src": "package-lock.json"
     },
     {
-     "caches": [
-      "npm-install"
-     ],
      "cmd": "npm ci"
     }
    ],
@@ -2061,6 +2190,10 @@
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -2080,11 +2213,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -2122,6 +2254,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -2149,6 +2284,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -2167,9 +2305,6 @@
      "src": "package-lock.json"
     },
     {
-     "caches": [
-      "npm-install"
-     ],
      "cmd": "npm ci"
     }
    ],
@@ -2206,6 +2341,10 @@
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -2216,17 +2355,21 @@
  },
  "steps": [
   {
+   "caches": [
+    "root"
+   ],
    "name": "packages:image",
    "startingImage": "php:8.2.27-fpm",
    "useSecrets": false
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y git nginx unzip zip'",
      "customName": "install apt packages: git nginx unzip zip"
     }
@@ -2238,6 +2381,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "/usr/bin/composer",
@@ -2253,9 +2399,6 @@
      "value": "/opt/cache/composer"
     },
     {
-     "caches": [
-      "composer"
-     ],
      "cmd": "composer install --ignore-platform-reqs"
     }
    ],
@@ -2268,11 +2411,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -2310,6 +2452,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -2337,6 +2482,9 @@
    "name": "setup:node"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -2347,9 +2495,6 @@
      "src": "package-lock.json"
     },
     {
-     "caches": [
-      "npm-install"
-     ],
      "cmd": "npm ci"
     }
    ],
@@ -2360,15 +2505,15 @@
    "name": "install:node"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "node-modules"
-     ],
      "cmd": "npm run build"
     }
    ],
@@ -2386,6 +2531,9 @@
     "php-fpm.conf": "[www]\nlisten = 127.0.0.1:9000\nuser = nobody\npm = dynamic\npm.max_children = 50\npm.min_spare_servers = 4\npm.max_spare_servers = 32\npm.start_servers = 18\nclear_env = no\ncatch_workers_output = yes\n",
     "start-nginx.sh": "#!/bin/bash\n\nset -e\n\nPORT=${PORT:-80}\n\n# Set the port in the nginx config\nsed -i \"s/80/$PORT/g\" /etc/nginx/railpack.conf\n\n# Set the storage permissions for Laravel\nif [ \"$IS_LARAVEL\" = \"true\" ]; then\n    chmod -R ugo+rw /app/storage\nfi\n\necho \"Starting Nginx on port $PORT\"\n\n# Start php-fpm and nginx\nphp-fpm --fpm-config /etc/php-fpm.conf \u0026 nginx -c /etc/nginx/railpack.conf\n"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "customName": "create nginx config",
@@ -2431,6 +2579,10 @@
   "apt-lists": {
    "directory": "/var/lib/apt/lists",
    "type": "locked"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -2441,17 +2593,21 @@
  },
  "steps": [
   {
+   "caches": [
+    "root"
+   ],
    "name": "packages:image",
    "startingImage": "php:8.4.3-fpm",
    "useSecrets": false
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y git nginx unzip zip'",
      "customName": "install apt packages: git nginx unzip zip"
     }
@@ -2468,6 +2624,9 @@
     "php-fpm.conf": "[www]\nlisten = 127.0.0.1:9000\nuser = nobody\npm = dynamic\npm.max_children = 50\npm.min_spare_servers = 4\npm.max_spare_servers = 32\npm.start_servers = 18\nclear_env = no\ncatch_workers_output = yes\n",
     "start-nginx.sh": "#!/bin/bash\n\nset -e\n\nPORT=${PORT:-80}\n\n# Set the port in the nginx config\nsed -i \"s/80/$PORT/g\" /etc/nginx/railpack.conf\n\n# Set the storage permissions for Laravel\nif [ \"$IS_LARAVEL\" = \"true\" ]; then\n    chmod -R ugo+rw /app/storage\nfi\n\necho \"Starting Nginx on port $PORT\"\n\n# Start php-fpm and nginx\nphp-fpm --fpm-config /etc/php-fpm.conf \u0026 nginx -c /etc/nginx/railpack.conf\n"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "customName": "create nginx config",
@@ -2495,6 +2654,9 @@
    "name": "nginx:setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "name": "packages:mise"
   }
  ]
@@ -2516,6 +2678,10 @@
   "composer": {
    "directory": "/opt/cache/composer",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -2526,17 +2692,21 @@
  },
  "steps": [
   {
+   "caches": [
+    "root"
+   ],
    "name": "packages:image",
    "startingImage": "php:8.2.27-fpm",
    "useSecrets": false
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y git nginx unzip zip'",
      "customName": "install apt packages: git nginx unzip zip"
     }
@@ -2548,6 +2718,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "/usr/bin/composer",
@@ -2563,9 +2736,6 @@
      "value": "/opt/cache/composer"
     },
     {
-     "caches": [
-      "composer"
-     ],
      "cmd": "composer install --ignore-platform-reqs"
     }
    ],
@@ -2580,6 +2750,9 @@
     "php-fpm.conf": "[www]\nlisten = 127.0.0.1:9000\nuser = nobody\npm = dynamic\npm.max_children = 50\npm.min_spare_servers = 4\npm.max_spare_servers = 32\npm.start_servers = 18\nclear_env = no\ncatch_workers_output = yes\n",
     "start-nginx.sh": "#!/bin/bash\n\nset -e\n\nPORT=${PORT:-80}\n\n# Set the port in the nginx config\nsed -i \"s/80/$PORT/g\" /etc/nginx/railpack.conf\n\n# Set the storage permissions for Laravel\nif [ \"$IS_LARAVEL\" = \"true\" ]; then\n    chmod -R ugo+rw /app/storage\nfi\n\necho \"Starting Nginx on port $PORT\"\n\n# Start php-fpm and nginx\nphp-fpm --fpm-config /etc/php-fpm.conf \u0026 nginx -c /etc/nginx/railpack.conf\n"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "customName": "create nginx config",
@@ -2607,6 +2780,9 @@
    "name": "nginx:setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "name": "packages:mise"
   }
  ]
@@ -2628,6 +2804,10 @@
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -2647,11 +2827,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -2689,6 +2868,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -2716,6 +2898,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -2726,9 +2911,6 @@
      "src": "package-lock.json"
     },
     {
-     "caches": [
-      "npm-install"
-     ],
      "cmd": "npm ci"
     }
    ],
@@ -2739,16 +2921,15 @@
    "name": "install"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "node-modules",
-      "next-"
-     ],
      "cmd": "npm run build"
     }
    ],
@@ -2780,6 +2961,10 @@
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "start": {
@@ -2798,11 +2983,10 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -2840,6 +3024,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "name": "CI",
@@ -2867,6 +3054,9 @@
    "name": "setup"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -2886,6 +3076,9 @@
    "name": "corepack"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": "package.json",
@@ -2920,9 +3113,6 @@
      "src": ".npmrc"
     },
     {
-     "caches": [
-      "npm-install"
-     ],
      "cmd": "npm ci"
     }
    ],
@@ -2934,17 +3124,15 @@
    "name": "install"
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "dest": ".",
      "src": "."
     },
     {
-     "caches": [
-      "node-modules",
-      "next-apps-docs",
-      "next-apps-web"
-     ],
      "cmd": "npm run build"
     }
    ],

--- a/core/__snapshots__/core_test.snap
+++ b/core/__snapshots__/core_test.snap
@@ -32,18 +32,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -69,7 +57,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -77,41 +72,22 @@
    ],
    "commands": [
     {
-     "name": "PIP_CACHE_DIR",
-     "value": "/opt/pip-cache"
-    },
-    {
-     "name": "PIP_DEFAULT_TIMEOUT",
-     "value": "100"
-    },
-    {
-     "name": "PIP_DISABLE_PIP_VERSION_CHECK",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONDONTWRITEBYTECODE",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONFAULTHANDLER",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONHASHSEED",
-     "value": "random"
-    },
-    {
-     "name": "PYTHONUNBUFFERED",
-     "value": "1"
-    },
-    {
      "path": "/root/.local/bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "PIP_CACHE_DIR": "/opt/pip-cache",
+    "PIP_DEFAULT_TIMEOUT": "100",
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONFAULTHANDLER": "1",
+    "PYTHONHASHSEED": "random",
+    "PYTHONUNBUFFERED": "1"
+   }
   },
   {
    "caches": [
@@ -206,18 +182,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -239,7 +203,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -257,16 +228,15 @@
     },
     {
      "cmd": "go mod download"
-    },
-    {
-     "name": "CGO_ENABLED",
-     "value": "0"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "install"
+   "name": "install",
+   "variables": {
+    "CGO_ENABLED": "0"
+   }
   },
   {
    "caches": [
@@ -322,18 +292,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -355,7 +313,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -373,16 +338,15 @@
     },
     {
      "cmd": "go mod download"
-    },
-    {
-     "name": "CGO_ENABLED",
-     "value": "0"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "install"
+   "name": "install",
+   "variables": {
+    "CGO_ENABLED": "0"
+   }
   },
   {
    "caches": [
@@ -447,18 +411,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -480,7 +432,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -488,29 +447,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -553,7 +502,10 @@
    "dependsOn": [
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -598,18 +550,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -631,7 +571,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -639,29 +586,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -727,7 +664,10 @@
    "dependsOn": [
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -768,18 +708,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -801,7 +729,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -809,29 +744,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -842,7 +767,10 @@
    "dependsOn": [
     "setup"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -881,18 +809,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -914,7 +830,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -922,41 +845,22 @@
    ],
    "commands": [
     {
-     "name": "PIP_CACHE_DIR",
-     "value": "/opt/pip-cache"
-    },
-    {
-     "name": "PIP_DEFAULT_TIMEOUT",
-     "value": "100"
-    },
-    {
-     "name": "PIP_DISABLE_PIP_VERSION_CHECK",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONDONTWRITEBYTECODE",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONFAULTHANDLER",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONHASHSEED",
-     "value": "random"
-    },
-    {
-     "name": "PYTHONUNBUFFERED",
-     "value": "1"
-    },
-    {
      "path": "/root/.local/bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "PIP_CACHE_DIR": "/opt/pip-cache",
+    "PIP_DEFAULT_TIMEOUT": "100",
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONFAULTHANDLER": "1",
+    "PYTHONHASHSEED": "random",
+    "PYTHONUNBUFFERED": "1"
+   }
   },
   {
    "caches": [
@@ -965,10 +869,6 @@
    "commands": [
     {
      "cmd": "pipx install pdm"
-    },
-    {
-     "name": "PDM_CHECK_UPDATE",
-     "value": "false"
     },
     {
      "dest": "pyproject.toml",
@@ -994,7 +894,10 @@
     "setup",
     "packages:apt:python-system-deps"
    ],
-   "name": "install"
+   "name": "install",
+   "variables": {
+    "PDM_CHECK_UPDATE": "false"
+   }
   },
   {
    "caches": [
@@ -1052,18 +955,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -1085,7 +976,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -1093,41 +991,22 @@
    ],
    "commands": [
     {
-     "name": "PIP_CACHE_DIR",
-     "value": "/opt/pip-cache"
-    },
-    {
-     "name": "PIP_DEFAULT_TIMEOUT",
-     "value": "100"
-    },
-    {
-     "name": "PIP_DISABLE_PIP_VERSION_CHECK",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONDONTWRITEBYTECODE",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONFAULTHANDLER",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONHASHSEED",
-     "value": "random"
-    },
-    {
-     "name": "PYTHONUNBUFFERED",
-     "value": "1"
-    },
-    {
      "path": "/root/.local/bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "PIP_CACHE_DIR": "/opt/pip-cache",
+    "PIP_DEFAULT_TIMEOUT": "100",
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONFAULTHANDLER": "1",
+    "PYTHONHASHSEED": "random",
+    "PYTHONUNBUFFERED": "1"
+   }
   },
   {
    "caches": [
@@ -1202,18 +1081,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -1235,7 +1102,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -1243,41 +1117,22 @@
    ],
    "commands": [
     {
-     "name": "PIP_CACHE_DIR",
-     "value": "/opt/pip-cache"
-    },
-    {
-     "name": "PIP_DEFAULT_TIMEOUT",
-     "value": "100"
-    },
-    {
-     "name": "PIP_DISABLE_PIP_VERSION_CHECK",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONDONTWRITEBYTECODE",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONFAULTHANDLER",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONHASHSEED",
-     "value": "random"
-    },
-    {
-     "name": "PYTHONUNBUFFERED",
-     "value": "1"
-    },
-    {
      "path": "/root/.local/bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "PIP_CACHE_DIR": "/opt/pip-cache",
+    "PIP_DEFAULT_TIMEOUT": "100",
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONFAULTHANDLER": "1",
+    "PYTHONHASHSEED": "random",
+    "PYTHONUNBUFFERED": "1"
+   }
   },
   {
    "caches": [
@@ -1365,18 +1220,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -1403,7 +1246,14 @@
     "/app/.python-version"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -1411,41 +1261,22 @@
    ],
    "commands": [
     {
-     "name": "PIP_CACHE_DIR",
-     "value": "/opt/pip-cache"
-    },
-    {
-     "name": "PIP_DEFAULT_TIMEOUT",
-     "value": "100"
-    },
-    {
-     "name": "PIP_DISABLE_PIP_VERSION_CHECK",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONDONTWRITEBYTECODE",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONFAULTHANDLER",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONHASHSEED",
-     "value": "random"
-    },
-    {
-     "name": "PYTHONUNBUFFERED",
-     "value": "1"
-    },
-    {
      "path": "/root/.local/bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "PIP_CACHE_DIR": "/opt/pip-cache",
+    "PIP_DEFAULT_TIMEOUT": "100",
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONFAULTHANDLER": "1",
+    "PYTHONHASHSEED": "random",
+    "PYTHONUNBUFFERED": "1"
+   }
   },
   {
    "caches": [
@@ -1520,18 +1351,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -1558,41 +1377,20 @@
     "/app/.python-version"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
     "root"
    ],
    "commands": [
-    {
-     "name": "PIP_CACHE_DIR",
-     "value": "/opt/pip-cache"
-    },
-    {
-     "name": "PIP_DEFAULT_TIMEOUT",
-     "value": "100"
-    },
-    {
-     "name": "PIP_DISABLE_PIP_VERSION_CHECK",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONDONTWRITEBYTECODE",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONFAULTHANDLER",
-     "value": "1"
-    },
-    {
-     "name": "PYTHONHASHSEED",
-     "value": "random"
-    },
-    {
-     "name": "PYTHONUNBUFFERED",
-     "value": "1"
-    },
     {
      "path": "/root/.local/bin"
     }
@@ -1600,25 +1398,22 @@
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "PIP_CACHE_DIR": "/opt/pip-cache",
+    "PIP_DEFAULT_TIMEOUT": "100",
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONFAULTHANDLER": "1",
+    "PYTHONHASHSEED": "random",
+    "PYTHONUNBUFFERED": "1"
+   }
   },
   {
    "caches": [
     "root"
    ],
    "commands": [
-    {
-     "name": "UV_COMPILE_BYTECODE",
-     "value": "1"
-    },
-    {
-     "name": "UV_LINK_MODE",
-     "value": "copy"
-    },
-    {
-     "name": "UV_CACHE_DIR",
-     "value": "/opt/uv-cache"
-    },
     {
      "cmd": "pipx install uv"
     },
@@ -1649,7 +1444,12 @@
     "setup",
     "packages:apt:python-system-deps"
    ],
-   "name": "install"
+   "name": "install",
+   "variables": {
+    "UV_CACHE_DIR": "/opt/uv-cache",
+    "UV_COMPILE_BYTECODE": "1",
+    "UV_LINK_MODE": "copy"
+   }
   },
   {
    "caches": [
@@ -1700,8 +1500,7 @@
    ],
    "commands": [
     {
-     "name": "NOT_SECRET",
-     "value": "not secret"
+     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'"
     },
     {
      "dest": ".",
@@ -1741,8 +1540,7 @@
    ],
    "commands": [
     {
-     "name": "NOT_SECRET",
-     "value": "not secret"
+     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'"
     },
     {
      "dest": ".",
@@ -1786,18 +1584,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -1819,7 +1605,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "assets": {
@@ -1871,18 +1664,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -1904,7 +1685,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "assets": {
@@ -1970,18 +1758,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -2008,7 +1784,14 @@
     "/app/mise.toml"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -2016,29 +1799,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -2077,7 +1850,10 @@
    "dependsOn": [
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -2122,18 +1898,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -2155,7 +1919,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -2163,29 +1934,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -2220,7 +1981,10 @@
    "dependsOn": [
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -2265,18 +2029,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -2298,7 +2050,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -2306,29 +2065,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -2371,7 +2120,10 @@
    "dependsOn": [
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -2455,17 +2207,16 @@
      "src": "."
     },
     {
-     "name": "COMPOSER_CACHE_DIR",
-     "value": "/opt/cache/composer"
-    },
-    {
      "cmd": "composer install --ignore-platform-reqs"
     }
    ],
    "dependsOn": [
     "packages:apt:nginx"
    ],
-   "name": "install"
+   "name": "install",
+   "variables": {
+    "COMPOSER_CACHE_DIR": "/opt/cache/composer"
+   }
   },
   {
    "assets": {
@@ -2475,18 +2226,6 @@
     "root"
    ],
    "commands": [
-    {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
     {
      "path": "/mise/shims"
     },
@@ -2509,7 +2248,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -2517,29 +2263,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup:node"
+   "name": "setup:node",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -2585,7 +2321,10 @@
    "name": "build:node",
    "outputs": [
     "/app"
-   ]
+   ],
+   "variables": {
+    "HELLO": "world"
+   }
   },
   {
    "assets": {
@@ -2615,16 +2354,15 @@
      "mode": 493,
      "name": "start-nginx.sh",
      "path": "/start-nginx.sh"
-    },
-    {
-     "name": "IS_LARAVEL",
-     "value": "true"
     }
    ],
    "dependsOn": [
     "packages:apt:nginx"
    ],
-   "name": "nginx:setup"
+   "name": "nginx:setup",
+   "variables": {
+    "IS_LARAVEL": "true"
+   }
   }
  ]
 }
@@ -2795,17 +2533,16 @@
      "src": "."
     },
     {
-     "name": "COMPOSER_CACHE_DIR",
-     "value": "/opt/cache/composer"
-    },
-    {
      "cmd": "composer install --ignore-platform-reqs"
     }
    ],
    "dependsOn": [
     "packages:apt:nginx"
    ],
-   "name": "install"
+   "name": "install",
+   "variables": {
+    "COMPOSER_CACHE_DIR": "/opt/cache/composer"
+   }
   },
   {
    "assets": {
@@ -2895,18 +2632,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -2928,7 +2653,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -2936,29 +2668,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -3002,7 +2724,10 @@
    "dependsOn": [
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -3054,18 +2779,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -3087,7 +2800,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [
@@ -3095,29 +2815,19 @@
    ],
    "commands": [
     {
-     "name": "CI",
-     "value": "true"
-    },
-    {
-     "name": "NODE_ENV",
-     "value": "production"
-    },
-    {
-     "name": "NPM_CONFIG_PRODUCTION",
-     "value": "false"
-    },
-    {
-     "name": "YARN_PRODUCTION",
-     "value": "false"
-    },
-    {
      "path": "/app/node_modules/.bin"
     }
    ],
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "YARN_PRODUCTION": "false"
+   }
   },
   {
    "caches": [
@@ -3209,7 +2919,10 @@
    "dependsOn": [
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }

--- a/core/__snapshots__/core_test.snap
+++ b/core/__snapshots__/core_test.snap
@@ -17,7 +17,7 @@
   }
  },
  "start": {
-  "cmd": "neofetch",
+  "cmd": "neofetch $HELLO",
   "outputs": [
    "."
   ]
@@ -28,6 +28,8 @@
     "mise.toml": "[mise.toml]"
    },
    "caches": [
+    "apt",
+    "apt-lists",
     "root"
    ],
    "commands": [
@@ -137,13 +139,18 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'neofetch'"
+     "cmd": "sh -c 'neofetch'",
+     "customName": "neofetch"
     }
    ],
    "dependsOn": [
-    "packages:mise"
+    "packages:mise",
+    "packages:apt:config"
    ],
-   "name": "build"
+   "name": "build",
+   "variables": {
+    "HELLO": "world"
+   }
   }
  ]
 }
@@ -1500,14 +1507,16 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'"
+     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'",
+     "customName": "{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }"
     },
     {
      "dest": ".",
      "src": "."
     },
     {
-     "cmd": "sh -c './run.sh'"
+     "cmd": "sh -c './run.sh'",
+     "customName": "./run.sh"
     }
    ],
    "dependsOn": [
@@ -1525,7 +1534,8 @@
      "src": "."
     },
     {
-     "cmd": "sh -c './run.sh true'"
+     "cmd": "sh -c './run.sh true'",
+     "customName": "./run.sh true"
     }
    ],
    "dependsOn": [
@@ -1540,14 +1550,16 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'"
+     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'",
+     "customName": "{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }"
     },
     {
      "dest": ".",
      "src": "."
     },
     {
-     "cmd": "sh -c './run.sh'"
+     "cmd": "sh -c './run.sh'",
+     "customName": "./run.sh"
     }
    ],
    "dependsOn": [

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -30,7 +30,11 @@ func TestMergeConfigSmall(t *testing.T) {
 				"dependsOn": ["packages"],
 				"commands": [
 					"echo first"
-				]
+				],
+				"variables": {
+					"HELLO": "world"
+				},
+				"caches": ["pip"]
 			}
 		},
 		"start": {
@@ -48,7 +52,11 @@ func TestMergeConfigSmall(t *testing.T) {
 			"bun": "latest"
 		},
 		"steps": {
-			"install": {}
+			"install": {
+				"variables": {
+					"another": "boop"
+				}
+			}
 		},
 		"start": {
 			"variables": {
@@ -71,7 +79,12 @@ func TestMergeConfigSmall(t *testing.T) {
 				"dependsOn": ["packages"],
 				"commands": [
 					"echo first"
-				]
+				],
+				"variables": {
+					"HELLO": "world",
+					"another": "boop"
+				},
+				"caches": ["pip"]
 			}
 		},
 		"start": {

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -36,18 +36,6 @@
    ],
    "commands": [
     {
-     "name": "MISE_DATA_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CONFIG_DIR",
-     "value": "/mise"
-    },
-    {
-     "name": "MISE_CACHE_DIR",
-     "value": "/mise/cache"
-    },
-    {
      "path": "/mise/shims"
     },
     {
@@ -73,7 +61,14 @@
     "/root/.local/state/mise"
    ],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false
+   "useSecrets": false,
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
   },
   {
    "caches": [

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -10,6 +10,10 @@
   "apt-lists": {
    "directory": "/var/lib/apt/lists",
    "type": "locked"
+  },
+  "root": {
+   "directory": "/root/.cache",
+   "type": "shared"
   }
  },
  "secrets": [
@@ -27,11 +31,10 @@
    "assets": {
     "mise.toml": "[tools]\n  [tools.go]\n    version = \"1.23.5\"\n  [tools.node]\n    version = \"20.18.2\"\n  [tools.python]\n    version = \"3.13.1\"\n"
    },
+   "caches": [
+    "root"
+   ],
    "commands": [
-    {
-     "name": "MISE_INSTALL_PATH",
-     "value": "/usr/local/bin/mise"
-    },
     {
      "name": "MISE_DATA_DIR",
      "value": "/mise"
@@ -48,10 +51,6 @@
      "path": "/mise/shims"
     },
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y curl'",
      "customName": "install apt packages: curl"
     },
@@ -77,12 +76,13 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y git neofetch'",
      "customName": "install apt packages: git neofetch"
     }
@@ -91,6 +91,9 @@
    "useSecrets": false
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "cmd": "npm install"
@@ -105,6 +108,9 @@
    ]
   },
   {
+   "caches": [
+    "root"
+   ],
    "commands": [
     {
      "cmd": "sh -c 'echo building'"
@@ -116,12 +122,13 @@
    "name": "build"
   },
   {
+   "caches": [
+    "apt",
+    "apt-lists",
+    "root"
+   ],
    "commands": [
     {
-     "caches": [
-      "apt",
-      "apt-lists"
-     ],
      "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y curl'",
      "customName": "install apt packages: curl"
     }

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -32,6 +32,8 @@
     "mise.toml": "[tools]\n  [tools.go]\n    version = \"1.23.5\"\n  [tools.node]\n    version = \"20.18.2\"\n  [tools.python]\n    version = \"3.13.1\"\n"
    },
    "caches": [
+    "apt",
+    "apt-lists",
     "root"
    ],
    "commands": [
@@ -108,11 +110,13 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'echo building'"
+     "cmd": "sh -c 'echo building'",
+     "customName": "echo building"
     }
    ],
    "dependsOn": [
-    "install"
+    "install",
+    "packages:apt:config"
    ],
    "name": "build"
   },

--- a/core/generate/apt_step_builder.go
+++ b/core/generate/apt_step_builder.go
@@ -41,6 +41,8 @@ func (b *AptStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 		options.NewAptInstallCommand(b.Packages),
 	})
 
+	step.Caches = options.Caches.GetAptCaches()
+
 	step.UseSecrets = &[]bool{false}[0]
 
 	return step, nil

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -89,6 +89,7 @@ func (b *CommandStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error
 	step.Outputs = b.Outputs
 	step.Commands = b.Commands
 	step.Assets = b.Assets
+	step.Caches = b.Caches
 
 	if !b.UseSecrets {
 		step.UseSecrets = &b.UseSecrets

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"maps"
-	"slices"
 
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/utils"
@@ -62,12 +61,7 @@ func (b *CommandStepBuilder) AddCommands(commands []plan.Command) {
 }
 
 func (b *CommandStepBuilder) AddEnvVars(envVars map[string]string) {
-	commands := []plan.Command{}
-
-	for _, k := range slices.Sorted(maps.Keys(envVars)) {
-		commands = append(commands, plan.NewVariableCommand(k, envVars[k]))
-	}
-	b.AddCommands(commands)
+	maps.Copy(b.Variables, envVars)
 }
 
 func (b *CommandStepBuilder) AddPaths(paths []string) {
@@ -90,6 +84,7 @@ func (b *CommandStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error
 	step.Commands = b.Commands
 	step.Assets = b.Assets
 	step.Caches = b.Caches
+	step.Variables = b.Variables
 
 	if !b.UseSecrets {
 		step.UseSecrets = &b.UseSecrets

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -14,6 +14,8 @@ type CommandStepBuilder struct {
 	Commands    *[]plan.Command
 	Outputs     *[]string
 	Assets      map[string]string
+	Variables   map[string]string
+	Caches      []string
 	UseSecrets  bool
 }
 
@@ -23,6 +25,8 @@ func (c *GenerateContext) NewCommandStep(name string) *CommandStepBuilder {
 		DependsOn:   []string{MisePackageStepName},
 		Commands:    &[]plan.Command{},
 		Assets:      map[string]string{},
+		Variables:   map[string]string{},
+		Caches:      []string{},
 		UseSecrets:  true,
 	}
 
@@ -33,6 +37,14 @@ func (c *GenerateContext) NewCommandStep(name string) *CommandStepBuilder {
 
 func (b *CommandStepBuilder) DependOn(name string) {
 	b.DependsOn = append(b.DependsOn, name)
+}
+
+func (b *CommandStepBuilder) AddVariables(variables map[string]string) {
+	maps.Copy(b.Variables, variables)
+}
+
+func (b *CommandStepBuilder) AddCache(name string) {
+	b.Caches = append(b.Caches, name)
 }
 
 func (b *CommandStepBuilder) AddCommand(command plan.Command) {

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -132,6 +132,7 @@ func (c *GenerateContext) Generate() (*plan.BuildPlan, map[string]*resolver.Reso
 			return nil, nil, fmt.Errorf("failed to build step: %w", err)
 		}
 
+		c.AddCommonCachesToStep(step)
 		buildPlan.AddStep(*step)
 	}
 
@@ -236,12 +237,17 @@ func (c *GenerateContext) ApplyConfig(config *config.Config) error {
 	return nil
 }
 
+func (c *GenerateContext) AddCommonCachesToStep(step *plan.Step) {
+	rootCache := c.Caches.AddCache("root", "/root/.cache")
+
+	step.Caches = append(step.Caches, rootCache)
+}
+
 func (o *BuildStepOptions) NewAptInstallCommand(pkgs []string) plan.Command {
 	pkgs = utils.RemoveDuplicates(pkgs)
 	sort.Strings(pkgs)
 
 	return plan.NewExecCommand("sh -c 'apt-get update && apt-get install -y "+strings.Join(pkgs, " ")+"'", plan.ExecOptions{
 		CustomName: "install apt packages: " + strings.Join(pkgs, " "),
-		Caches:     o.Caches.GetAptCaches(),
 	})
 }

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -159,12 +159,13 @@ func (c *GenerateContext) ApplyConfig(config *config.Config) error {
 	}
 
 	// Apt package config
+	aptStepName := ""
 	if len(config.AptPackages) > 0 {
 		aptStep := c.NewAptStepBuilder("config")
+		aptStepName = aptStep.Name()
 		aptStep.Packages = config.AptPackages
 
-		// The apt step should run first
-		// miseStep.DependsOn = append(miseStep.DependsOn, aptStep.DisplayName)
+		// We install the apt packages again in the mise step since they may be required for install mise packages
 		miseStep.SupportingAptPackages = append(miseStep.SupportingAptPackages, config.AptPackages...)
 	}
 
@@ -189,6 +190,10 @@ func (c *GenerateContext) ApplyConfig(config *config.Config) error {
 		// Overwrite the step with values from the config if they exist
 		if len(configStep.DependsOn) > 0 {
 			commandStepBuilder.DependsOn = configStep.DependsOn
+		}
+
+		if aptStepName != "" {
+			commandStepBuilder.DependsOn = append(commandStepBuilder.DependsOn, aptStepName)
 		}
 
 		if configStep.Commands != nil {

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -205,6 +205,14 @@ func (c *GenerateContext) ApplyConfig(config *config.Config) error {
 		if configStep.UseSecrets != nil {
 			commandStepBuilder.UseSecrets = *configStep.UseSecrets
 		}
+
+		if len(configStep.Caches) > 0 {
+			commandStepBuilder.Caches = configStep.Caches
+		}
+
+		if configStep.Variables != nil {
+			commandStepBuilder.AddEnvVars(configStep.Variables)
+		}
 	}
 
 	// Cache config

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -114,6 +114,7 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 		step.AddCommands([]plan.Command{
 			options.NewAptInstallCommand(b.SupportingAptPackages),
 		})
+		step.Caches = options.Caches.GetAptCaches()
 	}
 
 	// Setup mise commands

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -87,7 +87,6 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 
 	// Install mise
 	step.AddCommands([]plan.Command{
-		plan.NewVariableCommand("MISE_INSTALL_PATH", "/usr/local/bin/mise"),
 		plan.NewVariableCommand("MISE_DATA_DIR", "/mise"),
 		plan.NewVariableCommand("MISE_CONFIG_DIR", "/mise"),
 		plan.NewVariableCommand("MISE_CACHE_DIR", "/mise/cache"),
@@ -160,6 +159,7 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 
 var miseConfigFiles = []string{
 	"mise.toml",
+	".tool-versions",
 	".python-version",
 	".nvmrc",
 }

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -85,17 +86,16 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 
 	step.StartingImage = BuilderBaseImage
 
-	// Install mise
+	// Setup mise
 	step.AddCommands([]plan.Command{
-		plan.NewVariableCommand("MISE_DATA_DIR", "/mise"),
-		plan.NewVariableCommand("MISE_CONFIG_DIR", "/mise"),
-		plan.NewVariableCommand("MISE_CACHE_DIR", "/mise/cache"),
 		plan.NewPathCommand("/mise/shims"),
-		// options.NewAptInstallCommand([]string{"curl", "ca-certificates", "git"}),
-		// plan.NewExecCommand("sh -c 'curl -fsSL https://mise.run | sh'",
-		// 	plan.ExecOptions{
-		// 		CustomName: "install mise",
-		// 	}),
+	})
+	maps.Copy(step.Variables, map[string]string{
+		"MISE_DATA_DIR":     "/mise",
+		"MISE_CONFIG_DIR":   "/mise",
+		"MISE_CACHE_DIR":    "/mise/cache",
+		"MISE_SHIMS_DIR":    "/mise/shims",
+		"MISE_INSTALLS_DIR": "/mise/installs",
 	})
 
 	// Add user mise config files if they exist
@@ -145,7 +145,6 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 			}),
 			plan.NewExecCommand("sh -c 'mise trust -a && mise install'", plan.ExecOptions{
 				CustomName: "install mise packages: " + strings.Join(pkgNames, ", "),
-				// Caches:     []string{miseCache},
 			}),
 		})
 	}

--- a/core/plan/command.go
+++ b/core/plan/command.go
@@ -12,15 +12,15 @@ type Command interface {
 }
 
 type ExecOptions struct {
-	Caches     []string
+	// Caches     []string
 	CustomName string
 }
 
 // ExecCommand represents a shell command to be executed during the build
 type ExecCommand struct {
-	Cmd        string   `json:"cmd" jsonschema:"description=The shell command to execute (e.g. 'go build' or 'npm install')"`
-	Caches     []string `json:"caches,omitempty" jsonschema:"description=Optional list of cache key references that will be available during this command execution. The cache must be defined in the top level 'caches' config"`
-	CustomName string   `json:"customName,omitempty" jsonschema:"description=Optional custom name to display for this command in build output"`
+	Cmd string `json:"cmd" jsonschema:"description=The shell command to execute (e.g. 'go build' or 'npm install')"`
+	// Caches     []string `json:"caches,omitempty" jsonschema:"description=Optional list of cache key references that will be available during this command execution. The cache must be defined in the top level 'caches' config"`
+	CustomName string `json:"customName,omitempty" jsonschema:"description=Optional custom name to display for this command in build output"`
 }
 
 // PathCommand represents adding a directory to the global PATH environment variable
@@ -64,7 +64,7 @@ func NewExecCommand(cmd string, options ...ExecOptions) Command {
 	exec := ExecCommand{Cmd: cmd}
 	if len(options) > 0 {
 		exec.CustomName = options[0].CustomName
-		exec.Caches = options[0].Caches
+		// exec.Caches = options[0].Caches
 	}
 	return exec
 }

--- a/core/plan/command.go
+++ b/core/plan/command.go
@@ -148,7 +148,8 @@ func UnmarshalStringCommand(data []byte) (Command, error) {
 
 	// If no prefix, treat as exec command
 	if !strings.Contains(str, ":") {
-		return NewExecShellCommand(strings.Trim(str, "\"")), nil
+		cmdToRun := strings.Trim(str, "\"")
+		return NewExecShellCommand(cmdToRun, ExecOptions{CustomName: cmdToRun}), nil
 	}
 
 	parts := strings.SplitN(str, ":", 2)
@@ -187,5 +188,9 @@ func UnmarshalStringCommand(data []byte) (Command, error) {
 	}
 
 	// fallback to exec command type
-	return NewExecShellCommand(strings.Trim(str, "\""), ExecOptions{CustomName: customName}), nil
+	cmdToRun := strings.Trim(str, "\"")
+	if customName == "" {
+		customName = cmdToRun
+	}
+	return NewExecShellCommand(cmdToRun, ExecOptions{CustomName: customName}), nil
 }

--- a/core/plan/command.go
+++ b/core/plan/command.go
@@ -12,14 +12,12 @@ type Command interface {
 }
 
 type ExecOptions struct {
-	// Caches     []string
 	CustomName string
 }
 
 // ExecCommand represents a shell command to be executed during the build
 type ExecCommand struct {
-	Cmd string `json:"cmd" jsonschema:"description=The shell command to execute (e.g. 'go build' or 'npm install')"`
-	// Caches     []string `json:"caches,omitempty" jsonschema:"description=Optional list of cache key references that will be available during this command execution. The cache must be defined in the top level 'caches' config"`
+	Cmd        string `json:"cmd" jsonschema:"description=The shell command to execute (e.g. 'go build' or 'npm install')"`
 	CustomName string `json:"customName,omitempty" jsonschema:"description=Optional custom name to display for this command in build output"`
 }
 
@@ -57,7 +55,6 @@ func NewExecCommand(cmd string, options ...ExecOptions) Command {
 	exec := ExecCommand{Cmd: cmd}
 	if len(options) > 0 {
 		exec.CustomName = options[0].CustomName
-		// exec.Caches = options[0].Caches
 	}
 	return exec
 }

--- a/core/plan/command_test.go
+++ b/core/plan/command_test.go
@@ -17,8 +17,8 @@ func TestCommandMarshalUnmarshal(t *testing.T) {
 		// Exec
 		{
 			name:            "exec command without custom name",
-			command:         NewExecShellCommand("echo hello"),
-			expectedJSON:    `{"cmd":"sh -c 'echo hello'"}`,
+			command:         NewExecShellCommand("echo hello", ExecOptions{CustomName: "echo hello"}),
+			expectedJSON:    `{"cmd":"sh -c 'echo hello'","customName":"echo hello"}`,
 			unmarshalString: "echo hello",
 		},
 		{

--- a/core/plan/command_test.go
+++ b/core/plan/command_test.go
@@ -27,12 +27,6 @@ func TestCommandMarshalUnmarshal(t *testing.T) {
 			expectedJSON:    `{"cmd":"sh -c 'echo hello'","customName":"Say Hello"}`,
 			unmarshalString: "RUN#Say Hello:echo hello",
 		},
-		{
-			name:            "exec command with cache key",
-			command:         ExecCommand{Cmd: "npm install", Caches: []string{"v1", "v2"}},
-			expectedJSON:    `{"cmd":"npm install","caches":["v1","v2"]}`,
-			unmarshalString: "",
-		},
 
 		// Path
 		{

--- a/core/plan/command_test.go
+++ b/core/plan/command_test.go
@@ -36,14 +36,6 @@ func TestCommandMarshalUnmarshal(t *testing.T) {
 			unmarshalString: "PATH:/usr/local/bin",
 		},
 
-		// Variable
-		{
-			name:            "variable command",
-			command:         NewVariableCommand("KEY", "value"),
-			expectedJSON:    `{"name":"KEY","value":"value"}`,
-			unmarshalString: "ENV:KEY=value",
-		},
-
 		// Copy
 		{
 			name:            "copy command",

--- a/core/plan/step.go
+++ b/core/plan/step.go
@@ -25,6 +25,12 @@ type Step struct {
 	// The assets available to this step. The key is the name of the asset that is referenced in a file command
 	Assets map[string]string `json:"assets,omitempty" jsonschema:"description=The assets available to this step. The key is the name of the asset that is referenced in a file command"`
 
+	// The variables available to this step. The key is the name of the variable that is referenced in a variable command
+	Variables map[string]string `json:"variables,omitempty" jsonschema:"description=The variables available to this step. The key is the name of the variable that is referenced in a variable command"`
+
+	// The caches available to all commands in this step. Each cache must refer to a cache at the top level of the plan
+	Caches []string `json:"caches,omitempty" jsonschema:"description=The caches available to all commands in this step. Each cache must refer to a cache at the top level of the plan"`
+
 	// The base image that will be used for this step
 	// If empty (default), the base image will be the one from the previous step
 	// Only set this if you don't want to reuse any part of the file system from the previous step

--- a/core/plan/step.go
+++ b/core/plan/step.go
@@ -39,8 +39,9 @@ type Step struct {
 
 func NewStep(name string) *Step {
 	return &Step{
-		Name:   name,
-		Assets: make(map[string]string),
+		Name:      name,
+		Assets:    make(map[string]string),
+		Variables: make(map[string]string),
 	}
 }
 
@@ -111,11 +112,10 @@ func (Step) JSONSchemaExtend(schema *jsonschema.Schema) {
 func CommandsSchema() *jsonschema.Schema {
 	execSchema := generateSchemaWithComments(ExecCommand{})
 	pathSchema := generateSchemaWithComments(PathCommand{})
-	variableSchema := generateSchemaWithComments(VariableCommand{})
 	copySchema := generateSchemaWithComments(CopyCommand{})
 	fileSchema := generateSchemaWithComments(FileCommand{})
 
-	availableCommands := []*jsonschema.Schema{execSchema, pathSchema, variableSchema, copySchema, fileSchema}
+	availableCommands := []*jsonschema.Schema{execSchema, pathSchema, copySchema, fileSchema}
 
 	// Add string schema type as an additional valid command type
 	stringSchema := &jsonschema.Schema{

--- a/core/providers/golang/golang.go
+++ b/core/providers/golang/golang.go
@@ -88,11 +88,10 @@ func (p *GoProvider) Build(ctx *generate.GenerateContext, packages *generate.Mis
 	}
 
 	build := ctx.NewCommandStep("build")
+	build.AddCache(p.goBuildCache(ctx))
 	build.AddCommands([]plan.Command{
 		plan.NewCopyCommand("."),
-		plan.NewExecCommand(buildCmd, plan.ExecOptions{
-			Caches: []string{p.goBuildCacheKey(ctx)},
-		}),
+		plan.NewExecCommand(buildCmd),
 	})
 
 	if packages != nil {
@@ -112,12 +111,11 @@ func (p *GoProvider) Install(ctx *generate.GenerateContext, packages *generate.M
 	}
 
 	install := ctx.NewCommandStep("install")
+	install.AddCache(p.goBuildCache(ctx))
 	install.AddCommands([]plan.Command{
 		plan.NewCopyCommand("go.mod"),
 		plan.NewCopyCommand("go.sum"),
-		plan.NewExecCommand("go mod download", plan.ExecOptions{
-			Caches: []string{p.goBuildCacheKey(ctx)},
-		}),
+		plan.NewExecCommand("go mod download"),
 	})
 
 	// If CGO is enabled, we need to install the gcc packages
@@ -167,7 +165,7 @@ func (p *GoProvider) addMetadata(ctx *generate.GenerateContext) {
 	ctx.Metadata.Set("hasCGOEnabled", strconv.FormatBool(p.hasCGOEnabled(ctx)))
 }
 
-func (p *GoProvider) goBuildCacheKey(ctx *generate.GenerateContext) string {
+func (p *GoProvider) goBuildCache(ctx *generate.GenerateContext) string {
 	return ctx.Caches.AddCache(GO_BUILD_CACHE_KEY, "/root/.cache/go-build")
 }
 

--- a/core/providers/golang/golang.go
+++ b/core/providers/golang/golang.go
@@ -124,7 +124,7 @@ func (p *GoProvider) Install(ctx *generate.GenerateContext, packages *generate.M
 		aptStep.Packages = []string{"gcc", "g++", "libc6-dev"}
 		install.DependsOn = append(install.DependsOn, aptStep.DisplayName)
 	} else {
-		install.AddCommand(plan.NewVariableCommand("CGO_ENABLED", "0"))
+		install.AddEnvVars(map[string]string{"CGO_ENABLED": "0"})
 	}
 
 	install.DependsOn = []string{packages.DisplayName}

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -73,34 +73,32 @@ func (p *NodeProvider) start(ctx *generate.GenerateContext, packageJson *Package
 
 func (p *NodeProvider) Build(ctx *generate.GenerateContext, install *generate.CommandStepBuilder, packageJson *PackageJson) (*generate.CommandStepBuilder, error) {
 	packageManager := p.getPackageManager(ctx.App)
+	build := ctx.NewCommandStep("build")
+	build.DependsOn = []string{install.DisplayName}
+
 	_, ok := packageJson.Scripts["build"]
 	if ok {
-		build := ctx.NewCommandStep("build")
-
-		// Generic node_modules cache
-		build.AddCache(ctx.Caches.AddCache("node-modules", "/app/node_modules/.cache"))
-
-		// Add caches for Next.JS apps
-		if nextApps, err := p.getNextApps(ctx); err == nil {
-			ctx.Metadata.SetBool("nextjs", len(nextApps) > 0)
-
-			for _, nextApp := range nextApps {
-				nextCacheDir := path.Join("/app", nextApp, ".next/cache")
-				build.AddCache(ctx.Caches.AddCache(fmt.Sprintf("next-%s", nextApp), nextCacheDir))
-			}
-		}
-
 		build.AddCommands([]plan.Command{
 			plan.NewCopyCommand("."),
 			plan.NewExecCommand(packageManager.RunCmd("build")),
 		})
 
-		build.DependsOn = []string{install.DisplayName}
-
-		return build, nil
 	}
 
-	return nil, nil
+	// Generic node_modules cache
+	build.AddCache(ctx.Caches.AddCache("node-modules", "/app/node_modules/.cache"))
+
+	// Add caches for Next.JS apps
+	if nextApps, err := p.getNextApps(ctx); err == nil {
+		ctx.Metadata.SetBool("nextjs", len(nextApps) > 0)
+
+		for _, nextApp := range nextApps {
+			nextCacheDir := path.Join("/app", nextApp, ".next/cache")
+			build.AddCache(ctx.Caches.AddCache(fmt.Sprintf("next-%s", nextApp), nextCacheDir))
+		}
+	}
+
+	return build, nil
 }
 
 func (p *NodeProvider) Install(ctx *generate.GenerateContext, packages *generate.MiseStepBuilder, packageJson *PackageJson) (*generate.CommandStepBuilder, error) {

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -75,6 +75,7 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, install *generate.Co
 	packageManager := p.getPackageManager(ctx.App)
 	build := ctx.NewCommandStep("build")
 	build.DependsOn = []string{install.DisplayName}
+	build.AddEnvVars(map[string]string{"HELLO": "world"})
 
 	_, ok := packageJson.Scripts["build"]
 	if ok {

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -75,10 +75,10 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, install *generate.Co
 	packageManager := p.getPackageManager(ctx.App)
 	_, ok := packageJson.Scripts["build"]
 	if ok {
-		buildCaches := []string{}
+		build := ctx.NewCommandStep("build")
 
 		// Generic node_modules cache
-		buildCaches = append(buildCaches, ctx.Caches.AddCache("node-modules", "/app/node_modules/.cache"))
+		build.AddCache(ctx.Caches.AddCache("node-modules", "/app/node_modules/.cache"))
 
 		// Add caches for Next.JS apps
 		if nextApps, err := p.getNextApps(ctx); err == nil {
@@ -86,18 +86,13 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, install *generate.Co
 
 			for _, nextApp := range nextApps {
 				nextCacheDir := path.Join("/app", nextApp, ".next/cache")
-				nextCache := ctx.Caches.AddCache(fmt.Sprintf("next-%s", nextApp), nextCacheDir)
-				buildCaches = append(buildCaches, nextCache)
+				build.AddCache(ctx.Caches.AddCache(fmt.Sprintf("next-%s", nextApp), nextCacheDir))
 			}
 		}
 
-		build := ctx.NewCommandStep("build")
-
 		build.AddCommands([]plan.Command{
 			plan.NewCopyCommand("."),
-			plan.NewExecCommand(packageManager.RunCmd("build"), plan.ExecOptions{
-				Caches: buildCaches,
-			}),
+			plan.NewExecCommand(packageManager.RunCmd("build")),
 		})
 
 		build.DependsOn = []string{install.DisplayName}

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -68,30 +68,25 @@ func (p PackageManager) InstallDeps(ctx *generate.GenerateContext, install *gene
 	switch p {
 	case PackageManagerNpm:
 		hasLockfile := ctx.App.HasMatch("package-lock.json")
-		npmCache := ctx.Caches.AddCache("npm-install", "/root/.npm")
+		install.AddCache(ctx.Caches.AddCache("npm-install", "/root/.npm"))
 
 		if hasLockfile {
-			install.AddCommand(plan.NewExecCommand("npm ci", plan.ExecOptions{Caches: []string{npmCache}}))
+			install.AddCommand(plan.NewExecCommand("npm ci"))
 		} else {
-			install.AddCommand(plan.NewExecCommand("npm install",
-				plan.ExecOptions{Caches: []string{npmCache}}))
+			install.AddCommand(plan.NewExecCommand("npm install"))
 		}
 	case PackageManagerPnpm:
-		install.AddCommand(plan.NewExecCommand("pnpm install --frozen-lockfile --prod=false", plan.ExecOptions{
-			Caches: []string{ctx.Caches.AddCache("pnpm-install", "/root/.local/share/pnpm/store/v3")},
-		}))
+		install.AddCommand(plan.NewExecCommand("pnpm install --frozen-lockfile --prod=false"))
+		install.AddCache(ctx.Caches.AddCache("pnpm-install", "/root/.local/share/pnpm/store/v3"))
 	case PackageManagerBun:
-		install.AddCommand(plan.NewExecCommand("bun install --frozen-lockfile", plan.ExecOptions{
-			Caches: []string{ctx.Caches.AddCache("bun-install", "/root/.bun/install/cache")},
-		}))
+		install.AddCommand(plan.NewExecCommand("bun install --frozen-lockfile"))
+		install.AddCache(ctx.Caches.AddCache("bun-install", "/root/.bun/install/cache"))
 	case PackageManagerYarn1:
-		install.AddCommand(plan.NewExecCommand("yarn install --frozen-lockfile", plan.ExecOptions{
-			Caches: []string{ctx.Caches.AddCache("yarn-install", "/usr/local/share/.cache/yarn")},
-		}))
+		install.AddCommand(plan.NewExecCommand("yarn install --frozen-lockfile"))
+		install.AddCache(ctx.Caches.AddCache("yarn-install", "/usr/local/share/.cache/yarn"))
 	case PackageManagerYarn2:
-		install.AddCommand(plan.NewExecCommand("yarn install --check-cache", plan.ExecOptions{
-			Caches: []string{ctx.Caches.AddCache("yarn-install", "/usr/local/share/.cache/yarn")},
-		}))
+		install.AddCommand(plan.NewExecCommand("yarn install --check-cache"))
+		install.AddCache(ctx.Caches.AddCache("yarn-install", "/usr/local/share/.cache/yarn"))
 	}
 }
 

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -41,14 +41,14 @@ func (p *PhpProvider) Plan(ctx *generate.GenerateContext) error {
 	// Install composer
 	if _, err := p.readComposerJson(ctx); err == nil {
 		install := ctx.NewCommandStep("install")
+		install.AddCache(ctx.Caches.AddCache("composer", "/opt/cache/composer"))
+
 		install.AddCommands([]plan.Command{
 			// Copy composer from the composer image
 			plan.CopyCommand{Image: "composer:latest", Src: "/usr/bin/composer", Dest: "/usr/bin/composer"},
 			plan.NewCopyCommand("."),
 			plan.NewVariableCommand("COMPOSER_CACHE_DIR", "/opt/cache/composer"),
-			plan.NewExecCommand("composer install --ignore-platform-reqs", plan.ExecOptions{
-				Caches: []string{ctx.Caches.AddCache("composer", "/opt/cache/composer")},
-			}),
+			plan.NewExecCommand("composer install --ignore-platform-reqs"),
 		})
 
 		install.DependsOn = []string{nginxPackages.DisplayName}

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -42,12 +42,12 @@ func (p *PhpProvider) Plan(ctx *generate.GenerateContext) error {
 	if _, err := p.readComposerJson(ctx); err == nil {
 		install := ctx.NewCommandStep("install")
 		install.AddCache(ctx.Caches.AddCache("composer", "/opt/cache/composer"))
+		install.AddEnvVars(map[string]string{"COMPOSER_CACHE_DIR": "/opt/cache/composer"})
 
 		install.AddCommands([]plan.Command{
 			// Copy composer from the composer image
 			plan.CopyCommand{Image: "composer:latest", Src: "/usr/bin/composer", Dest: "/usr/bin/composer"},
 			plan.NewCopyCommand("."),
-			plan.NewVariableCommand("COMPOSER_CACHE_DIR", "/opt/cache/composer"),
 			plan.NewExecCommand("composer install --ignore-platform-reqs"),
 		})
 
@@ -97,9 +97,7 @@ func (p *PhpProvider) Plan(ctx *generate.GenerateContext) error {
 	})
 
 	if p.usesLaravel(ctx) {
-		nginxSetup.AddCommands([]plan.Command{
-			plan.NewVariableCommand("IS_LARAVEL", "true"),
-		})
+		nginxSetup.AddEnvVars(map[string]string{"IS_LARAVEL": "true"})
 	}
 
 	nginxSetup.Assets["start-nginx.sh"] = startNginxScriptAsset

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -81,11 +81,10 @@ func (p *PythonProvider) install(ctx *generate.GenerateContext) error {
 	install.DependsOn = append(install.DependsOn, setup.DisplayName)
 
 	if hasRequirements {
+		install.AddCache(ctx.Caches.AddCache("pip", PIP_CACHE_DIR))
 		install.AddCommands([]plan.Command{
 			plan.NewCopyCommand("requirements.txt"),
-			plan.NewExecCommand("pip install -r requirements.txt", plan.ExecOptions{
-				Caches: []string{ctx.Caches.AddCache("pip", PIP_CACHE_DIR)},
-			}),
+			plan.NewExecCommand("pip install -r requirements.txt"),
 		})
 	} else if hasPyproject && hasPoetry {
 		install.AddCommands([]plan.Command{

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -97,9 +97,9 @@ func (p *PythonProvider) install(ctx *generate.GenerateContext) error {
 	} else if hasPyproject && hasPdm {
 		// TODO: Fix this. PDM is not working because the packages are installed into a venv
 		// that is not available to python at runtime
+		install.AddEnvVars(map[string]string{"PDM_CHECK_UPDATE": "false"})
 		install.AddCommands([]plan.Command{
 			plan.NewExecCommand("pipx install pdm"),
-			plan.NewVariableCommand("PDM_CHECK_UPDATE", "false"),
 			plan.NewCopyCommand("pyproject.toml"),
 			plan.NewCopyCommand("pdm.lock"),
 			plan.NewCopyCommand("."),
@@ -107,10 +107,13 @@ func (p *PythonProvider) install(ctx *generate.GenerateContext) error {
 			plan.NewPathCommand("/app/.venv/bin"),
 		})
 	} else if hasPyproject && hasUv {
+		install.AddEnvVars(map[string]string{
+			"UV_COMPILE_BYTECODE": "1",
+			"UV_LINK_MODE":        "copy",
+			"UV_CACHE_DIR":        UV_CACHE_DIR,
+		})
+
 		install.AddCommands([]plan.Command{
-			plan.NewVariableCommand("UV_COMPILE_BYTECODE", "1"),
-			plan.NewVariableCommand("UV_LINK_MODE", "copy"),
-			plan.NewVariableCommand("UV_CACHE_DIR", UV_CACHE_DIR),
 			plan.NewExecCommand("pipx install uv"),
 			plan.NewCopyCommand("pyproject.toml"),
 			plan.NewCopyCommand("uv.lock"),

--- a/examples/config-file/railpack.json
+++ b/examples/config-file/railpack.json
@@ -7,10 +7,13 @@
   "aptPackages": ["neofetch"],
   "steps": {
     "build": {
-      "commands": ["neofetch"]
+      "commands": ["neofetch"],
+      "variables": {
+        "HELLO": "world"
+      }
     }
   },
   "start": {
-    "cmd": "neofetch"
+    "cmd": "neofetch $HELLO"
   }
 }


### PR DESCRIPTION
Previously the caches and env variables were specified at the command level. That made it difficult to apply config (like custom build commands), because that would wipe out the caches and variables. This PR moves those fields the step level so that config can override commands while keeping the variable and cache config.

This solves a real problem for building the railway.com frontend where we are setting a custom build command but want to keep using the auto detected cache config.
