### PR TITLE
Refactor providers with init

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -235,6 +235,10 @@ func getProviders(ctx *generate.GenerateContext, config *config.Config) ([]provi
 
 			// If there are no providers manually specified in the config,
 			if config.Providers == nil {
+				if err := provider.Initialize(ctx); err != nil {
+					log.Warnf("Failed to initialize provider `%s`: %s", provider.Name(), err.Error())
+					continue
+				}
 				providersToUse = append(providersToUse, provider)
 			}
 
@@ -250,6 +254,10 @@ func getProviders(ctx *generate.GenerateContext, config *config.Config) ([]provi
 				continue
 			}
 
+			if err := provider.Initialize(ctx); err != nil {
+				log.Warnf("Failed to initialize provider `%s`: %s", providerName, err.Error())
+				continue
+			}
 			providersToUse = append(providersToUse, provider)
 		}
 	}

--- a/core/providers/golang/golang.go
+++ b/core/providers/golang/golang.go
@@ -26,6 +26,10 @@ func (p *GoProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
 	return p.isGoMod(ctx) || ctx.App.HasMatch("main.go"), nil
 }
 
+func (p *GoProvider) Initialize(ctx *generate.GenerateContext) error {
+	return nil
+}
+
 func (p *GoProvider) Plan(ctx *generate.GenerateContext) error {
 	packages, err := p.Packages(ctx)
 	if err != nil {

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -19,6 +19,7 @@ const (
 
 type NodeProvider struct {
 	packageJson *PackageJson
+	workspace   *Workspace
 }
 
 func (p *NodeProvider) Name() string {
@@ -31,6 +32,13 @@ func (p *NodeProvider) Initialize(ctx *generate.GenerateContext) error {
 		return err
 	}
 	p.packageJson = packageJson
+
+	workspace, err := NewWorkspace(ctx.App)
+	if err != nil {
+		return err
+	}
+	p.workspace = workspace
+
 	return nil
 }
 

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -27,6 +27,10 @@ func (p *PhpProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
 		ctx.App.HasMatch("composer.json"), nil
 }
 
+func (p *PhpProvider) Initialize(ctx *generate.GenerateContext) error {
+	return nil
+}
+
 func (p *PhpProvider) Plan(ctx *generate.GenerateContext) error {
 	imageStep, err := p.phpImagePackage(ctx)
 	if err != nil {

--- a/core/providers/provider.go
+++ b/core/providers/provider.go
@@ -12,6 +12,7 @@ import (
 type Provider interface {
 	Name() string
 	Detect(ctx *generate.GenerateContext) (bool, error)
+	Initialize(ctx *generate.GenerateContext) error
 	Plan(ctx *generate.GenerateContext) error
 }
 

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -20,6 +20,10 @@ func (p *PythonProvider) Name() string {
 	return "python"
 }
 
+func (p *PythonProvider) Initialize(ctx *generate.GenerateContext) error {
+	return nil
+}
+
 func (p *PythonProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
 	hasPython := ctx.App.HasMatch("main.py") ||
 		p.hasRequirements(ctx) ||

--- a/core/providers/staticfile/staticfile.go
+++ b/core/providers/staticfile/staticfile.go
@@ -28,6 +28,10 @@ func (p *StaticfileProvider) Name() string {
 	return "staticfile"
 }
 
+func (p *StaticfileProvider) Initialize(ctx *generate.GenerateContext) error {
+	return nil
+}
+
 func (p *StaticfileProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
 	rootDir, err := p.getRootDir(ctx)
 


### PR DESCRIPTION
It is often useful to store information on the providers that can be reused through the plan generation.
