### PR TITLE
skip yarn gpg verification

### DIFF
--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -276,7 +276,7 @@ func (p *NodeProvider) GetNodeEnvVars(ctx *generate.GenerateContext) map[string]
 
 	if p.packageManager == PackageManagerYarn1 {
 		envVars["YARN_PRODUCTION"] = "false"
-		envVars["MISE_YARN_SKIP_GPG"] = "1" // https://github.com/twuni/asdf-yarn/issues/33
+		envVars["MISE_YARN_SKIP_GPG"] = "true" // https://github.com/mise-plugins/mise-yarn/pull/8
 	}
 
 	if p.isAstro(ctx) && !p.isAstroSPA(ctx) {

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -276,6 +276,7 @@ func (p *NodeProvider) GetNodeEnvVars(ctx *generate.GenerateContext) map[string]
 
 	if p.packageManager == PackageManagerYarn1 {
 		envVars["YARN_PRODUCTION"] = "false"
+		envVars["MISE_YARN_SKIP_GPG"] = "1" // https://github.com/twuni/asdf-yarn/issues/33
 	}
 
 	if p.isAstro(ctx) && !p.isAstroSPA(ctx) {


### PR DESCRIPTION
The _newer_ versions of yarn 1 don't have valid gpg verification keys uploaded. We shouldn't fail the install in this case.

https://github.com/twuni/asdf-yarn/issues/33

https://github.com/mise-plugins/mise-yarn/pull/8