### PR TITLE
Node: also use all files for preinstall scripts

### DIFF
--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -48,7 +48,7 @@ func (p PackageManager) installDependencies(ctx *generate.GenerateContext, packa
 	hasPostInstall := packageJson.Scripts != nil && packageJson.Scripts["postinstall"] != ""
 	hasPrepare := packageJson.Scripts != nil && packageJson.Scripts["prepare"] != ""
 
-	// If there is a postinstall script, we need the entire app to be copied
+	// If there are any pre/post install scripts, we need the entire app to be copied
 	// This is to handle things like patch-package
 	if hasPreInstall || hasPostInstall || hasPrepare {
 		install.AddCommands([]plan.Command{

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -44,12 +44,13 @@ func (p PackageManager) RunScriptCommand(cmd string) string {
 }
 
 func (p PackageManager) installDependencies(ctx *generate.GenerateContext, packageJson *PackageJson, install *generate.CommandStepBuilder) {
+	hasPreInstall := packageJson.Scripts != nil && packageJson.Scripts["preinstall"] != ""
 	hasPostInstall := packageJson.Scripts != nil && packageJson.Scripts["postinstall"] != ""
 	hasPrepare := packageJson.Scripts != nil && packageJson.Scripts["prepare"] != ""
 
 	// If there is a postinstall script, we need the entire app to be copied
 	// This is to handle things like patch-package
-	if hasPostInstall || hasPrepare {
+	if hasPreInstall || hasPostInstall || hasPrepare {
 		install.AddCommands([]plan.Command{
 			plan.NewCopyCommand(".", "."),
 		})


### PR DESCRIPTION
I'm using a preinstall script to fetch and build a native dependency, for instance, and it needs my Makefile in order to do that.