### PR TITLE
parse semver version from text

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -62,7 +62,7 @@ func GenerateBuildResultForCommand(cmd *cli.Command) (*core.BuildResult, *a.App,
 		return nil, nil, nil, fmt.Errorf("error creating env: %w", err)
 	}
 
-	previousVersions := utils.ParseVersions(cmd.StringSlice("previous"))
+	previousVersions := utils.ParsePackageWithVersion(cmd.StringSlice("previous"))
 
 	generateOptions := &core.GenerateBuildPlanOptions{
 		RailpackVersion:          Version,

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -103,10 +103,10 @@
    ],
    "commands": [
     {
-     "cmd": "pipx install uv"
+     "path": "/root/.local/bin"
     },
     {
-     "path": "/root/.local/bin"
+     "cmd": "pipx install uv"
     },
     {
      "path": "/app/.venv/bin"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -91,10 +91,10 @@
   {
    "commands": [
     {
-     "cmd": "pipx install pdm"
+     "path": "/root/.local/bin"
     },
     {
-     "path": "/root/.local/bin"
+     "cmd": "pipx install pdm"
     },
     {
      "dest": ".",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -91,10 +91,10 @@
   {
    "commands": [
     {
-     "cmd": "pipx install pipenv"
+     "path": "/root/.local/bin"
     },
     {
-     "path": "/root/.local/bin"
+     "cmd": "pipx install pipenv"
     },
     {
      "path": "/app/.venv/bin"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -91,10 +91,10 @@
   {
    "commands": [
     {
-     "cmd": "pipx install poetry"
+     "path": "/root/.local/bin"
     },
     {
-     "path": "/root/.local/bin"
+     "cmd": "pipx install poetry"
     },
     {
      "path": "/app/.venv/bin"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -103,10 +103,10 @@
    ],
    "commands": [
     {
-     "cmd": "pipx install uv"
+     "path": "/root/.local/bin"
     },
     {
-     "path": "/root/.local/bin"
+     "cmd": "pipx install uv"
     },
     {
      "path": "/app/.venv/bin"

--- a/core/core.go
+++ b/core/core.go
@@ -176,7 +176,7 @@ func GenerateConfigFromEnvironment(app *app.App, env *app.Environment) *config.C
 	}
 
 	if envPackages, _ := env.GetConfigVariable("PACKAGES"); envPackages != "" {
-		config.Packages = utils.ParseVersions(strings.Split(envPackages, " "))
+		config.Packages = utils.ParsePackageWithVersion(strings.Split(envPackages, " "))
 	}
 
 	if envAptPackages, _ := env.GetConfigVariable("BUILD_APT_PACKAGES"); envAptPackages != "" {

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/alexflint/go-filemutex"
 	"github.com/charmbracelet/log"
+	"github.com/railwayapp/railpack/core/utils"
 )
 
 const (
@@ -47,7 +48,7 @@ func (m *Mise) GetLatestVersion(pkg, version string) (string, error) {
 	}
 	defer unlock()
 
-	query := fmt.Sprintf("%s@%s", pkg, strings.TrimSpace(version))
+	query := fmt.Sprintf("%s@%s", pkg, utils.ExtractSemverVersion(version))
 	output, err := m.runCmd("latest", query)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found in mise tool registry") {
@@ -72,7 +73,7 @@ func (m *Mise) GetAllVersions(pkg, version string) ([]string, error) {
 	}
 	defer unlock()
 
-	query := fmt.Sprintf("%s@%s", pkg, strings.TrimSpace(version))
+	query := fmt.Sprintf("%s@%s", pkg, utils.ExtractSemverVersion(version))
 	output, err := m.runCmd("ls-remote", query)
 	if err != nil {
 		return nil, err

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/railwayapp/railpack/core/generate"
 	"github.com/railwayapp/railpack/core/plan"
+	"github.com/railwayapp/railpack/core/utils"
 )
 
 const (
@@ -276,11 +277,11 @@ func (p *PythonProvider) InstallMisePackages(ctx *generate.GenerateContext, mise
 	}
 
 	if versionFile, err := ctx.App.ReadFile(".python-version"); err == nil {
-		miseStep.Version(python, string(versionFile), ".python-version")
+		miseStep.Version(python, utils.ExtractSemverVersion(string(versionFile)), ".python-version")
 	}
 
 	if runtimeFile, err := ctx.App.ReadFile("runtime.txt"); err == nil {
-		miseStep.Version(python, string(runtimeFile), "runtime.txt")
+		miseStep.Version(python, utils.ExtractSemverVersion(string(runtimeFile)), "runtime.txt")
 	}
 
 	if pipfileVersion := parseVersionFromPipfile(ctx); pipfileVersion != "" {

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -123,8 +123,8 @@ func (p *PythonProvider) InstallUv(ctx *generate.GenerateContext, install *gener
 	})
 	install.AddEnvVars(p.GetPythonEnvVars(ctx))
 	install.AddCommands([]plan.Command{
-		plan.NewExecCommand("pipx install uv"),
 		plan.NewPathCommand(LOCAL_BIN_PATH),
+		plan.NewExecCommand("pipx install uv"),
 		plan.NewPathCommand(VENV_PATH + "/bin"),
 		plan.NewCopyCommand("pyproject.toml"),
 		plan.NewCopyCommand("uv.lock"),
@@ -147,8 +147,8 @@ func (p *PythonProvider) InstallPipenv(ctx *generate.GenerateContext, install *g
 	})
 
 	install.AddCommands([]plan.Command{
-		plan.NewExecCommand("pipx install pipenv"),
 		plan.NewPathCommand(LOCAL_BIN_PATH),
+		plan.NewExecCommand("pipx install pipenv"),
 		plan.NewPathCommand(VENV_PATH + "/bin"),
 	})
 
@@ -177,8 +177,8 @@ func (p *PythonProvider) InstallPDM(ctx *generate.GenerateContext, install *gene
 	})
 
 	install.AddCommands([]plan.Command{
-		plan.NewExecCommand("pipx install pdm"),
 		plan.NewPathCommand(LOCAL_BIN_PATH),
+		plan.NewExecCommand("pipx install pdm"),
 		plan.NewCopyCommand("."),
 		plan.NewExecCommand("python --version"),
 		plan.NewExecCommand("pdm install --check --prod --no-editable"),
@@ -194,8 +194,8 @@ func (p *PythonProvider) InstallPoetry(ctx *generate.GenerateContext, install *g
 	install.AddEnvVars(p.GetPythonEnvVars(ctx))
 
 	install.AddCommands([]plan.Command{
-		plan.NewExecCommand("pipx install poetry"),
 		plan.NewPathCommand(LOCAL_BIN_PATH),
+		plan.NewExecCommand("pipx install poetry"),
 		plan.NewPathCommand(VENV_PATH + "/bin"),
 		plan.NewExecCommand("poetry config virtualenvs.in-project true"),
 		plan.NewCopyCommand("pyproject.toml"),

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -102,7 +102,7 @@ func ParsePackageWithVersion(versions []string) map[string]string {
 // Returns an empty string if no version number is found.
 func ExtractSemverVersion(version string) string {
 	semverRe := regexp.MustCompile(`(\d+(?:\.\d+)?(?:\.\d+)?)`)
-	matches := semverRe.FindStringSubmatch(version)
+	matches := semverRe.FindStringSubmatch(strings.TrimSpace(version))
 	if len(matches) > 1 {
 		return matches[1]
 	}

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -47,6 +48,13 @@ func MergeStringSlicePointers(slices ...*[]string) *[]string {
 	return &uniqueStrings
 }
 
+// CapitalizeFirst converts the first character of a string to uppercase.
+// The rest of the string remains unchanged.
+// Examples:
+//   - "hello" -> "Hello"
+//   - "world" -> "World"
+//   - "" -> ""
+//   - "already Capitalized" -> "Already Capitalized"
 func CapitalizeFirst(s string) string {
 	if s == "" {
 		return ""
@@ -57,7 +65,15 @@ func CapitalizeFirst(s string) string {
 	return string(runes)
 }
 
-func ParseVersions(versions []string) map[string]string {
+// ParsePackageWithVersion parses a slice of package specifications in the format "name@version"
+// and returns a map of package names to their versions.
+// If a package has no version specified (no @ symbol), it defaults to "latest".
+// Examples:
+//   - ["node@14.2"] -> {"node": "14.2"}
+//   - ["python"] -> {"python": "latest"}
+//   - ["ruby@3.0.0", "go"] -> {"ruby": "3.0.0", "go": "latest"}
+//   - ["node@^14.3", "python@>=3.9"] -> {"node": "^14.3", "python": ">=3.9"}
+func ParsePackageWithVersion(versions []string) map[string]string {
 	parsedVersions := make(map[string]string)
 
 	for _, version := range versions {
@@ -70,4 +86,25 @@ func ParseVersions(versions []string) map[string]string {
 	}
 
 	return parsedVersions
+}
+
+// ExtractSemverVersion extracts the first version number found in a string.
+// It supports full semver (major.minor.patch) as well as partial versions (major or major.minor).
+// The version can appear anywhere in the string and can have prefixes or suffixes.
+// Examples:
+//   - "1.2.3" -> "1.2.3"
+//   - "v1.2.3" -> "1.2.3"
+//   - "python-3.10.7" -> "3.10.7"
+//   - "version1.2.3-beta" -> "1.2.3"
+//   - "requires node 14.2" -> "14.2"
+//   - "python 3" -> "3"
+//
+// Returns an empty string if no version number is found.
+func ExtractSemverVersion(version string) string {
+	semverRe := regexp.MustCompile(`(\d+(?:\.\d+)?(?:\.\d+)?)`)
+	matches := semverRe.FindStringSubmatch(version)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
 }

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -145,22 +145,38 @@ func TestExtractSemverVersion(t *testing.T) {
 		input    string
 		expected string
 	}{
+		// Basic version formats
+		{"major version only", "1", "1"},
+		{"major.minor version", "1.2", "1.2"},
 		{"simple version", "1.2.3", "1.2.3"},
 		{"v prefix", "v1.2.3", "1.2.3"},
-		{"major.minor version", "1.2", "1.2"},
-		{"major version only", "1", "1"},
-		{"invalid format", "1.2.3.4", "1.2.3"},
+
+		// Large version numbers
+		{"large major version", "100", "100"},
+		{"large minor version", "1.234", "1.234"},
+		{"large patch version", "1.2.345", "1.2.345"},
+		{"all large numbers", "123.456.789", "123.456.789"},
+		{"leading zeros", "01.02.03", "01.02.03"},
+
+		// Version in different contexts
 		{"with prefix", "version1.2.3", "1.2.3"},
 		{"with suffix", "1.2.3-beta", "1.2.3"},
-		{"empty string", "", ""},
-		{"non-numeric", "a.b.c", ""},
-		{"mixed format", "v1.2.x", "1.2"},
 		{"python style version", "python-3.10.7", "3.10.7"},
 		{"version in text", "runtime version is 2.4.1 or higher", "2.4.1"},
-		{"multiple versions", "supports both 1.2.3 and 4.5.6", "1.2.3"},
 		{"with suffix and prefix", "myapp1.2.3-rc1", "1.2.3"},
 		{"major version in text", "python 3 or higher", "3"},
 		{"major.minor in text", "requires node 14.2", "14.2"},
+		{"multiple versions", "supports both 1.2.3 and 4.5.6", "1.2.3"},
+
+		// Edge cases
+		{"empty string", "", ""},
+		{"non-numeric", "a.b.c", ""},
+		{"mixed format", "v1.2.x", "1.2"},
+		{"invalid format", "1.2.3.4", "1.2.3"},
+		{"double digit major", "10.2.3", "10.2.3"},
+		{"version with spaces", "  2.3.4  ", "2.3.4"},
+		{"version in parentheses", "(1.2.3)", "1.2.3"},
+		{"version with build info", "1.2.3+build123", "1.2.3"},
 	}
 
 	for _, tt := range tests {

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -124,7 +124,7 @@ func TestParseVersions(t *testing.T) {
 		"wildcard@*",
 	}
 
-	parsedVersions := ParseVersions(input)
+	parsedVersions := ParsePackageWithVersion(input)
 
 	expected := map[string]string{
 		"basic":     "1.0.0",
@@ -137,4 +137,38 @@ func TestParseVersions(t *testing.T) {
 	}
 
 	require.Equal(t, expected, parsedVersions)
+}
+
+func TestExtractSemverVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple version", "1.2.3", "1.2.3"},
+		{"v prefix", "v1.2.3", "1.2.3"},
+		{"major.minor version", "1.2", "1.2"},
+		{"major version only", "1", "1"},
+		{"invalid format", "1.2.3.4", "1.2.3"},
+		{"with prefix", "version1.2.3", "1.2.3"},
+		{"with suffix", "1.2.3-beta", "1.2.3"},
+		{"empty string", "", ""},
+		{"non-numeric", "a.b.c", ""},
+		{"mixed format", "v1.2.x", "1.2"},
+		{"python style version", "python-3.10.7", "3.10.7"},
+		{"version in text", "runtime version is 2.4.1 or higher", "2.4.1"},
+		{"multiple versions", "supports both 1.2.3 and 4.5.6", "1.2.3"},
+		{"with suffix and prefix", "myapp1.2.3-rc1", "1.2.3"},
+		{"major version in text", "python 3 or higher", "3"},
+		{"major.minor in text", "requires node 14.2", "14.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractSemverVersion(tt.input)
+			if result != tt.expected {
+				t.Errorf("ExtractSemverVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Support parsing python `runtime.txt` files with versions like `python-3.13.1`
