### PR TITLE
Support "..." in config file for arrays

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -7,6 +7,14 @@
   "apt-lists": {
    "directory": "/var/lib/apt/lists",
    "type": "locked"
+  },
+  "bun-install": {
+   "directory": "/root/.bun/install/cache",
+   "type": "shared"
+  },
+  "node-modules": {
+   "directory": "/app/node_modules/.cache",
+   "type": "shared"
   }
  },
  "deploy": {
@@ -16,12 +24,36 @@
    },
    {
     "include": [
+     "/mise/shims",
+     "/mise/installs",
+     "/usr/local/bin/mise",
+     "/etc/mise/config.toml",
+     "/root/.local/state/mise"
+    ],
+    "step": "packages:mise"
+   },
+   {
+    "include": [
      "."
     ],
     "step": "build"
+   },
+   {
+    "include": [
+     "."
+    ],
+    "local": true
    }
   ],
-  "startCommand": "neofetch $HELLO"
+  "startCommand": "python --version \u0026\u0026 neofetch $HELLO",
+  "variables": {
+   "CI": "true",
+   "NODE_ENV": "production",
+   "NPM_CONFIG_FUND": "false",
+   "NPM_CONFIG_PRODUCTION": "false",
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "YARN_PRODUCTION": "false"
+  }
  },
  "steps": [
   {
@@ -65,7 +97,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: python"
+     "customName": "install mise packages: bun, python"
     }
    ],
    "inputs": [
@@ -83,6 +115,52 @@
    }
   },
   {
+   "caches": [
+    "bun-install"
+   ],
+   "commands": [
+    {
+     "path": "/app/node_modules/.bin"
+    },
+    {
+     "dest": "package.json",
+     "src": "package.json"
+    },
+    {
+     "dest": "bun.lockb",
+     "src": "bun.lockb"
+    },
+    {
+     "cmd": "bun install --frozen-lockfile"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    }
+   ],
+   "name": "install",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_FUND": "false",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+    "YARN_PRODUCTION": "false"
+   }
+  },
+  {
+   "inputs": [
+    {
+     "step": "install"
+    }
+   ],
+   "name": "prune"
+  },
+  {
+   "caches": [
+    "node-modules"
+   ],
    "commands": [
     {
      "cmd": "sh -c 'neofetch'",
@@ -91,7 +169,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:mise"
+     "step": "install"
     }
    ],
    "name": "build",
@@ -101,6 +179,24 @@
    "variables": {
     "HELLO": "world"
    }
+  },
+  {
+   "caches": [
+    "apt",
+    "apt-lists"
+   ],
+   "commands": [
+    {
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y neofetch'",
+     "customName": "install apt packages: neofetch"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:latest"
+    }
+   ],
+   "name": "packages:runtime"
   }
  ]
 }

--- a/core/core.go
+++ b/core/core.go
@@ -164,10 +164,15 @@ func GenerateConfigFromFile(app *app.App, env *app.Environment, options *Generat
 
 	config := config.EmptyConfig()
 	if err := app.ReadJSON(configFileName, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file: %w", err)
+		return nil, err
 	}
 
 	logger.LogInfo("Using config file `%s`", configFileName)
+
+	fmt.Printf("CONFIG: %v\n", config)
+	for _, step := range config.Steps {
+		fmt.Printf("STEP: %v (nil? %v)\n", step.Secrets, step.Secrets == nil)
+	}
 
 	return config, nil
 }

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -104,3 +104,23 @@ func TestGenerateContext(t *testing.T) {
 
 	snaps.MatchJSON(t, serializedPlan)
 }
