### PR TITLE
append global python-packages/bin path for pip

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -104,6 +104,9 @@
     },
     {
      "cmd": "pip install --target=/opt/python-packages -r requirements.txt"
+    },
+    {
+     "path": "/opt/python-packages/bin"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -109,6 +109,9 @@
     },
     {
      "cmd": "pip install --target=/opt/python-packages -r requirements.txt"
+    },
+    {
+     "path": "/opt/python-packages/bin"
     }
    ],
    "inputs": [

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -212,6 +212,7 @@ func (p *PythonProvider) InstallPip(ctx *generate.GenerateContext, install *gene
 	install.AddCommands([]plan.Command{
 		plan.NewCopyCommand("requirements.txt"),
 		plan.NewExecCommand(fmt.Sprintf("pip install --target=%s -r requirements.txt", PACKAGES_DIR)),
+		plan.NewPathCommand(fmt.Sprintf("%s/bin", PACKAGES_DIR)),
 	})
 	maps.Copy(install.Variables, p.GetPythonEnvVars(ctx))
 	maps.Copy(install.Variables, map[string]string{


### PR DESCRIPTION
We need to append `/opt/python-packages/bin` to the `$PATH` variable so you can use executables installed (like gunicorn)
