### PR TITLE
Opt-in to specific secrets

### DIFF
--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -342,18 +342,6 @@ func (g *BuildGraph) convertExecCommandToLLB(node *StepNode, cmd plan.ExecComman
 		}
 	}
 
-	// if node.Step.UseSecrets == nil || *node.Step.UseSecrets { // default to using secrets
-	// 	for _, secret := range g.Plan.Secrets {
-	// 		opts = append(opts, llb.AddSecret(secret, llb.SecretID(secret), llb.SecretAsEnv(true), llb.SecretAsEnvName(secret)))
-	// 	}
-
-	// 	// If there is a secrets hash, add a mount to invalidate the cache if the secrets hash changes
-	// 	if g.SecretsHash != "" {
-	// 		opts = append(opts, llb.AddMount("/cache-invalidate",
-	// 			llb.Scratch().File(llb.Mkfile("secrets-hash", 0644, []byte(g.SecretsHash)), llb.WithCustomName("invalidate cache on secrets hash change"))))
-	// 	}
-	// }
-
 	if len(node.Step.Caches) > 0 {
 		cacheOpts, err := g.getCacheMountOptions(node.Step.Caches)
 		if err != nil {

--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -237,8 +237,8 @@ func (g *BuildGraph) convertNodeToLLB(node *StepNode, baseState *llb.State) (*ll
 	}
 
 	// Process the step commands
-	if node.Step.Commands != nil {
-		for _, cmd := range *node.Step.Commands {
+	if len(node.Step.Commands) > 0 {
+		for _, cmd := range node.Step.Commands {
 			var err error
 			state, err = g.convertCommandToLLB(node, cmd, state, node.Step)
 			if err != nil {
@@ -247,10 +247,10 @@ func (g *BuildGraph) convertNodeToLLB(node *StepNode, baseState *llb.State) (*ll
 		}
 	}
 
-	if node.Step.Outputs != nil {
+	if len(node.Step.Outputs) > 0 {
 		result := llb.Scratch()
 
-		for _, output := range *node.Step.Outputs {
+		for _, output := range node.Step.Outputs {
 			result = result.File(llb.Copy(state, output, output, &llb.CopyInfo{
 				CreateDestPath:      true,
 				AllowWildcard:       true,
@@ -329,7 +329,7 @@ func (g *BuildGraph) convertExecCommandToLLB(node *StepNode, cmd plan.ExecComman
 		opts = append(opts, llb.WithCustomName(cmd.CustomName))
 	}
 
-	if node.Step.Secrets != nil && len(*node.Step.Secrets) > 0 {
+	if len(node.Step.Secrets) > 0 {
 		secretOpts := []llb.RunOption{}
 		for _, secret := range g.Plan.Secrets {
 			secretOpts = append(secretOpts, llb.AddSecret(secret, llb.SecretID(secret), llb.SecretAsEnv(true), llb.SecretAsEnvName(secret)))
@@ -417,7 +417,7 @@ func (g *BuildGraph) getSecretMountOptions(node *StepNode, secretOpts []llb.RunO
 
 	// If all secrets are included, we can just copy the secrets hash file to the new state
 	includesAllSecrets := false
-	for _, secret := range *node.Step.Secrets {
+	for _, secret := range node.Step.Secrets {
 		if secret == "*" {
 			includesAllSecrets = true
 			break
@@ -430,8 +430,8 @@ func (g *BuildGraph) getSecretMountOptions(node *StepNode, secretOpts []llb.RunO
 	} else {
 		// If not all secrets are included, we want to compute the hash of only the used secrets
 
-		secretsWithDollar := make([]string, len(*node.Step.Secrets))
-		for i, secret := range *node.Step.Secrets {
+		secretsWithDollar := make([]string, len(node.Step.Secrets))
+		for i, secret := range node.Step.Secrets {
 			secretsWithDollar[i] = "$" + secret
 		}
 		secretsString := strings.Join(secretsWithDollar, " ")

--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -330,16 +330,16 @@ func (g *BuildGraph) convertExecCommandToLLB(node *StepNode, cmd plan.ExecComman
 	}
 
 	if node.Step.Secrets != nil && len(*node.Step.Secrets) > 0 {
-		// secretOpts := []llb.RunOption{}
-		// for _, secret := range g.Plan.Secrets {
-		// 	secretOpts = append(secretOpts, llb.AddSecret(secret, llb.SecretID(secret), llb.SecretAsEnv(true), llb.SecretAsEnvName(secret)))
-		// }
-		// opts = append(opts, secretOpts...)
+		secretOpts := []llb.RunOption{}
+		for _, secret := range g.Plan.Secrets {
+			secretOpts = append(secretOpts, llb.AddSecret(secret, llb.SecretID(secret), llb.SecretAsEnv(true), llb.SecretAsEnvName(secret)))
+		}
+		opts = append(opts, secretOpts...)
 
-		// if g.SecretsHash != "" {
-		// 	secretOpts = g.getSecretMountOptions(node, secretOpts)
-		// 	opts = append(opts, secretOpts...)
-		// }
+		if g.SecretsHash != "" {
+			secretOpts = g.getSecretMountOptions(node, secretOpts)
+			opts = append(opts, secretOpts...)
+		}
 	}
 
 	// if node.Step.UseSecrets == nil || *node.Step.UseSecrets { // default to using secrets

--- a/buildkit/frontend.go
+++ b/buildkit/frontend.go
@@ -66,6 +66,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		BuildPlatform: buildPlatform,
 		SecretsHash:   secretsHash,
 		CacheKey:      cacheKey,
+		SessionID:     c.BuildOpts().SessionID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error converting plan to LLB: %w", err)

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -85,7 +85,6 @@
    }
   },
   {
-   "commands": [],
    "dependsOn": [
     "packages:mise",
     "setup",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -51,8 +51,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -71,6 +71,9 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "PIP_CACHE_DIR": "/opt/pip-cache",
     "PIP_DEFAULT_TIMEOUT": "100",
@@ -88,7 +91,8 @@
     "setup",
     "packages:apt:python-system-deps"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -102,7 +106,7 @@
     }
    ],
    "name": "packages:apt:python-system-deps",
-   "useSecrets": false
+   "secrets": []
   },
   {
    "caches": [
@@ -116,7 +120,7 @@
     }
    ],
    "name": "packages:apt:config",
-   "useSecrets": false
+   "secrets": []
   },
   {
    "commands": [
@@ -130,6 +134,9 @@
     "packages:apt:config"
    ],
    "name": "build",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "HELLO": "world"
    }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
@@ -43,8 +43,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -74,6 +74,9 @@
     "packages:mise"
    ],
    "name": "install",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "CGO_ENABLED": "0"
    }
@@ -95,7 +98,10 @@
     "packages:mise",
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
@@ -40,8 +40,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -71,6 +71,9 @@
     "packages:mise"
    ],
    "name": "install",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "CGO_ENABLED": "0"
    }
@@ -92,7 +95,10 @@
     "packages:mise",
     "install"
    ],
-   "name": "build"
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -54,8 +54,8 @@
     "/root/.local/state/mise",
     "/app/mise.toml"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -74,6 +74,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -98,7 +99,8 @@
     "packages:mise",
     "setup"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -117,9 +119,9 @@
     "install"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -49,8 +49,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -69,6 +69,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -97,7 +98,8 @@
     "packages:mise",
     "setup"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -116,9 +118,9 @@
     "install"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -49,8 +49,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -69,6 +69,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -93,7 +94,8 @@
     "packages:mise",
     "setup"
    ],
-   "name": "corepack"
+   "name": "corepack",
+   "secrets": []
   },
   {
    "caches": [
@@ -117,7 +119,8 @@
     "setup",
     "corepack"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -136,9 +139,9 @@
     "install"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -53,8 +53,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -73,6 +73,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -101,7 +102,8 @@
     "packages:mise",
     "setup"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -121,9 +123,9 @@
     "install"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -113,7 +113,6 @@
    "caches": [
     "node-modules"
    ],
-   "commands": [],
    "dependsOn": [
     "install"
    ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -49,8 +49,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -69,6 +69,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -105,7 +106,8 @@
     "packages:mise",
     "setup"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -116,9 +118,9 @@
     "install"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -105,7 +105,6 @@
    "caches": [
     "node-modules"
    ],
-   "commands": [],
    "dependsOn": [
     "install"
    ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -49,8 +49,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -69,6 +69,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -97,7 +98,8 @@
     "packages:mise",
     "setup"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -108,9 +110,9 @@
     "install"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -45,8 +45,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -65,6 +65,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -81,9 +82,9 @@
     "setup"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -77,7 +77,6 @@
    "caches": [
     "node-modules"
    ],
-   "commands": [],
    "dependsOn": [
     "setup"
    ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -56,8 +56,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -76,6 +76,7 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -100,7 +101,8 @@
     "packages:mise",
     "setup"
    ],
-   "name": "corepack"
+   "name": "corepack",
+   "secrets": []
   },
   {
    "caches": [
@@ -148,7 +150,8 @@
     "setup",
     "corepack"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -169,9 +172,9 @@
     "install"
    ],
    "name": "build",
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-inertia_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-inertia_1.snap.json
@@ -31,8 +31,8 @@
  "steps": [
   {
    "name": "packages:image",
-   "startingImage": "php:8.2.27-fpm",
-   "useSecrets": false
+   "secrets": [],
+   "startingImage": "php:8.2.27-fpm"
   },
   {
    "caches": [
@@ -49,7 +49,7 @@
     "packages:image"
    ],
    "name": "packages:apt:nginx",
-   "useSecrets": false
+   "secrets": []
   },
   {
    "caches": [
@@ -73,6 +73,9 @@
     "packages:apt:nginx"
    ],
    "name": "install",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "COMPOSER_CACHE_DIR": "/opt/cache/composer"
    }
@@ -103,8 +106,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -123,6 +126,7 @@
     "packages:mise"
    ],
    "name": "setup:node",
+   "secrets": [],
    "variables": {
     "CI": "true",
     "NODE_ENV": "production",
@@ -151,7 +155,8 @@
     "packages:mise",
     "setup:node"
    ],
-   "name": "install:node"
+   "name": "install:node",
+   "secrets": []
   },
   {
    "caches": [
@@ -173,9 +178,9 @@
    "outputs": [
     "/app"
    ],
-   "variables": {
-    "HELLO": "world"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "assets": {
@@ -208,6 +213,9 @@
     "packages:apt:nginx"
    ],
    "name": "nginx:setup",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "IS_LARAVEL": "true"
    }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
@@ -23,8 +23,8 @@
  "steps": [
   {
    "name": "packages:image",
-   "startingImage": "php:8.2.27-fpm",
-   "useSecrets": false
+   "secrets": [],
+   "startingImage": "php:8.2.27-fpm"
   },
   {
    "caches": [
@@ -41,7 +41,7 @@
     "packages:image"
    ],
    "name": "packages:apt:nginx",
-   "useSecrets": false
+   "secrets": []
   },
   {
    "caches": [
@@ -65,6 +65,9 @@
     "packages:apt:nginx"
    ],
    "name": "install",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "COMPOSER_CACHE_DIR": "/opt/cache/composer"
    }
@@ -99,10 +102,16 @@
    "dependsOn": [
     "packages:apt:nginx"
    ],
-   "name": "nginx:setup"
+   "name": "nginx:setup",
+   "secrets": [
+    "*"
+   ]
   },
   {
-   "name": "packages:mise"
+   "name": "packages:mise",
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
@@ -19,8 +19,8 @@
  "steps": [
   {
    "name": "packages:image",
-   "startingImage": "php:8.4.3-fpm",
-   "useSecrets": false
+   "secrets": [],
+   "startingImage": "php:8.4.3-fpm"
   },
   {
    "caches": [
@@ -37,7 +37,7 @@
     "packages:image"
    ],
    "name": "packages:apt:nginx",
-   "useSecrets": false
+   "secrets": []
   },
   {
    "assets": {
@@ -69,10 +69,16 @@
    "dependsOn": [
     "packages:apt:nginx"
    ],
-   "name": "nginx:setup"
+   "name": "nginx:setup",
+   "secrets": [
+    "*"
+   ]
   },
   {
-   "name": "packages:mise"
+   "name": "packages:mise",
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -43,8 +43,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -63,6 +63,9 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "PIP_CACHE_DIR": "/opt/pip-cache",
     "PIP_DEFAULT_TIMEOUT": "100",
@@ -103,6 +106,7 @@
     "packages:apt:python-system-deps"
    ],
    "name": "install",
+   "secrets": [],
    "variables": {
     "PDM_CHECK_UPDATE": "false"
    }
@@ -119,7 +123,7 @@
     }
    ],
    "name": "packages:apt:python-system-deps",
-   "useSecrets": false
+   "secrets": []
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -47,8 +47,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -67,6 +67,9 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "PIP_CACHE_DIR": "/opt/pip-cache",
     "PIP_DEFAULT_TIMEOUT": "100",
@@ -95,7 +98,8 @@
     "setup",
     "packages:apt:python-system-deps"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -109,7 +113,7 @@
     }
    ],
    "name": "packages:apt:python-system-deps",
-   "useSecrets": false
+   "secrets": []
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -43,8 +43,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -63,6 +63,9 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "PIP_CACHE_DIR": "/opt/pip-cache",
     "PIP_DEFAULT_TIMEOUT": "100",
@@ -98,7 +101,8 @@
     "setup",
     "packages:apt:python-system-deps"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -112,7 +116,7 @@
     }
    ],
    "name": "packages:apt:python-system-deps",
-   "useSecrets": false
+   "secrets": []
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -52,8 +52,8 @@
     "/root/.local/state/mise",
     "/app/.python-version"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -72,6 +72,9 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "PIP_CACHE_DIR": "/opt/pip-cache",
     "PIP_DEFAULT_TIMEOUT": "100",
@@ -100,7 +103,8 @@
     "setup",
     "packages:apt:python-system-deps"
    ],
-   "name": "install"
+   "name": "install",
+   "secrets": []
   },
   {
    "caches": [
@@ -114,7 +118,7 @@
     }
    ],
    "name": "packages:apt:python-system-deps",
-   "useSecrets": false
+   "secrets": []
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -48,8 +48,8 @@
     "/root/.local/state/mise",
     "/app/.python-version"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -68,6 +68,9 @@
     "packages:mise"
    ],
    "name": "setup",
+   "secrets": [
+    "*"
+   ],
    "variables": {
     "PIP_CACHE_DIR": "/opt/pip-cache",
     "PIP_DEFAULT_TIMEOUT": "100",
@@ -111,6 +114,7 @@
     "packages:apt:python-system-deps"
    ],
    "name": "install",
+   "secrets": [],
    "variables": {
     "UV_CACHE_DIR": "/opt/uv-cache",
     "UV_COMPILE_BYTECODE": "1",
@@ -129,7 +133,7 @@
     }
    ],
    "name": "packages:apt:python-system-deps",
-   "useSecrets": false
+   "secrets": []
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
@@ -10,14 +10,13 @@
  },
  "steps": [
   {
-   "name": "packages:mise"
+   "name": "packages:mise",
+   "secrets": [
+    "*"
+   ]
   },
   {
    "commands": [
-    {
-     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'",
-     "customName": "{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }"
-    },
     {
      "dest": ".",
      "src": "."
@@ -30,7 +29,16 @@
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "defaultsToUsing"
+   "name": "defaultsToUsing",
+   "outputs": [
+    "/app"
+   ],
+   "secrets": [
+    "*"
+   ],
+   "variables": {
+    "NOT_SECRET": "not secret"
+   }
   },
   {
    "commands": [
@@ -47,14 +55,13 @@
     "packages:mise"
    ],
    "name": "doesNotUseSecrets",
-   "useSecrets": false
+   "outputs": [
+    "/app"
+   ],
+   "secrets": []
   },
   {
    "commands": [
-    {
-     "cmd": "sh -c '{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }'",
-     "customName": "{ \"name\": \"NOT_SECRET\", \"value\": \"not secret\" }"
-    },
     {
      "dest": ".",
      "src": "."
@@ -67,7 +74,17 @@
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "usesSecrets"
+   "name": "usesSecrets",
+   "outputs": [
+    "/app"
+   ],
+   "secrets": [
+    "MY_SECRET",
+    "MY_OTHER_SECRET"
+   ],
+   "variables": {
+    "NOT_SECRET": "not secret"
+   }
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
@@ -33,8 +33,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -59,7 +59,10 @@
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
@@ -33,8 +33,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -59,7 +59,10 @@
    "dependsOn": [
     "packages:mise"
    ],
-   "name": "setup"
+   "name": "setup",
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -80,3 +80,16 @@ func (e *Environment) IsConfigVariableTruthy(name string) bool {
 	}
 	return false
 }
+
+// GetSecretsWithPrefix returns all secrets that have the given prefix
+func (e *Environment) GetSecretsWithPrefix(prefix string) []string {
+	fmt.Printf("Getting secrets with prefix: %s\n", prefix)
+	secrets := []string{}
+	for secretName := range e.Variables {
+		fmt.Printf("secret: %s\n", secretName)
+		if strings.HasPrefix(secretName, prefix) {
+			secrets = append(secrets, secretName)
+		}
+	}
+	return secrets
+}

--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -83,10 +83,8 @@ func (e *Environment) IsConfigVariableTruthy(name string) bool {
 
 // GetSecretsWithPrefix returns all secrets that have the given prefix
 func (e *Environment) GetSecretsWithPrefix(prefix string) []string {
-	fmt.Printf("Getting secrets with prefix: %s\n", prefix)
 	secrets := []string{}
 	for secretName := range e.Variables {
-		fmt.Printf("secret: %s\n", secretName)
 		if strings.HasPrefix(secretName, prefix) {
 			secrets = append(secrets, secretName)
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -155,13 +155,13 @@ func GenerateConfigFromEnvironment(app *app.App, env *app.Environment) *config.C
 
 	if installCmdVar, _ := env.GetConfigVariable("INSTALL_CMD"); installCmdVar != "" {
 		installStep := config.GetOrCreateStep("install")
-		installStep.Commands = &[]plan.Command{plan.NewExecCommand(installCmdVar)}
+		installStep.Commands = []plan.Command{plan.NewExecCommand(installCmdVar)}
 		installStep.DependsOn = append(installStep.DependsOn, "packages")
 	}
 
 	if buildCmdVar, _ := env.GetConfigVariable("BUILD_CMD"); buildCmdVar != "" {
 		buildStep := config.GetOrCreateStep("build")
-		buildStep.Commands = &[]plan.Command{
+		buildStep.Commands = []plan.Command{
 			// We want to run the build command with all the files in the current directory
 			plan.NewCopyCommand("."),
 			plan.NewExecCommand(buildCmdVar),
@@ -202,7 +202,7 @@ func GenerateConfigFromOptions(options *GenerateBuildPlanOptions) *config.Config
 
 	if options.BuildCommand != "" {
 		buildStep := config.GetOrCreateStep("build")
-		buildStep.Commands = &[]plan.Command{
+		buildStep.Commands = []plan.Command{
 			plan.NewCopyCommand("."),
 			plan.NewExecCommand(options.BuildCommand),
 		}

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -57,8 +57,8 @@
     "/etc/mise/config.toml",
     "/root/.local/state/mise"
    ],
+   "secrets": [],
    "startingImage": "ghcr.io/railwayapp/railpack-builder-base:latest",
-   "useSecrets": false,
    "variables": {
     "MISE_CACHE_DIR": "/mise/cache",
     "MISE_CONFIG_DIR": "/mise",
@@ -79,7 +79,7 @@
     }
    ],
    "name": "packages:apt:test",
-   "useSecrets": false
+   "secrets": []
   },
   {
    "commands": [
@@ -93,6 +93,9 @@
    "name": "install",
    "outputs": [
     "node_modules"
+   ],
+   "secrets": [
+    "*"
    ]
   },
   {
@@ -106,7 +109,10 @@
     "install",
     "packages:apt:config"
    ],
-   "name": "build"
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [
@@ -120,7 +126,7 @@
     }
    ],
    "name": "packages:apt:config",
-   "useSecrets": false
+   "secrets": []
   }
  ]
 }

--- a/core/generate/apt_step_builder.go
+++ b/core/generate/apt_step_builder.go
@@ -44,7 +44,7 @@ func (b *AptStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 	step.Caches = options.Caches.GetAptCaches()
 
 	// Does not use any secrets
-	step.Secrets = &[]string{}
+	step.Secrets = []string{}
 
 	return step, nil
 }

--- a/core/generate/apt_step_builder.go
+++ b/core/generate/apt_step_builder.go
@@ -43,7 +43,8 @@ func (b *AptStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 
 	step.Caches = options.Caches.GetAptCaches()
 
-	step.UseSecrets = &[]bool{false}[0]
+	// Does not use any secrets
+	step.Secrets = &[]string{}
 
 	return step, nil
 }

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -1,8 +1,10 @@
 package generate
 
 import (
+	"fmt"
 	"maps"
 
+	a "github.com/railwayapp/railpack/core/app"
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/utils"
 )
@@ -16,6 +18,8 @@ type CommandStepBuilder struct {
 	Variables   map[string]string
 	Caches      []string
 	Secrets     *[]string
+	app         *a.App
+	env         *a.Environment
 }
 
 func (c *GenerateContext) NewCommandStep(name string) *CommandStepBuilder {
@@ -27,6 +31,8 @@ func (c *GenerateContext) NewCommandStep(name string) *CommandStepBuilder {
 		Variables:   map[string]string{},
 		Caches:      []string{},
 		Secrets:     &[]string{"*"},
+		app:         c.App,
+		env:         c.Env,
 	}
 
 	c.Steps = append(c.Steps, step)
@@ -70,6 +76,18 @@ func (b *CommandStepBuilder) AddPaths(paths []string) {
 		commands = append(commands, plan.NewPathCommand(path))
 	}
 	b.AddCommands(commands)
+}
+
+func (b *CommandStepBuilder) UseSecretsWithPrefix(prefix string) {
+	secrets := b.env.GetSecretsWithPrefix(prefix)
+	fmt.Printf("secrets: %v\n", secrets)
+	*b.Secrets = append(*b.Secrets, secrets...)
+}
+
+func (b *CommandStepBuilder) UseSecrets(secrets []string) {
+	if b.env.GetVariable("CI") != "" {
+		*b.Secrets = append(*b.Secrets, secrets...)
+	}
 }
 
 func (b *CommandStepBuilder) Name() string {

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"fmt"
 	"maps"
 
 	a "github.com/railwayapp/railpack/core/app"
@@ -12,12 +11,12 @@ import (
 type CommandStepBuilder struct {
 	DisplayName string
 	DependsOn   []string
-	Commands    *[]plan.Command
-	Outputs     *[]string
+	Commands    []plan.Command
+	Outputs     []string
 	Assets      map[string]string
 	Variables   map[string]string
 	Caches      []string
-	Secrets     *[]string
+	Secrets     []string
 	app         *a.App
 	env         *a.Environment
 }
@@ -26,11 +25,11 @@ func (c *GenerateContext) NewCommandStep(name string) *CommandStepBuilder {
 	step := &CommandStepBuilder{
 		DisplayName: c.GetStepName(name),
 		DependsOn:   []string{MisePackageStepName},
-		Commands:    &[]plan.Command{},
+		Commands:    []plan.Command{},
 		Assets:      map[string]string{},
 		Variables:   map[string]string{},
 		Caches:      []string{},
-		Secrets:     &[]string{"*"},
+		Secrets:     []string{"*"},
 		app:         c.App,
 		env:         c.Env,
 	}
@@ -53,17 +52,14 @@ func (b *CommandStepBuilder) AddCache(name string) {
 }
 
 func (b *CommandStepBuilder) AddCommand(command plan.Command) {
-	if b.Commands == nil {
-		b.Commands = &[]plan.Command{}
-	}
-	*b.Commands = append(*b.Commands, command)
+	b.AddCommands([]plan.Command{command})
 }
 
 func (b *CommandStepBuilder) AddCommands(commands []plan.Command) {
 	if b.Commands == nil {
-		b.Commands = &[]plan.Command{}
+		b.Commands = []plan.Command{}
 	}
-	*b.Commands = append(*b.Commands, commands...)
+	b.Commands = append(b.Commands, commands...)
 }
 
 func (b *CommandStepBuilder) AddEnvVars(envVars map[string]string) {
@@ -86,13 +82,12 @@ func (b *CommandStepBuilder) UseSecretsWithPrefixes(prefixes []string) {
 
 func (b *CommandStepBuilder) UseSecretsWithPrefix(prefix string) {
 	secrets := b.env.GetSecretsWithPrefix(prefix)
-	fmt.Printf("secrets: %v\n", secrets)
-	*b.Secrets = append(*b.Secrets, secrets...)
+	b.Secrets = append(b.Secrets, secrets...)
 }
 
 func (b *CommandStepBuilder) UseSecrets(secrets []string) {
 	if b.env.GetVariable("CI") != "" {
-		*b.Secrets = append(*b.Secrets, secrets...)
+		b.Secrets = append(b.Secrets, secrets...)
 	}
 }
 

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -78,6 +78,12 @@ func (b *CommandStepBuilder) AddPaths(paths []string) {
 	b.AddCommands(commands)
 }
 
+func (b *CommandStepBuilder) UseSecretsWithPrefixes(prefixes []string) {
+	for _, prefix := range prefixes {
+		b.UseSecretsWithPrefix(prefix)
+	}
+}
+
 func (b *CommandStepBuilder) UseSecretsWithPrefix(prefix string) {
 	secrets := b.env.GetSecretsWithPrefix(prefix)
 	fmt.Printf("secrets: %v\n", secrets)

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -15,7 +15,7 @@ type CommandStepBuilder struct {
 	Assets      map[string]string
 	Variables   map[string]string
 	Caches      []string
-	UseSecrets  bool
+	Secrets     *[]string
 }
 
 func (c *GenerateContext) NewCommandStep(name string) *CommandStepBuilder {
@@ -26,7 +26,7 @@ func (c *GenerateContext) NewCommandStep(name string) *CommandStepBuilder {
 		Assets:      map[string]string{},
 		Variables:   map[string]string{},
 		Caches:      []string{},
-		UseSecrets:  true,
+		Secrets:     &[]string{"*"},
 	}
 
 	c.Steps = append(c.Steps, step)
@@ -85,10 +85,7 @@ func (b *CommandStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error
 	step.Assets = b.Assets
 	step.Caches = b.Caches
 	step.Variables = b.Variables
-
-	if !b.UseSecrets {
-		step.UseSecrets = &b.UseSecrets
-	}
+	step.Secrets = b.Secrets
 
 	return step, nil
 }

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -207,9 +207,13 @@ func (c *GenerateContext) ApplyConfig(config *config.Config) error {
 			commandStepBuilder.Assets[k] = v
 		}
 
-		if configStep.UseSecrets != nil {
-			commandStepBuilder.UseSecrets = *configStep.UseSecrets
+		if configStep.Secrets != nil {
+			commandStepBuilder.Secrets = configStep.Secrets
 		}
+
+		// if configStep.UseSecrets != nil {
+		// 	commandStepBuilder.UseSecrets = *configStep.UseSecrets
+		// }
 
 		if len(configStep.Caches) > 0 {
 			commandStepBuilder.Caches = configStep.Caches

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -27,7 +27,7 @@ func (p *TestProvider) Plan(ctx *GenerateContext) error {
 	// commands
 	installStep := ctx.NewCommandStep("install")
 	installStep.AddCommand(plan.NewExecCommand("npm install", plan.ExecOptions{}))
-	installStep.Outputs = &[]string{"node_modules"}
+	installStep.Outputs = []string{"node_modules"}
 	installStep.DependsOn = []string{aptStep.Name()}
 
 	buildStep := ctx.NewCommandStep("build")

--- a/core/generate/image_step_builder.go
+++ b/core/generate/image_step_builder.go
@@ -50,7 +50,7 @@ func (b *ImageStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) 
 
 	step.StartingImage = b.ResolveStepImage(options)
 	step.Outputs = b.Outputs
-	step.UseSecrets = &[]bool{false}[0]
+	step.Secrets = &[]string{}
 
 	return step, nil
 }

--- a/core/generate/image_step_builder.go
+++ b/core/generate/image_step_builder.go
@@ -9,7 +9,7 @@ type ImageStepBuilder struct {
 	DisplayName      string
 	Resolver         *resolver.Resolver
 	Packages         []*resolver.PackageRef
-	Outputs          *[]string
+	Outputs          []string
 	ResolveStepImage func(options *BuildStepOptions) string
 }
 
@@ -50,7 +50,7 @@ func (b *ImageStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) 
 
 	step.StartingImage = b.ResolveStepImage(options)
 	step.Outputs = b.Outputs
-	step.Secrets = &[]string{}
+	step.Secrets = []string{}
 
 	return step, nil
 }

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -149,7 +149,7 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 
 	step.Assets = b.Assets
 	step.Outputs = b.Outputs
-	step.UseSecrets = &[]bool{false}[0]
+	step.Secrets = &[]string{}
 
 	return step, nil
 }

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -24,7 +24,7 @@ type MiseStepBuilder struct {
 	MisePackages          []*resolver.PackageRef
 	SupportingMiseFiles   []string
 	Assets                map[string]string
-	Outputs               *[]string
+	Outputs               []string
 	app                   *a.App
 	env                   *a.Environment
 }
@@ -36,7 +36,7 @@ func (c *GenerateContext) newMiseStepBuilder() *MiseStepBuilder {
 		MisePackages:          []*resolver.PackageRef{},
 		SupportingAptPackages: []string{},
 		Assets:                map[string]string{},
-		Outputs:               &[]string{"/mise/shims", "/mise/installs", "/usr/local/bin/mise", "/etc/mise/config.toml", "/root/.local/state/mise"},
+		Outputs:               []string{"/mise/shims", "/mise/installs", "/usr/local/bin/mise", "/etc/mise/config.toml", "/root/.local/state/mise"},
 		app:                   c.App,
 		env:                   c.Env,
 	}
@@ -103,7 +103,7 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 		})
 
 		// We want to make sure the file is copied into the next step
-		*b.Outputs = append(*b.Outputs, "/app/"+file)
+		b.Outputs = append(b.Outputs, "/app/"+file)
 	}
 
 	// Setup apt commands
@@ -149,7 +149,7 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 
 	step.Assets = b.Assets
 	step.Outputs = b.Outputs
-	step.Secrets = &[]string{}
+	step.Secrets = []string{}
 
 	return step, nil
 }

--- a/core/plan/step.go
+++ b/core/plan/step.go
@@ -17,7 +17,10 @@ type Step struct {
 	Commands *[]Command `json:"commands,omitempty" jsonschema:"description=The commands to run in this step"`
 
 	// Whether the commands executed in this step should have access to secrets
-	UseSecrets *bool `json:"useSecrets,omitempty" jsonschema:"description=Whether the commands executed in this step should have access to secrets"`
+	// UseSecrets *bool `json:"useSecrets,omitempty" jsonschema:"description=Whether the commands executed in this step should have access to secrets"`
+
+	// The secrets that this step uses
+	Secrets *[]string `json:"secrets,omitempty" jsonschema:"description=The secrets that this step uses"`
 
 	// Paths that this step outputs. Only these paths will be available to the next step
 	Outputs *[]string `json:"outputs,omitempty" jsonschema:"description=Paths that this step outputs. Only these paths will be available to the next step"`
@@ -42,6 +45,7 @@ func NewStep(name string) *Step {
 		Name:      name,
 		Assets:    make(map[string]string),
 		Variables: make(map[string]string),
+		Secrets:   &[]string{"*"}, // default to using all secrets
 	}
 }
 

--- a/core/plan/step.go
+++ b/core/plan/step.go
@@ -14,16 +14,13 @@ type Step struct {
 	DependsOn []string `json:"dependsOn,omitempty" jsonschema:"description=The steps that this step depends on. The step will only run after all the steps in DependsOn have run"`
 
 	// The commands to run in this step
-	Commands *[]Command `json:"commands,omitempty" jsonschema:"description=The commands to run in this step"`
-
-	// Whether the commands executed in this step should have access to secrets
-	// UseSecrets *bool `json:"useSecrets,omitempty" jsonschema:"description=Whether the commands executed in this step should have access to secrets"`
+	Commands []Command `json:"commands,omitempty" jsonschema:"description=The commands to run in this step"`
 
 	// The secrets that this step uses
-	Secrets *[]string `json:"secrets,omitempty" jsonschema:"description=The secrets that this step uses"`
+	Secrets []string `json:"secrets" jsonschema:"description=The secrets that this step uses"`
 
 	// Paths that this step outputs. Only these paths will be available to the next step
-	Outputs *[]string `json:"outputs,omitempty" jsonschema:"description=Paths that this step outputs. Only these paths will be available to the next step"`
+	Outputs []string `json:"outputs,omitempty" jsonschema:"description=Paths that this step outputs. Only these paths will be available to the next step"`
 
 	// The assets available to this step. The key is the name of the asset that is referenced in a file command
 	Assets map[string]string `json:"assets,omitempty" jsonschema:"description=The assets available to this step. The key is the name of the asset that is referenced in a file command"`
@@ -45,7 +42,7 @@ func NewStep(name string) *Step {
 		Name:      name,
 		Assets:    make(map[string]string),
 		Variables: make(map[string]string),
-		Secrets:   &[]string{"*"}, // default to using all secrets
+		Secrets:   []string{"*"}, // default to using all secrets
 	}
 }
 
@@ -55,9 +52,9 @@ func (s *Step) DependOn(name string) {
 
 func (s *Step) AddCommands(commands []Command) {
 	if s.Commands == nil {
-		s.Commands = &[]Command{}
+		s.Commands = []Command{}
 	}
-	*s.Commands = append(*s.Commands, commands...)
+	s.Commands = append(s.Commands, commands...)
 }
 
 func (s *Step) UnmarshalJSON(data []byte) error {
@@ -74,13 +71,13 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 	}
 
 	if aux.Commands != nil {
-		s.Commands = &[]Command{}
+		s.Commands = []Command{}
 		for _, rawCmd := range *aux.Commands {
 			cmd, err := UnmarshalCommand(rawCmd)
 			if err != nil {
 				return err
 			}
-			*s.Commands = append(*s.Commands, cmd)
+			s.Commands = append(s.Commands, cmd)
 		}
 	}
 

--- a/core/prettyPrint.go
+++ b/core/prettyPrint.go
@@ -179,13 +179,13 @@ func getStepsToPrint(br *BuildResult) []*plan.Step {
 	return execSteps
 }
 
-func getCommandsToPrint(commands *[]plan.Command) []plan.ExecCommand {
+func getCommandsToPrint(commands []plan.Command) []plan.ExecCommand {
 	if commands == nil {
 		return []plan.ExecCommand{}
 	}
 
 	execCommands := []plan.ExecCommand{}
-	for _, cmd := range *commands {
+	for _, cmd := range commands {
 		if execCmd, ok := cmd.(plan.ExecCommand); ok {
 			execCommands = append(execCommands, execCmd)
 		}

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -123,7 +123,7 @@ func (p *NodeProvider) Install(ctx *generate.GenerateContext, packages *generate
 		})
 		corepackStepName = corepackStep.DisplayName
 		corepackStep.DependsOn = append(corepackStep.DependsOn, setup.DisplayName)
-		corepackStep.Secrets = &[]string{} // Don't include any secrets in this step
+		corepackStep.Secrets = []string{} // Don't include any secrets in this step
 	}
 
 	pkgManager := p.getPackageManager(ctx.App)
@@ -132,7 +132,7 @@ func (p *NodeProvider) Install(ctx *generate.GenerateContext, packages *generate
 	install.DependsOn = append(install.DependsOn, []string{packages.DisplayName, setup.DisplayName}...)
 
 	// We only want to invalidate the install step when these secrets change, not all of them
-	install.Secrets = &[]string{}
+	install.Secrets = []string{}
 	install.UseSecretsWithPrefixes([]string{"NODE", "NPM", "BUN", "PNPM", "YARN", "CI"})
 
 	pkgManager.installDependencies(ctx, packageJson, install)
@@ -148,7 +148,7 @@ func (p *NodeProvider) Setup(ctx *generate.GenerateContext) (*generate.CommandSt
 	setup := ctx.NewCommandStep("setup")
 	setup.AddEnvVars(p.GetNodeEnvVars(ctx))
 	setup.AddPaths([]string{"/app/node_modules/.bin"})
-	setup.Secrets = &[]string{}
+	setup.Secrets = []string{}
 
 	return setup, nil
 }

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -75,7 +75,6 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, install *generate.Co
 	packageManager := p.getPackageManager(ctx.App)
 	build := ctx.NewCommandStep("build")
 	build.DependsOn = []string{install.DisplayName}
-	build.AddEnvVars(map[string]string{"HELLO": "world"})
 
 	_, ok := packageJson.Scripts["build"]
 	if ok {
@@ -124,12 +123,22 @@ func (p *NodeProvider) Install(ctx *generate.GenerateContext, packages *generate
 		})
 		corepackStepName = corepackStep.DisplayName
 		corepackStep.DependsOn = append(corepackStep.DependsOn, setup.DisplayName)
+		corepackStep.Secrets = &[]string{} // Don't include any secrets in this step
 	}
 
 	pkgManager := p.getPackageManager(ctx.App)
 
 	install := ctx.NewCommandStep("install")
 	install.DependsOn = append(install.DependsOn, []string{packages.DisplayName, setup.DisplayName}...)
+
+	// We only want to invalidate the install step when these secrets change, not all of them
+	install.Secrets = &[]string{}
+	install.UseSecretsWithPrefix("NODE")
+	install.UseSecretsWithPrefix("NPM")
+	install.UseSecretsWithPrefix("BUN")
+	install.UseSecretsWithPrefix("PNPM")
+	install.UseSecretsWithPrefix("YARN")
+	install.UseSecrets([]string{"CI"})
 
 	pkgManager.installDependencies(ctx, packageJson, install)
 
@@ -144,6 +153,7 @@ func (p *NodeProvider) Setup(ctx *generate.GenerateContext) (*generate.CommandSt
 	setup := ctx.NewCommandStep("setup")
 	setup.AddEnvVars(p.GetNodeEnvVars(ctx))
 	setup.AddPaths([]string{"/app/node_modules/.bin"})
+	setup.Secrets = &[]string{}
 
 	return setup, nil
 }

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -133,12 +133,7 @@ func (p *NodeProvider) Install(ctx *generate.GenerateContext, packages *generate
 
 	// We only want to invalidate the install step when these secrets change, not all of them
 	install.Secrets = &[]string{}
-	install.UseSecretsWithPrefix("NODE")
-	install.UseSecretsWithPrefix("NPM")
-	install.UseSecretsWithPrefix("BUN")
-	install.UseSecretsWithPrefix("PNPM")
-	install.UseSecretsWithPrefix("YARN")
-	install.UseSecrets([]string{"CI"})
+	install.UseSecretsWithPrefixes([]string{"NODE", "NPM", "BUN", "PNPM", "YARN", "CI"})
 
 	pkgManager.installDependencies(ctx, packageJson, install)
 

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -77,7 +77,7 @@ func (p *PhpProvider) Plan(ctx *generate.GenerateContext) error {
 		}
 
 		// Only copy the changes to the app, not the entire rest of the file system
-		nodeBuild.Outputs = &[]string{"/app"}
+		nodeBuild.Outputs = []string{"/app"}
 
 		ctx.ExitSubContext()
 	}

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -139,7 +139,7 @@ func (p *PythonProvider) install(ctx *generate.GenerateContext) error {
 		}
 	}
 
-	install.Secrets = &[]string{}
+	install.Secrets = []string{}
 	install.UseSecretsWithPrefixes([]string{"PYTHON", "PIP", "PIPX", "PIPENV", "UV", "POETRY", "PDM"})
 
 	aptStep := ctx.NewAptStepBuilder("python-system-deps")

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -139,6 +139,9 @@ func (p *PythonProvider) install(ctx *generate.GenerateContext) error {
 		}
 	}
 
+	install.Secrets = &[]string{}
+	install.UseSecretsWithPrefixes([]string{"PYTHON", "PIP", "PIPX", "PIPENV", "UV", "POETRY", "PDM"})
+
 	aptStep := ctx.NewAptStepBuilder("python-system-deps")
 	aptStep.Packages = []string{"pkg-config"}
 	install.DependsOn = append(install.DependsOn, aptStep.DisplayName)

--- a/examples/secrets/railpack.json
+++ b/examples/secrets/railpack.json
@@ -5,25 +5,26 @@
 
   "steps": {
     "usesSecrets": {
-      "commands": [
-        { "name": "NOT_SECRET", "value": "not secret" },
-        { "src": ".", "dest": "." },
-        "./run.sh"
-      ],
-      "useSecrets": true
+      "commands": [{ "src": ".", "dest": "." }, "./run.sh"],
+      "secrets": ["MY_SECRET", "MY_OTHER_SECRET"],
+      "variables": {
+        "NOT_SECRET": "not secret"
+      },
+      "outputs": ["/app"]
     },
 
     "defaultsToUsing": {
-      "commands": [
-        { "name": "NOT_SECRET", "value": "not secret" },
-        { "src": ".", "dest": "." },
-        "./run.sh"
-      ]
+      "commands": [{ "src": ".", "dest": "." }, "./run.sh"],
+      "variables": {
+        "NOT_SECRET": "not secret"
+      },
+      "outputs": ["/app"]
     },
 
     "doesNotUseSecrets": {
       "commands": [{ "src": ".", "dest": "." }, "./run.sh true"],
-      "useSecrets": false
+      "secrets": [],
+      "outputs": ["/app"]
     }
   },
 

--- a/examples/secrets/test.json
+++ b/examples/secrets/test.json
@@ -1,0 +1,10 @@
+[
+  {
+    "expectedOutput": "one",
+    "envs": {
+      "MY_SECRET": "one",
+      "MY_OTHER_SECRET": "two",
+      "HELLO_WORLD": "three"
+    }
+  }
+]

--- a/images/debian/runtime/Dockerfile
+++ b/images/debian/runtime/Dockerfile
@@ -4,6 +4,5 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    curl \
-    git \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR allows steps to opt-in to only invalidating when specific secret values change. For example, the node install step can invalidate only when variables that are prefixed with `NODE` change. As opposed to re-running when any secret changes. This is useful on platforms like Railway where a deployment id is passed in as a secret. With this PR, the install layer can be re-used even though that changes every build.

- Change the step `UseSecrets` to a `Secrets` array
- Specified a shared hint key on local state context
- Remove git and curl from the runtime image
