### PR TITLE
publish separate mise image

### DIFF
--- a/.github/workflows/publish-mise.yml
+++ b/.github/workflows/publish-mise.yml
@@ -1,4 +1,4 @@
-name: Publish Runtime Base Image
+name: Publish Mise Image
 
 on:
   push:

--- a/.github/workflows/publish-mise.yml
+++ b/.github/workflows/publish-mise.yml
@@ -1,0 +1,59 @@
+name: Publish Runtime Base Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "images/debian/mise/Dockerfile"
+      - ".github/workflows/publish-mise.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-mise
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=debian-bookworm
+            type=sha,format=long
+            type=raw,value={{date 'YYYYMMDD'}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: images/debian/mise
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/images/debian/mise/Dockerfile
+++ b/images/debian/mise/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1-slim-bookworm AS builder
+
+# Compile mise from source with size optimizations
+RUN apt-get update && apt-get install -y \
+    git \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/jdx/mise.git /tmp/mise && \
+    cd /tmp/mise && \
+    RUSTFLAGS="-C opt-level=z -C link-arg=-s -C codegen-units=1" \
+    cargo build --profile serious \
+    --config debuginfo=0


### PR DESCRIPTION
Building mise from source with the compiler flags we have takes a really long time. This PR splits that up into its own Dockerfile
