### PR TITLE
allow forcing an spa deployment

### DIFF
--- a/core/providers/node/spa.go
+++ b/core/providers/node/spa.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	DefaultCaddyfilePath = "/Caddyfile"
+	OUTPUT_DIR_VAR       = "SPA_OUTPUT_DIR"
 )
 
 //go:embed Caddyfile.template
@@ -18,13 +19,16 @@ var caddyfileTemplate string
 
 func (p *NodeProvider) isSPA(ctx *generate.GenerateContext) bool {
 	if ctx.Env.IsConfigVariableTruthy("NO_SPA") {
-		ctx.Logger.LogInfo("Skipping SPA deployment because NO_SPA is set")
 		return false
+	}
+
+	// Setting the output dir directly will force an SPA build
+	if value, _ := ctx.Env.GetConfigVariable(OUTPUT_DIR_VAR); value != "" {
+		return true
 	}
 
 	// If there is a custom start command, we don't want to deploy with Caddy as an SPA
 	if p.hasCustomStartCommand(ctx) {
-		ctx.Logger.LogInfo("Skipping SPA deployment because a custom start command is set")
 		return false
 	}
 
@@ -104,7 +108,7 @@ func (p *NodeProvider) DeploySPA(ctx *generate.GenerateContext, build *generate.
 func (p *NodeProvider) getOutputDirectory(ctx *generate.GenerateContext) string {
 	outputDir := ""
 
-	if dir, _ := ctx.Env.GetConfigVariable("SPA_OUTPUT_DIR"); dir != "" {
+	if dir, _ := ctx.Env.GetConfigVariable(OUTPUT_DIR_VAR); dir != "" {
 		outputDir = dir
 	} else if p.isVite(ctx) {
 		outputDir = p.getViteOutputDirectory(ctx)

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -90,7 +90,7 @@ disable this behaviour by either:
 These frameworks are supported:
 
 - **Vite**: Detected if `vite.config.js` or `vite.config.ts` exists, or if the build script contains `vite build`
-- **Astro**: Detected if `astro.config.js` exists
+- **Astro**: Detected if `astro.config.js` exists and the output is not type `"server"`
 - **CRA**: Detected if `react-scripts` is in dependencies and build script contains `react-scripts build`
 - **Angular**: Detected if `angular.json` exists
 


### PR DESCRIPTION
If the `RAILPACK_SPA_OUTPUT_DIR` environment variable is set, we force an SPA deployment
