### PR TITLE
re-order the providers so that go is above node

### DIFF
--- a/core/providers/provider.go
+++ b/core/providers/provider.go
@@ -19,11 +19,12 @@ type Provider interface {
 }
 
 func GetLanguageProviders() []Provider {
+	// Order is important here. The first provider that returns true from Detect() will be used.
 	return []Provider{
 		&php.PhpProvider{},
-		&node.NodeProvider{},
-		&python.PythonProvider{},
 		&golang.GoProvider{},
+		&python.PythonProvider{},
+		&node.NodeProvider{},
 		&staticfile.StaticfileProvider{},
 		&shell.ShellProvider{},
 	}


### PR DESCRIPTION
Node should match after all other main language provider