+
+func TestOverwriteCommands(t *testing.T) {
+	ctx := CreateTestContext(t, "../../examples/node-npm")
+	step := ctx.NewCommandStep("test")
+	step.AddCommand(plan.NewExecCommand("echo hello", plan.ExecOptions{}))
+	step.AddCommand(plan.NewExecCommand("echo world", plan.ExecOptions{}))
+
+	newCommands := overwriteCommands(step, []plan.Command{
+		plan.NewExecCommand("echo foo", plan.ExecOptions{}),
+		plan.NewExecCommand("...", plan.ExecOptions{}),
+		plan.NewExecCommand("echo bar", plan.ExecOptions{}),
+	})
+
+	require.Equal(t, []plan.Command{
+		plan.NewExecCommand("echo foo", plan.ExecOptions{}),
+		plan.NewExecCommand("echo hello", plan.ExecOptions{}),
+		plan.NewExecCommand("echo world", plan.ExecOptions{}),
+		plan.NewExecCommand("echo bar", plan.ExecOptions{}),
+	}, newCommands)
+}

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -104,23 +104,3 @@ func TestGenerateContext(t *testing.T) {
 
 	snaps.MatchJSON(t, serializedPlan)
 }
-
-func TestOverwriteCommands(t *testing.T) {
-	ctx := CreateTestContext(t, "../../examples/node-npm")
-	step := ctx.NewCommandStep("test")
-	step.AddCommand(plan.NewExecCommand("echo hello", plan.ExecOptions{}))
-	step.AddCommand(plan.NewExecCommand("echo world", plan.ExecOptions{}))
-
-	newCommands := overwriteCommands(step, []plan.Command{
-		plan.NewExecCommand("echo foo", plan.ExecOptions{}),
-		plan.NewExecCommand("...", plan.ExecOptions{}),
-		plan.NewExecCommand("echo bar", plan.ExecOptions{}),
-	})
-
-	require.Equal(t, []plan.Command{
-		plan.NewExecCommand("echo foo", plan.ExecOptions{}),
-		plan.NewExecCommand("echo hello", plan.ExecOptions{}),
-		plan.NewExecCommand("echo world", plan.ExecOptions{}),
-		plan.NewExecCommand("echo bar", plan.ExecOptions{}),
-	}, newCommands)
-}

--- a/core/plan/command.go
+++ b/core/plan/command.go
@@ -59,6 +59,10 @@ func NewExecCommand(cmd string, options ...ExecOptions) Command {
 	return exec
 }
 
