### PR TITLE
[trivial] Update docs to include the correct build command for building from source.

### DIFF
--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -27,7 +27,7 @@ download the `railpack` binary for your platform.
 ```sh
 git clone https://github.com/railwayapp/railpack.git
 cd railpack
-go build -o railpack
+go build -o railpack ./cmd/...
 
 ./railpack --help
 ```


### PR DESCRIPTION
Existing documentation suggests using ```go build -o railpack``` to build from source, which results in the error: ```no Go files in /path/to/railpack```. Adding `./cmd/...` seems to do the trick.