### PR TITLE
Don't prune node_modules by default

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -122,10 +122,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -27,15 +27,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      "."
     ],
     "step": "build"
@@ -126,23 +117,15 @@
    }
   },
   {
-   "caches": [
-    "npm-install"
-   ],
-   "commands": [
-    {
-     "cmd": "npm prune --omit=dev"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -121,10 +121,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -26,15 +26,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      "."
     ],
     "step": "build"
@@ -125,24 +116,15 @@
    }
   },
   {
-   "caches": [
-    "bun-install"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'rm -rf node_modules \u0026\u0026 bun install --production'",
-     "customName": "rm -rf node_modules \u0026\u0026 bun install --production"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -26,15 +26,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      ".",
      "/root/.cache"
     ],
@@ -137,23 +128,15 @@
    }
   },
   {
-   "caches": [
-    "pnpm-install"
-   ],
-   "commands": [
-    {
-     "cmd": "pnpm prune --prod"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -133,10 +133,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -30,15 +30,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      "."
     ],
     "step": "build"
@@ -129,23 +120,15 @@
    }
   },
   {
-   "caches": [
-    "npm-install"
-   ],
-   "commands": [
-    {
-     "cmd": "npm prune --omit=dev"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -125,10 +125,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -129,10 +129,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -26,15 +26,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      "."
     ],
     "step": "build"
@@ -133,23 +124,15 @@
    }
   },
   {
-   "caches": [
-    "npm-install"
-   ],
-   "commands": [
-    {
-     "cmd": "npm prune --omit=dev"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -121,10 +121,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -26,15 +26,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      "."
     ],
     "step": "build"
@@ -125,23 +116,15 @@
    }
   },
   {
-   "caches": [
-    "npm-install"
-   ],
-   "commands": [
-    {
-     "cmd": "npm prune --omit=dev"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -26,15 +26,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      "."
     ],
     "step": "build"
@@ -137,23 +128,15 @@
    }
   },
   {
-   "caches": [
-    "pnpm-install"
-   ],
-   "commands": [
-    {
-     "cmd": "pnpm prune --prod"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -133,10 +133,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -34,15 +34,6 @@
    },
    {
     "include": [
-     "/app/node_modules"
-    ],
-    "step": "prune"
-   },
-   {
-    "exclude": [
-     "node_modules"
-    ],
-    "include": [
      ".",
      "/root/.cache"
     ],
@@ -168,23 +159,15 @@
    }
   },
   {
-   "caches": [
-    "npm-install"
-   ],
-   "commands": [
-    {
-     "cmd": "npm prune --omit=dev"
-    }
-   ],
    "inputs": [
     {
      "step": "install"
     }
    ],
    "name": "prune",
-   "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
-   }
+   "secrets": [
+    "*"
+   ]
   },
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -164,10 +164,7 @@
      "step": "install"
     }
    ],
-   "name": "prune",
-   "secrets": [
-    "*"
-   ]
+   "name": "prune"
   },
   {
    "caches": [

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -66,7 +66,9 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 	// Prune
 	prune := ctx.NewCommandStep("prune")
 	prune.AddInput(plan.NewStepInput(install.Name()))
-	p.PruneNodeDeps(ctx, prune)
+	if p.shouldPrune(ctx) {
+		p.PruneNodeDeps(ctx, prune)
+	}
 
 	// Build
 	build := ctx.NewCommandStep("build")
@@ -154,10 +156,6 @@ func (p *NodeProvider) shouldPrune(ctx *generate.GenerateContext) bool {
 }
 
 func (p *NodeProvider) PruneNodeDeps(ctx *generate.GenerateContext, prune *generate.CommandStepBuilder) {
-	if !p.shouldPrune(ctx) {
-		return
-	}
-
 	prune.Variables["NPM_CONFIG_PRODUCTION"] = "true"
 	prune.Secrets = []string{}
 	p.packageManager.PruneDeps(ctx, prune)

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -150,7 +150,7 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, build *generate.Comm
 }
 
 func (p *NodeProvider) shouldPrune(ctx *generate.GenerateContext) bool {
-	return !ctx.Env.IsConfigVariableTruthy("NO_PRUNE")
+	return ctx.Env.IsConfigVariableTruthy("PRUNE_DEPS")
 }
 
 func (p *NodeProvider) PruneNodeDeps(ctx *generate.GenerateContext, prune *generate.CommandStepBuilder) {

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -66,6 +66,7 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 	// Prune
 	prune := ctx.NewCommandStep("prune")
 	prune.AddInput(plan.NewStepInput(install.Name()))
+	prune.Secrets = []string{}
 	if p.shouldPrune(ctx) {
 		p.PruneNodeDeps(ctx, prune)
 	}

--- a/examples/node-npm/test.json
+++ b/examples/node-npm/test.json
@@ -1,5 +1,8 @@
 [
   {
-    "expectedOutput": "hello from Node v23.5.0"
+    "expectedOutput": "hello from Node v23.5.0",
+    "envs": {
+      "RAILPACK_PRUNE_DEPS": "true"
+    }
   }
 ]


### PR DESCRIPTION
We can't guarantee that apps don't need their dev deps in production. Recently ran into an issue where next was using a dev dep when server rendering some pages. To be safe this PR defaults to not pruning. You can enable pruning with the `RAILPACK_PRUNE_DEPS=1` environment variable.
