### PR TITLE
do not use `RANDOM` in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ get_tmpfile() {
   local suffix
   suffix="$1"
   if has mktemp; then
-    printf "%s%s.%s.%s" "$(mktemp)" "-railpack" "${RANDOM}" "${suffix}"
+    printf "%s%s.%s.%s" "$(mktemp)" "-railpack" "$(date +%s)" "${suffix}"
   else
     printf "/tmp/railpack.%s" "${suffix}"
   fi


### PR DESCRIPTION
`RANDOM` is not available in `sh`. This PR removes it and uses something else.

Fixes https://github.com/railwayapp/railpack/issues/87
