### PR TITLE
dont build as static SPA if custom start command

### DIFF
--- a/core/providers/node/angular.go
+++ b/core/providers/node/angular.go
@@ -8,6 +8,10 @@ import (
 	"github.com/railwayapp/railpack/core/generate"
 )
 
+const (
+	DefaultAngularStartCommand = "ng serve"
+)
+
 func (p *NodeProvider) isAngular(ctx *generate.GenerateContext) bool {
 	hasAngularDep := p.hasDependency("@angular/core")
 	hasAngularConfig := ctx.App.HasMatch("angular.json")

--- a/core/providers/node/cra.go
+++ b/core/providers/node/cra.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	DefaultCRAOutputDirectory = "build"
+	DefaultCRAStartCommand    = "react-scripts start"
 )
 
 func (p *NodeProvider) isCRA(ctx *generate.GenerateContext) bool {

--- a/core/providers/node/spa.go
+++ b/core/providers/node/spa.go
@@ -22,6 +22,12 @@ func (p *NodeProvider) isSPA(ctx *generate.GenerateContext) bool {
 		return false
 	}
 
+	// If there is a custom start command, we don't want to deploy with Caddy as an SPA
+	if p.hasCustomStartCommand(ctx) {
+		ctx.Logger.LogInfo("Skipping SPA deployment because a custom start command is set")
+		return false
+	}
+
 	isVite := p.isVite(ctx)
 	isAstro := p.isAstroSPA(ctx)
 	isCRA := p.isCRA(ctx)
@@ -111,6 +117,16 @@ func (p *NodeProvider) getOutputDirectory(ctx *generate.GenerateContext) string 
 	}
 
 	return outputDir
+}
+
+func (p *NodeProvider) hasCustomStartCommand(ctx *generate.GenerateContext) bool {
+	startCommand := ctx.Config.Deploy.StartCmd
+	if startCommand == "" {
+		startCommand = p.packageJson.Scripts["start"]
+	}
+	isAngularDefaultStartCommand := startCommand == DefaultAngularStartCommand
+	isCRAStartCommand := startCommand == DefaultCRAStartCommand
+	return startCommand != "" && !isAngularDefaultStartCommand && !isCRAStartCommand
 }
 
 // func (p *NodeProvider) isReact() bool {

--- a/core/providers/node/spa_test.go
+++ b/core/providers/node/spa_test.go
@@ -102,3 +102,49 @@ func TestVite(t *testing.T) {
 		})
 	}
 }
+
+func TestHasCustomStartCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "vite-react",
+			path: "../../../examples/node-vite-react",
+			want: false,
+		},
+		{
+			name: "angular",
+			path: "../../../examples/node-angular",
+			want: false,
+		},
+		{
+			name: "astro static",
+			path: "../../../examples/node-astro",
+			want: false,
+		},
+		{
+			name: "astro server",
+			path: "../../../examples/node-astro-server",
+			want: true,
+		},
+		{
+			name: "npm",
+			path: "../../../examples/node-npm",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testingUtils.CreateGenerateContext(t, tt.path)
+			provider := NodeProvider{}
+			err := provider.Initialize(ctx)
+			require.NoError(t, err)
+
+			hasCustomStart := provider.hasCustomStartCommand(ctx)
+			require.Equal(t, tt.want, hasCustomStart)
+		})
+	}
+}


### PR DESCRIPTION
If there is a custom start command, we don't want to deploy a static site with Caddy. We should instead build as a normal Node app
