### PR TITLE
save railpack version to build result

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -65,6 +65,7 @@ func GenerateBuildResultForCommand(cmd *cli.Command) (*core.BuildResult, *a.App,
 	previousVersions := getPreviousVersions(cmd.StringSlice("previous"))
 
 	generateOptions := &core.GenerateBuildPlanOptions{
+		RailpackVersion:          Version,
 		BuildCommand:             cmd.String("build-cmd"),
 		StartCommand:             cmd.String("start-cmd"),
 		PreviousVersions:         previousVersions,

--- a/core/core.go
+++ b/core/core.go
@@ -21,6 +21,7 @@ const (
 )
 
 type GenerateBuildPlanOptions struct {
+	RailpackVersion          string
 	BuildCommand             string
 	StartCommand             string
 	PreviousVersions         map[string]string
@@ -29,6 +30,7 @@ type GenerateBuildPlanOptions struct {
 }
 
 type BuildResult struct {
+	RailpackVersion   string                               `json:"railpackVersion,omitempty"`
 	Plan              *plan.BuildPlan                      `json:"plan,omitempty"`
 	ResolvedPackages  map[string]*resolver.ResolvedPackage `json:"resolvedPackages,omitempty"`
 	Metadata          map[string]string                    `json:"metadata,omitempty"`
@@ -110,6 +112,7 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 	}
 
 	buildResult := &BuildResult{
+		RailpackVersion:   options.RailpackVersion,
 		Plan:              buildPlan,
 		ResolvedPackages:  resolvedPackages,
 		Metadata:          ctx.Metadata.Properties,


### PR DESCRIPTION
So it is saved in `railpack prepare` and can be used by platforms
