### PR TITLE
Fix mise binary location

### DIFF
--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -26,6 +26,5 @@ ENV MISE_INSTALL_PATH=/usr/local/bin/mise \
     PATH=/mise/shims:$PATH
 
 # Copy mise binary from builder
-ARG MISE_IMAGE=ghcr.io/railwayapp/railpack-mise:latest
-COPY --from=${MISE_IMAGE} /usr/local/bin/mise /usr/local/bin/
+COPY --from=ghcr.io/railwayapp/railpack-mise:latest /tmp/mise/target/serious/mise /usr/local/bin/
 RUN chmod +x /usr/local/bin/mise

--- a/images/debian/mise/Dockerfile
+++ b/images/debian/mise/Dockerfile
@@ -12,3 +12,5 @@ RUN git clone https://github.com/jdx/mise.git /tmp/mise && \
     RUSTFLAGS="-C opt-level=z -C link-arg=-s -C codegen-units=1" \
     cargo build --profile serious \
     --config debuginfo=0
+
+RUN cp /tmp/mise/target/serious/mise /usr/local/bin/


### PR DESCRIPTION
- **rename the builder and runtime images**
- **pull mise from mise image**
- **fix path to mise binary**
- **copy mise bin to /usr/local/bin**
