### PR TITLE
ensure node is available for bun install at build

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -83,8 +83,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y neofetch'",
-     "customName": "install apt packages: neofetch"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y neofetch nodejs'",
+     "customName": "install apt packages: neofetch nodejs"
     },
     {
      "path": "/mise/shims"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -67,7 +67,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node"
+     "customName": "install mise packages: bun, node"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -1,5 +1,13 @@
 {
  "caches": {
+  "apt": {
+   "directory": "/var/cache/apt",
+   "type": "locked"
+  },
+  "apt-lists": {
+   "directory": "/var/lib/apt/lists",
+   "type": "locked"
+  },
   "bun-install": {
    "directory": "/root/.bun/install/cache",
    "type": "shared"
@@ -51,7 +59,15 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "apt",
+    "apt-lists"
+   ],
    "commands": [
+    {
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y nodejs'",
+     "customName": "install apt packages: nodejs"
+    },
     {
      "path": "/mise/shims"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -1,5 +1,13 @@
 {
  "caches": {
+  "apt": {
+   "directory": "/var/cache/apt",
+   "type": "locked"
+  },
+  "apt-lists": {
+   "directory": "/var/lib/apt/lists",
+   "type": "locked"
+  },
   "bun-install": {
    "directory": "/root/.bun/install/cache",
    "type": "shared"
@@ -51,7 +59,15 @@
    "assets": {
     "mise.toml": "[mise.toml]"
    },
+   "caches": [
+    "apt",
+    "apt-lists"
+   ],
    "commands": [
+    {
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y nodejs'",
+     "customName": "install apt packages: nodejs"
+    },
     {
      "path": "/mise/shims"
     },

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -418,6 +418,10 @@ func (p *NodeProvider) requiresBun(ctx *generate.GenerateContext) bool {
 		}
 	}
 
+	if ctx.Config.Deploy != nil && strings.Contains(ctx.Config.Deploy.StartCmd, "bun") {
+		return true
+	}
+
 	return false
 }
 

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -228,8 +228,10 @@ func (p *NodeProvider) InstallNodeDeps(ctx *generate.GenerateContext, install *g
 }
 
 func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder) {
+	requiresNode := p.requiresNode(ctx)
+
 	// Node
-	if p.requiresNode(ctx) {
+	if requiresNode {
 		node := miseStep.Default("node", DEFAULT_NODE_VERSION)
 
 		if envVersion, varName := ctx.Env.GetConfigVariable("NODE_VERSION"); envVersion != "" {
@@ -250,11 +252,18 @@ func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 	}
 
 	// Bun
-	if p.packageManager == PackageManagerBun {
+	if p.requiresBun(ctx) {
 		bun := miseStep.Default("bun", DEFAULT_BUN_VERSION)
 
 		if envVersion, varName := ctx.Env.GetConfigVariable("BUN_VERSION"); envVersion != "" {
 			miseStep.Version(bun, envVersion, varName)
+		}
+
+		// If we don't need node in the final image, we still want to include it for the install steps
+		// since many packages need node-gyp to install native modules
+		// in this case, we don't need a specific version, so we'll just pull from apt
+		if !requiresNode && ctx.Config.Packages["node"] == "" {
+			miseStep.AddSupportingAptPackage("nodejs")
 		}
 	}
 
@@ -389,15 +398,27 @@ func (p *NodeProvider) requiresNode(ctx *generate.GenerateContext) bool {
 		return true
 	}
 
-	scripts := p.packageJson.Scripts
-
-	for _, script := range scripts {
+	for _, script := range p.packageJson.Scripts {
 		if strings.Contains(script, "node") {
 			return true
 		}
 	}
 
 	return p.isAstro(ctx)
+}
+
+func (p *NodeProvider) requiresBun(ctx *generate.GenerateContext) bool {
+	if p.packageManager == PackageManagerBun {
+		return true
+	}
+
+	for _, script := range p.packageJson.Scripts {
+		if strings.Contains(script, "bun") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (p *NodeProvider) getRuntime(ctx *generate.GenerateContext) string {


### PR DESCRIPTION
Some packages require node to be installed regardless of if `bun install` is being used. If we detect that bun isn't needed at runtime, we will install nodejs with apt so that packages can still be installed with node-gyp.

I've also added a check for adding bun to the final image if it is used in any of the scripts.