+func ShellCommandString(cmd string) string {
+	return "sh -c '" + cmd + "'"
+}
+
 func NewExecShellCommand(cmd string, options ...ExecOptions) Command {
 	if len(options) == 0 {
 		options = []ExecOptions{
@@ -66,7 +70,7 @@ func NewExecShellCommand(cmd string, options ...ExecOptions) Command {
 		}
 	}
 
-	exec := NewExecCommand("sh -c '"+cmd+"'", options...)
+	exec := NewExecCommand(ShellCommandString(cmd), options...)
 	return exec
 }
 

--- a/core/plan/command.go
+++ b/core/plan/command.go
@@ -9,6 +9,7 @@ import (
 
 type Command interface {
 	CommandType() string
+	Spreadable
 }
 
 type ExecOptions struct {
@@ -200,4 +201,20 @@ func UnmarshalStringCommand(data []byte) (Command, error) {
 		customName = cmdToRun
 	}
 	return NewExecShellCommand(cmdToRun, ExecOptions{CustomName: customName}), nil
+}
+
+func (e ExecCommand) IsSpread() bool {
+	return e.Cmd == ShellCommandString("...") || e.Cmd == "..."
+}
+
+func (p PathCommand) IsSpread() bool {
+	return false
+}
+
+func (c CopyCommand) IsSpread() bool {
+	return false
+}
+
+func (f FileCommand) IsSpread() bool {
+	return false
 }

--- a/core/plan/input.go
+++ b/core/plan/input.go
@@ -1,0 +1,166 @@
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+)
+
+type Input struct {
+	Image   string   `json:"image,omitempty" jsonschema:"description=The image to use as input"`
+	Step    string   `json:"step,omitempty" jsonschema:"description=The step to use as input"`
+	Local   bool     `json:"local,omitempty" jsonschema:"description=Whether to use local files as input"`
+	Spread  bool     `json:"spread,omitempty" jsonschema:"description=Whether to spread the input"`
+	Include []string `json:"include,omitempty" jsonschema:"description=Files or directories to include"`
+	Exclude []string `json:"exclude,omitempty" jsonschema:"description=Files or directories to exclude"`
+}
+
+type InputOptions struct {
+	Include []string
+	Exclude []string
+}
+
+func NewStepInput(stepName string, options ...InputOptions) Input {
+	input := Input{
+		Step: stepName,
+	}
+
+	if len(options) > 0 {
+		input.Include = options[0].Include
+		input.Exclude = options[0].Exclude
+	}
+
+	return input
+}
+
+func NewImageInput(image string, options ...InputOptions) Input {
+	input := Input{
+		Image: image,
+	}
+
+	if len(options) > 0 {
+		input.Include = options[0].Include
+		input.Exclude = options[0].Exclude
+	}
+	return input
+}
+
+func NewLocalInput(path string) Input {
+	return Input{
+		Local:   true,
+		Include: []string{path},
+	}
+}
+
+func (i *Input) String() string {
+	bytes, _ := json.Marshal(i)
+	return string(bytes)
+}
+
+func (i Input) IsSpread() bool {
+	return i.Spread
+}
+
+func (i *Input) UnmarshalJSON(data []byte) error {
+	// First try normal JSON unmarshal
+	type Alias Input
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(i),
+	}
+	if err := json.Unmarshal(data, &aux); err == nil {
+		return nil
+	}
+
+	str := string(data)
+
+	str = strings.Trim(str, "\"")
+	switch str {
+	case ".":
+		*i = NewLocalInput(".")
+		return nil
+	case "...":
+		*i = Input{Spread: true}
+		return nil
+	default:
+		if strings.HasPrefix(str, "$") {
+			stepName := strings.TrimPrefix(str, "$")
+			*i = NewStepInput(stepName)
+			return nil
+		}
+		return fmt.Errorf("invalid input format: %s", str)
+	}
+}
+
+func (Input) JSONSchema() *jsonschema.Schema {
+	// Create common schemas for include/exclude
+	includeSchema := &jsonschema.Schema{
+		Type:        "array",
+		Description: "Files or directories to include",
+		Items: &jsonschema.Schema{
+			Type: "string",
+		},
+	}
+	excludeSchema := &jsonschema.Schema{
+		Type:        "array",
+		Description: "Files or directories to exclude",
+		Items: &jsonschema.Schema{
+			Type: "string",
+		},
+	}
+
+	// Step input schema
+	stepSchema := &jsonschema.Schema{
+		Type:       "object",
+		Properties: jsonschema.NewProperties(),
+	}
+	stepSchema.Properties.Set("step", &jsonschema.Schema{
+		Type:        "string",
+		Description: "The step to use as input",
+	})
+	stepSchema.Properties.Set("include", includeSchema)
+	stepSchema.Properties.Set("exclude", excludeSchema)
+	stepSchema.Required = []string{"step"}
+
+	// Image input schema
+	imageSchema := &jsonschema.Schema{
+		Type:       "object",
+		Properties: jsonschema.NewProperties(),
+	}
+	imageSchema.Properties.Set("image", &jsonschema.Schema{
+		Type:        "string",
+		Description: "The image to use as input",
+	})
+	imageSchema.Properties.Set("include", includeSchema)
+	imageSchema.Properties.Set("exclude", excludeSchema)
+	imageSchema.Required = []string{"image"}
+
+	// Local input schema
+	localSchema := &jsonschema.Schema{
+		Type:       "object",
+		Properties: jsonschema.NewProperties(),
+	}
+	localSchema.Properties.Set("local", &jsonschema.Schema{
+		Type:        "boolean",
+		Description: "Whether to use local files as input",
+	})
+	localSchema.Properties.Set("include", includeSchema)
+	localSchema.Properties.Set("exclude", excludeSchema)
+	localSchema.Required = []string{"local"}
+
+	// String input schema
+	stringSchema := &jsonschema.Schema{
+		Type:        "string",
+		Description: "Strings will be parsed and interpreted as an input. Valid formats are: '.', '...', or '$step'",
+		Enum:        []interface{}{".", "...", "$step"},
+	}
+
+	availableInputs := []*jsonschema.Schema{stepSchema, imageSchema, localSchema, stringSchema}
+
+	return &jsonschema.Schema{
+		OneOf: availableInputs,
+	}
+}

