### PR TITLE
dont install npm package

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -42,7 +42,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node, npm"
+     "customName": "install mise packages: node"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -56,6 +56,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_COREPACK": "true",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -42,7 +42,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node, npm"
+     "customName": "install mise packages: node"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -38,7 +38,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node, npm"
+     "customName": "install mise packages: node"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -38,7 +38,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node, npm"
+     "customName": "install mise packages: node"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -45,7 +45,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node, npm"
+     "customName": "install mise packages: node"
     }
    ],
    "name": "packages:mise",
@@ -63,6 +63,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_COREPACK": "true",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-inertia_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-inertia_1.snap.json
@@ -95,7 +95,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node, npm"
+     "customName": "install mise packages: node"
     }
    ],
    "name": "packages:mise",

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -25,6 +25,7 @@ type MiseStepBuilder struct {
 	SupportingMiseFiles   []string
 	Assets                map[string]string
 	Outputs               []string
+	Variables             map[string]string
 	app                   *a.App
 	env                   *a.Environment
 }
@@ -37,6 +38,7 @@ func (c *GenerateContext) newMiseStepBuilder() *MiseStepBuilder {
 		SupportingAptPackages: []string{},
 		Assets:                map[string]string{},
 		Outputs:               []string{"/mise/shims", "/mise/installs", "/usr/local/bin/mise", "/etc/mise/config.toml", "/root/.local/state/mise"},
+		Variables:             map[string]string{},
 		app:                   c.App,
 		env:                   c.Env,
 	}
@@ -90,6 +92,7 @@ func (b *MiseStepBuilder) Build(options *BuildStepOptions) (*plan.Step, error) {
 		"MISE_SHIMS_DIR":    "/mise/shims",
 		"MISE_INSTALLS_DIR": "/mise/installs",
 	})
+	maps.Copy(step.Variables, b.Variables)
 
 	if verbose := b.env.GetVariable("MISE_VERBOSE"); verbose != "" {
 		step.Variables["MISE_VERBOSE"] = verbose

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -183,6 +183,10 @@ func (p *NodeProvider) Packages(ctx *generate.GenerateContext, packageJson *Pack
 
 	packageManager.GetPackageManagerPackages(ctx, packages)
 
+	if p.usesCorepack(packageJson) {
+		packages.Variables["MISE_NODE_COREPACK"] = "true"
+	}
+
 	return packages, nil
 }
 

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -132,24 +132,6 @@ func (p PackageManager) SupportingInstallFiles(app *a.App) []string {
 
 // GetPackageManagerPackages installs specific versions of package managers by analyzing the users code
 func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext, packages *generate.MiseStepBuilder) {
-	// NPM
-	if p == PackageManagerNpm {
-		npm := packages.Default("npm", "latest")
-
-		lockfile, err := ctx.App.ReadFile("package-lock.json")
-		if err != nil {
-			lockfile = ""
-		}
-
-		if strings.Contains(lockfile, "\"lockfileVersion\": 1") {
-			packages.Version(npm, "6", "package-lock.json")
-		} else if strings.Contains(lockfile, "\"lockfileVersion\": 2") {
-			packages.Version(npm, "8", "package-lock.json")
-		} else if strings.Contains(lockfile, "\"lockfileVersion\": 3") {
-			packages.Version(npm, "9", "package-lock.json")
-		}
-	}
-
 	// Pnpm
 	if p == PackageManagerPnpm {
 		pnpm := packages.Default("pnpm", "latest")


### PR DESCRIPTION
`npm` is installed by default with node. Installing a specific version was not correctly working using mise shims. npm can also handle old lockfiles without issue. Checking the latest version of npm also requires having npm/node installed locally. So all in all, it is best to remove installing a specific version of npm through mise.
