### PR TITLE
update to latest corepack before preparing

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -94,7 +94,8 @@
      "src": "package.json"
     },
     {
-     "cmd": "corepack enable"
+     "cmd": "sh -c 'npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate'",
+     "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
      "cmd": "corepack prepare --activate"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -101,7 +101,8 @@
      "src": "package.json"
     },
     {
-     "cmd": "corepack enable"
+     "cmd": "sh -c 'npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate'",
+     "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
      "cmd": "corepack prepare --activate"

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -220,7 +220,7 @@ func (p *NodeProvider) InstallNodeDeps(ctx *generate.GenerateContext, install *g
 
 		install.AddCommands([]plan.Command{
 			plan.NewCopyCommand("package.json"),
-			plan.NewExecCommand("corepack enable"),
+			plan.NewExecShellCommand("npm i -g corepack@latest && corepack enable && corepack prepare --activate"),
 			plan.NewExecCommand("corepack prepare --activate"),
 		})
 	}

--- a/core/providers/node/node_test.go
+++ b/core/providers/node/node_test.go
@@ -35,7 +35,7 @@ func TestNode(t *testing.T) {
 			detected:       true,
 			packageManager: PackageManagerPnpm,
 			nodeVersion:    "20",
-			pnpmVersion:    "9.9.0",
+			pnpmVersion:    "10.4.1",
 		},
 		{
 			name:           "pnpm",

--- a/examples/node-corepack/package.json
+++ b/examples/node-corepack/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "start": "node dist/index.js"
   },
-  "packageManager": "pnpm@9.9.0",
+  "packageManager": "pnpm@10.4.1",
   "engines": {
     "node": "20"
   },


### PR DESCRIPTION
Fixes an issue where an old version of corepack is not able to verify newer versions of packages.

Before enabling corepack, we upgrade the version of corepack used

https://github.com/pnpm/pnpm/issues/9029#issuecomment-2629866277