--- a/core/plan/input_test.go
+++ b/core/plan/input_test.go
@@ -1,0 +1,80 @@
+package plan
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUnmarshalInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected Input
+		wantErr  bool
+	}{
+		{
+			name:     "JSON step input",
+			input:    []byte(`{"step": "build", "include": ["src"]}`),
+			expected: NewStepInput("build", InputOptions{Include: []string{"src"}}),
+			wantErr:  false,
+		},
+		{
+			name:     "JSON image input",
+			input:    []byte(`{"image": "golang:1.21", "exclude": ["tmp"]}`),
+			expected: NewImageInput("golang:1.21", InputOptions{Exclude: []string{"tmp"}}),
+			wantErr:  false,
+		},
+		{
+			name:     "JSON local input",
+			input:    []byte(`{"local": true, "include": ["."]}`),
+			expected: NewLocalInput("."),
+			wantErr:  false,
+		},
+		{
+			name:     "String local input with dot",
+			input:    []byte(`"."`),
+			expected: NewLocalInput("."),
+			wantErr:  false,
+		},
+		{
+			name:     "String spread input",
+			input:    []byte(`"..."`),
+			expected: Input{Spread: true},
+			wantErr:  false,
+		},
+		{
+			name:     "String step input",
+			input:    []byte(`"$build"`),
+			expected: NewStepInput("build"),
+			wantErr:  false,
+		},
+		{
+			name:    "Invalid string input",
+			input:   []byte(`"invalid"`),
+			wantErr: true,
+		},
+		{
+			name:    "Invalid JSON input",
+			input:   []byte(`{"invalid": json}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Input
+			err := json.Unmarshal(tt.input, &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalInput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if diff := cmp.Diff(tt.expected, got); diff != "" {
+					t.Errorf("UnmarshalInput() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/core/plan/spread.go
+++ b/core/plan/spread.go
@@ -1,0 +1,49 @@
+package plan
+
+type Spreadable interface {
+	IsSpread() bool
+}
+
+type StringWrapper struct {
+	Value string
+}
+
+func (s StringWrapper) IsSpread() bool {
+	return s.Value == "..."
+}
+
+func Spread[T Spreadable](left []T, right []T) []T {
+	if left == nil {
+		return right
+	}
+
+	result := make([]T, 0, len(left)+len(right))
+
+	for _, val := range left {
+		if val.IsSpread() {
+			result = append(result, right...)
+		} else {
+			result = append(result, val)
+		}
+	}
+
+	return result
+}
+
+func SpreadStrings(left []string, right []string) []string {
+	if left == nil {
+		return right
+	}
+
+	result := make([]string, 0, len(left)+len(right))
+
+	for _, val := range left {
+		if val == "..." {
+			result = append(result, right...)
+		} else {
+			result = append(result, val)
+		}
+	}
+
+	return result
+}

--- a/core/plan/step.go
+++ b/core/plan/step.go
@@ -6,19 +6,6 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
-type Input struct {
-	Image   string   `json:"image,omitempty"`
-	Step    string   `json:"step,omitempty"`
-	Local   bool     `json:"local,omitempty"`
-	Include []string `json:"include,omitempty"`
-	Exclude []string `json:"exclude,omitempty"`
-}
-
-type InputOptions struct {
-	Include []string
-	Exclude []string
-}
-
 type Step struct {
 	Name      string            `json:"name,omitempty" jsonschema:"description=The name of the step"`
 	Inputs    []Input           `json:"inputs,omitempty" jsonschema:"description=The inputs for this step"`
@@ -27,47 +14,6 @@ type Step struct {
 	Assets    map[string]string `json:"assets,omitempty" jsonschema:"description=The assets available to this step. The key is the name of the asset that is referenced in a file command"`
 	Variables map[string]string `json:"variables,omitempty" jsonschema:"description=The variables available to this step. The key is the name of the variable that is referenced in a variable command"`
 	Caches    []string          `json:"caches,omitempty" jsonschema:"description=The caches available to all commands in this step. Each cache must refer to a cache at the top level of the plan"`
-}
-
-func NewStepInput(stepName string, options ...InputOptions) Input {
-	input := Input{
-		Step: stepName,
-	}
-
-	if len(options) > 0 {
-		input.Include = options[0].Include
-		input.Exclude = options[0].Exclude
-	}
-
-	return input
-}
-
-func NewImageInput(image string, options ...InputOptions) Input {
-	input := Input{
-		Image: image,
-	}
-
-	if len(options) > 0 {
-		input.Include = options[0].Include
-		input.Exclude = options[0].Exclude
-	}
-	return input
-}
-
-func RuntimeImageInput() Input {
-	return NewImageInput("ghcr.io/railwayapp/railpack-runtime-base:latest")
-}
-
-func NewLocalInput(path string) Input {
-	return Input{
-		Local:   true,
-		Include: []string{path},
-	}
-}
-
-func (i *Input) String() string {
-	bytes, _ := json.Marshal(i)
-	return string(bytes)
 }
 
 func NewStep(name string) *Step {

--- a/examples/config-file/railpack.json
+++ b/examples/config-file/railpack.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../test/schema.json",
-  "provider": "python",
+  "provider": "node",
   "packages": {
     "python": "latest"
   },
@@ -15,6 +15,6 @@
   },
   "deploy": {
     "aptPackages": ["neofetch"],
-    "startCommand": "neofetch $HELLO"
+    "startCommand": "python --version && neofetch $HELLO"
   }
 }

--- a/examples/config-file/railpack.json
+++ b/examples/config-file/railpack.json
@@ -14,6 +14,7 @@
     }
   },
   "deploy": {
+    "inputs": ["..."],
     "aptPackages": ["neofetch"],
     "startCommand": "python --version && neofetch $HELLO"
   }

--- a/examples/config-file/railpack.other.json
+++ b/examples/config-file/railpack.other.json
@@ -1,6 +1,5 @@
 {
   "$schema": "../../test/schema.json",
-  "providers": [],
   "buildAptPackages": ["cowsay"],
   "steps": {
     "build": {
@@ -8,8 +7,11 @@
     }
   },
   "deploy": {
+    "inputs": [
+      "...",
+      { "image": "macabees/neofetch", "include": ["/usr/bin/neofetch"] }
+    ],
     "aptPackages": ["cowsay"],
-    "paths": ["/usr/games"],
-    "startCommand": "cowsay hello"
+    "startCommand": "neofetch && cowsay hello"
   }
 }

--- a/examples/config-file/railpack.other.json
+++ b/examples/config-file/railpack.other.json
@@ -3,7 +3,7 @@
   "buildAptPackages": ["cowsay"],
   "steps": {
     "build": {
-      "commands": [{ "path": "/usr/games" }, "cowsay hello"]
+      "commands": ["...", { "path": "/usr/games" }, "cowsay hello"]
     }
   },
   "deploy": {


### PR DESCRIPTION
Having a `"..."` in a config array will insert the contents of the auto generated array. This is useful when you want to extend something without completely replacing it. For example,

```json
{
  "$schema": "../../test/schema.json",
  "buildAptPackages": ["cowsay"],
  "steps": {
    "build": {
      "commands": ["...", { "path": "/usr/games" }, "cowsay hello"]
    }
  },
  "deploy": {
    "inputs": [
      "...",
      { "image": "macabees/neofetch", "include": ["/usr/bin/neofetch"] }
    ],
    "aptPackages": ["cowsay"],
    "startCommand": "neofetch && cowsay hello"
  }
}
```

