### PR TITLE
Pip virtual env

### DIFF
--- a/buildkit/build_llb/build_env.go
+++ b/buildkit/build_llb/build_env.go
@@ -1,5 +1,10 @@
 package build_llb
 
+import (
+	"maps"
+	"slices"
+)
+
 type BuildEnvironment struct {
 	PathList []string
 	EnvVars  map[string]string
@@ -15,20 +20,14 @@ func NewGraphEnvironment() BuildEnvironment {
 // Merges the other environment into the current environment
 func (e *BuildEnvironment) Merge(other BuildEnvironment) {
 	e.PathList = append(e.PathList, other.PathList...)
-
-	for k, v := range other.EnvVars {
-		e.EnvVars[k] = v
-	}
+	maps.Copy(e.EnvVars, other.EnvVars)
 }
 
-func (e *BuildEnvironment) AddPath(path string) {
-	for _, existingPath := range e.PathList {
-		if existingPath == path {
-			return
-		}
+func (e *BuildEnvironment) PushPath(path string) {
+	if slices.Contains(e.PathList, path) {
+		return
 	}
-
-	e.PathList = append(e.PathList, path)
+	e.PathList = append([]string{path}, e.PathList...)
 }
 
 func (e *BuildEnvironment) AddEnvVar(key, value string) {

--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -317,9 +317,7 @@ func (g *BuildGraph) getNodeStartingState(node *StepNode) (llb.State, error) {
 	if len(node.InputEnv.PathList) > 0 {
 		pathString := strings.Join(node.InputEnv.PathList, ":")
 		state = state.AddEnvf("PATH", "%s:%s", pathString, system.DefaultPathEnvUnix)
-		for _, path := range node.InputEnv.PathList {
-			node.OutputEnv.AddPath(path)
-		}
+		node.OutputEnv.PathList = append(node.OutputEnv.PathList, node.InputEnv.PathList...)
 	}
 
 	return state, nil
@@ -375,9 +373,8 @@ func (g *BuildGraph) convertExecCommandToLLB(node *StepNode, cmd plan.ExecComman
 
 // convertPathCommandToLLB converts a path command to an LLB state
 func (g *BuildGraph) convertPathCommandToLLB(node *StepNode, cmd plan.PathCommand, state llb.State) (llb.State, error) {
-	node.OutputEnv.AddPath(cmd.Path)
-	pathList := node.getPathList()
-	pathString := strings.Join(pathList, ":")
+	node.OutputEnv.PushPath(cmd.Path)
+	pathString := strings.Join(node.getPathList(), ":")
 
 	s := state.AddEnvf("PATH", "%s:%s", pathString, system.DefaultPathEnvUnix)
 	return s, nil

--- a/buildkit/build_llb/step_node.go
+++ b/buildkit/build_llb/step_node.go
@@ -40,7 +40,6 @@ func (n *StepNode) SetChildren(children []graph.Node) {
 
 func (node *StepNode) getPathList() []string {
 	pathList := make([]string, 0)
-	pathList = append(pathList, node.InputEnv.PathList...)
 	pathList = append(pathList, node.OutputEnv.PathList...)
 	return pathList
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -109,6 +109,9 @@
      "path": "/root/.local/bin"
     },
     {
+     "path": "/app/.venv/bin"
+    },
+    {
      "dest": "pyproject.toml",
      "src": "pyproject.toml"
     },
@@ -125,9 +128,6 @@
     },
     {
      "cmd": "uv sync --locked --no-dev --no-editable"
-    },
-    {
-     "path": "/app/.venv/bin"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -30,7 +30,6 @@
    },
    {
     "include": [
-     "/opt/python-packages",
      "."
     ],
     "step": "build"
@@ -99,14 +98,17 @@
    ],
    "commands": [
     {
+     "cmd": "python -m venv /app/.venv"
+    },
+    {
+     "path": "/app/.venv/bin"
+    },
+    {
      "dest": "requirements.txt",
      "src": "requirements.txt"
     },
     {
-     "cmd": "pip install --target=/opt/python-packages -r requirements.txt"
-    },
-    {
-     "path": "/opt/python-packages/bin"
+     "cmd": "pip install -r requirements.txt"
     }
    ],
    "inputs": [
@@ -122,8 +124,8 @@
     "PYTHONDONTWRITEBYTECODE": "1",
     "PYTHONFAULTHANDLER": "1",
     "PYTHONHASHSEED": "random",
-    "PYTHONPATH": "/opt/python-packages",
-    "PYTHONUNBUFFERED": "1"
+    "PYTHONUNBUFFERED": "1",
+    "VIRTUAL_ENV": "/app/.venv"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -109,9 +109,6 @@
     },
     {
      "cmd": "pipenv install --deploy --ignore-pipfile"
-    },
-    {
-     "path": "/app/.venv/bin"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -113,9 +113,6 @@
     {
      "dest": ".",
      "src": "."
-    },
-    {
-     "path": "/app/.venv/bin"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -31,7 +31,6 @@
    },
    {
     "include": [
-     "/opt/python-packages",
      "."
     ],
     "step": "build"
@@ -104,14 +103,17 @@
    ],
    "commands": [
     {
+     "cmd": "python -m venv /app/.venv"
+    },
+    {
+     "path": "/app/.venv/bin"
+    },
+    {
      "dest": "requirements.txt",
      "src": "requirements.txt"
     },
     {
-     "cmd": "pip install --target=/opt/python-packages -r requirements.txt"
-    },
-    {
-     "path": "/opt/python-packages/bin"
+     "cmd": "pip install -r requirements.txt"
     }
    ],
    "inputs": [
@@ -127,8 +129,8 @@
     "PYTHONDONTWRITEBYTECODE": "1",
     "PYTHONFAULTHANDLER": "1",
     "PYTHONHASHSEED": "random",
-    "PYTHONPATH": "/opt/python-packages",
-    "PYTHONUNBUFFERED": "1"
+    "PYTHONUNBUFFERED": "1",
+    "VIRTUAL_ENV": "/app/.venv"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -109,6 +109,9 @@
      "path": "/root/.local/bin"
     },
     {
+     "path": "/app/.venv/bin"
+    },
+    {
      "dest": "pyproject.toml",
      "src": "pyproject.toml"
     },
@@ -125,9 +128,6 @@
     },
     {
      "cmd": "uv sync --locked --no-dev --no-editable"
-    },
-    {
-     "path": "/app/.venv/bin"
     }
    ],
    "inputs": [

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -14,9 +14,8 @@ const (
 	DEFAULT_PYTHON_VERSION = "3.13.2"
 	UV_CACHE_DIR           = "/opt/uv-cache"
 	PIP_CACHE_DIR          = "/opt/pip-cache"
-	// PACKAGES_DIR           = "/opt/python-packages"
-	VENV_PATH      = "/app/.venv"
-	LOCAL_BIN_PATH = "/root/.local/bin"
+	VENV_PATH              = "/app/.venv"
+	LOCAL_BIN_PATH         = "/root/.local/bin"
 )
 
 type PythonProvider struct{}

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -14,9 +14,9 @@ const (
 	DEFAULT_PYTHON_VERSION = "3.13.2"
 	UV_CACHE_DIR           = "/opt/uv-cache"
 	PIP_CACHE_DIR          = "/opt/pip-cache"
-	PACKAGES_DIR           = "/opt/python-packages"
-	VENV_PATH              = "/app/.venv"
-	LOCAL_BIN_PATH         = "/root/.local/bin"
+	// PACKAGES_DIR           = "/opt/python-packages"
+	VENV_PATH      = "/app/.venv"
+	LOCAL_BIN_PATH = "/root/.local/bin"
 )
 
 type PythonProvider struct{}
@@ -115,12 +115,12 @@ func (p *PythonProvider) InstallUv(ctx *generate.GenerateContext, install *gener
 	install.AddCommands([]plan.Command{
 		plan.NewExecCommand("pipx install uv"),
 		plan.NewPathCommand(LOCAL_BIN_PATH),
+		plan.NewPathCommand(VENV_PATH + "/bin"),
 		plan.NewCopyCommand("pyproject.toml"),
 		plan.NewCopyCommand("uv.lock"),
 		plan.NewExecCommand("uv sync --locked --no-dev --no-install-project"),
 		plan.NewCopyCommand("."),
 		plan.NewExecCommand("uv sync --locked --no-dev --no-editable"),
-		plan.NewPathCommand(VENV_PATH + "/bin"),
 	})
 
 	return []string{}
@@ -154,10 +154,6 @@ func (p *PythonProvider) InstallPipenv(ctx *generate.GenerateContext, install *g
 			plan.NewExecCommand("pipenv install --skip-lock"),
 		})
 	}
-
-	install.AddCommands([]plan.Command{
-		plan.NewPathCommand(VENV_PATH + "/bin"),
-	})
 
 	return []string{}
 }
@@ -195,7 +191,6 @@ func (p *PythonProvider) InstallPoetry(ctx *generate.GenerateContext, install *g
 		plan.NewCopyCommand("poetry.lock"),
 		plan.NewExecCommand("poetry install --no-interaction --no-ansi --only main --no-root"),
 		plan.NewCopyCommand("."),
-		plan.NewPathCommand(VENV_PATH + "/bin"),
 	})
 
 	install.AddEnvVars(map[string]string{
@@ -210,17 +205,18 @@ func (p *PythonProvider) InstallPip(ctx *generate.GenerateContext, install *gene
 
 	install.AddCache(ctx.Caches.AddCache("pip", PIP_CACHE_DIR))
 	install.AddCommands([]plan.Command{
+		plan.NewExecCommand(fmt.Sprintf("python -m venv %s", VENV_PATH)),
+		plan.NewPathCommand(VENV_PATH + "/bin"),
 		plan.NewCopyCommand("requirements.txt"),
-		plan.NewExecCommand(fmt.Sprintf("pip install --target=%s -r requirements.txt", PACKAGES_DIR)),
-		plan.NewPathCommand(fmt.Sprintf("%s/bin", PACKAGES_DIR)),
+		plan.NewExecCommand("pip install -r requirements.txt"),
 	})
 	maps.Copy(install.Variables, p.GetPythonEnvVars(ctx))
 	maps.Copy(install.Variables, map[string]string{
 		"PIP_CACHE_DIR": PIP_CACHE_DIR,
-		"PYTHONPATH":    PACKAGES_DIR,
+		"VIRTUAL_ENV":   VENV_PATH,
 	})
 
-	return []string{PACKAGES_DIR}
+	return []string{}
 }
 
 func (p *PythonProvider) GetImageWithRuntimeDeps(ctx *generate.GenerateContext) *generate.AptStepBuilder {

--- a/examples/python-pip/main.py
+++ b/examples/python-pip/main.py
@@ -1,7 +1,12 @@
 import numpy as np
 import pandas as pd
+import os
 
-print("Package versions:")
+print("PATH:", os.environ['PATH'])
+path = os.environ['PATH']
+assert path.startswith("/app/.venv/bin"), f"Expected PATH to start with /app/.venv/bin but got {path}"
+
+
 print("numpy", np.__version__)
 print("pandas", pd.__version__)
 


### PR DESCRIPTION
- Use a virtual env for pip installs. This fixes some issues where system deps were conflicting with the pip installed ones
- Fix path env ordering. This really fixed some issues where the previous steps PATH output would have higher priority over the current steps PATH commands
