### PR TITLE
disable the slice flag separator for all commands

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -30,6 +30,20 @@ func main() {
 		lipgloss.SetColorProfile(termenv.TrueColor)
 	}
 
+	commands := []*urfave.Command{
+		cli.BuildCommand,
+		cli.PrepareCommand,
+		cli.InfoCommand,
+		cli.PlanCommand,
+		cli.SchemaCommand,
+		cli.FrontendCommand,
+	}
+
+	// Disable the slice flag separator for all commands
+	for _, command := range commands {
+		command.DisableSliceFlagSeparator = true
+	}
+
 	cmd := &urfave.Command{
 		Name:                  "railpack",
 		Usage:                 "Automatically analyze and generate build plans for applications",
@@ -48,14 +62,7 @@ func main() {
 
 			return ctx, nil
 		},
-		Commands: []*urfave.Command{
-			cli.BuildCommand,
-			cli.PrepareCommand,
-			cli.InfoCommand,
-			cli.PlanCommand,
-			cli.SchemaCommand,
-			cli.FrontendCommand,
-		},
+		Commands: commands,
 	}
 
 	if err := cmd.Run(context.Background(), os.Args); err != nil {

--- a/core/app/environment_test.go
+++ b/core/app/environment_test.go
@@ -11,10 +11,12 @@ func TestFromEnvs(t *testing.T) {
 		"VAR1=value1",
 		"VAR2=value2",
 		"RAILPACK_APT_PACKAGES=apt1,apt2",
+		"COMMA=this has, a comma",
 	})
 
 	require.NoError(t, err)
 	require.Equal(t, env.GetVariable("VAR1"), "value1")
 	require.Equal(t, env.GetVariable("VAR2"), "value2")
 	require.Equal(t, env.GetVariable("RAILPACK_APT_PACKAGES"), "apt1,apt2")
+	require.Equal(t, env.GetVariable("COMMA"), "this has, a comma")
 }

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -109,14 +109,6 @@ func (c *GenerateContext) ResolvePackages() (map[string]*resolver.ResolvedPackag
 
 // Generate a build plan from the context
 func (c *GenerateContext) Generate() (*plan.BuildPlan, map[string]*resolver.ResolvedPackage, error) {
-	// Add all packages from the config to the mise step
-	miseStep := c.GetMiseStepBuilder()
-	for _, pkg := range slices.Sorted(maps.Keys(c.Config.Packages)) {
-		version := c.Config.Packages[pkg]
-		pkgRef := miseStep.Default(pkg, version)
-		miseStep.Version(pkgRef, version, "custom config")
-	}
-
 	c.applyConfig()
 
 	// Resolve all package versions into a fully qualified and valid version
@@ -179,6 +171,11 @@ func (o *BuildStepOptions) NewAptInstallCommand(pkgs []string) plan.Command {
 
 func (c *GenerateContext) applyConfig() {
 	miseStep := c.GetMiseStepBuilder()
+	for _, pkg := range slices.Sorted(maps.Keys(c.Config.Packages)) {
+		version := c.Config.Packages[pkg]
+		pkgRef := miseStep.Default(pkg, version)
+		miseStep.Version(pkgRef, version, "custom config")
+	}
 
 	// Apply the cache config to the context
 	maps.Copy(c.Caches.Caches, c.Config.Caches)


### PR DESCRIPTION
It breaks when flags (like envs) have commands. (e.g. `--env "COMMA=this has, a comma"`)
