### PR TITLE
Deno provider

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
@@ -1,0 +1,81 @@
+{
+ "deploy": {
+  "inputs": [
+   {
+    "image": "ghcr.io/railwayapp/railpack-runtime:latest"
+   },
+   {
+    "include": [
+     "/mise/shims",
+     "/mise/installs",
+     "/usr/local/bin/mise",
+     "/etc/mise/config.toml",
+     "/root/.local/state/mise"
+    ],
+    "step": "packages:mise"
+   },
+   {
+    "include": [
+     ".",
+     "/root/.cache/deno"
+    ],
+    "step": "build"
+   }
+  ],
+  "startCommand": "deno run --allow-all main.ts"
+ },
+ "steps": [
+  {
+   "assets": {
+    "mise.toml": "[mise.toml]"
+   },
+   "commands": [
+    {
+     "path": "/mise/shims"
+    },
+    {
+     "customName": "create mise config",
+     "name": "mise.toml",
+     "path": "/etc/mise/config.toml"
+    },
+    {
+     "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
+     "customName": "install mise packages: deno"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
+    }
+   ],
+   "name": "packages:mise",
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
+  },
+  {
+   "commands": [
+    {
+     "dest": ".",
+     "src": "."
+    },
+    {
+     "cmd": "deno cache main.ts"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    }
+   ],
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
+  }
+ ]
+}

--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -1,0 +1,111 @@
+package deno
+
+import (
+	"fmt"
+
+	"github.com/railwayapp/railpack/core/generate"
+	"github.com/railwayapp/railpack/core/plan"
+)
+
+const (
+	DEFAULT_DENO_VERSION = "2"
+	DENO_DIR             = "/root/.cache/deno"
+)
+
+type DenoJson struct {
+	Tasks map[string]string `json:"tasks"`
+}
+
+type DenoProvider struct {
+	mainFile string
+}
+
+func (p *DenoProvider) Name() string {
+	return "deno"
+}
+
+func (p *DenoProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
+	hasDenoJson := ctx.App.HasMatch("deno.json") || ctx.App.HasMatch("deno.jsonc")
+	return hasDenoJson, nil
+}
+
+func (p *DenoProvider) Initialize(ctx *generate.GenerateContext) error {
+	p.mainFile = p.findMainFile(ctx)
+	return nil
+}
+
+func (p *DenoProvider) Plan(ctx *generate.GenerateContext) error {
+	miseStep := ctx.GetMiseStepBuilder()
+	p.InstallMisePackages(ctx, miseStep)
+
+	build := ctx.NewCommandStep("build")
+	build.AddInput(plan.NewStepInput(miseStep.Name()))
+	p.Build(ctx, build)
+
+	ctx.Deploy.Inputs = []plan.Input{
+		ctx.DefaultRuntimeInput(),
+		plan.NewStepInput(miseStep.Name(), plan.InputOptions{
+			Include: miseStep.GetOutputPaths(),
+		}),
+		plan.NewStepInput(build.Name(), plan.InputOptions{
+			Include: []string{".", DENO_DIR},
+		}),
+	}
+	ctx.Deploy.StartCmd = p.GetStartCommand(ctx)
+
+	return nil
+}
+
+func (p *DenoProvider) StartCommandHelp() string {
+	return "To start your Deno application, Railpack will look for:\n\n" +
+		"1. A main.ts, main.js, main.mjs, or main.mts file in your project root\n\n" +
+		"2. If no main file is found, it will use the first .ts, .js, .mjs, or .mts file found in your project\n\n" +
+		"The selected file will be run with `deno run --allow-all`"
+}
+
+func (p *DenoProvider) GetStartCommand(ctx *generate.GenerateContext) string {
+	if p.mainFile == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("deno run --allow-all %s", p.mainFile)
+}
+
+func (p *DenoProvider) Build(ctx *generate.GenerateContext, build *generate.CommandStepBuilder) {
+	if p.mainFile == "" {
+		return
+	}
+
+	build.AddCommands([]plan.Command{
+		plan.NewCopyCommand("."),
+		plan.NewExecCommand(fmt.Sprintf("deno cache %s", p.mainFile)),
+	})
+}
+
+func (p *DenoProvider) InstallMisePackages(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder) {
+	deno := miseStep.Default("deno", DEFAULT_DENO_VERSION)
+
+	if envVersion, varName := ctx.Env.GetConfigVariable("DENO_VERSION"); envVersion != "" {
+		miseStep.Version(deno, envVersion, varName)
+	}
+}
+
+func (p *DenoProvider) findMainFile(ctx *generate.GenerateContext) string {
+	files := []string{"main.ts", "main.js", "main.mjs", "main.mts"}
+	for _, file := range files {
+		if ctx.App.HasMatch(file) {
+			return file
+		}
+	}
+
+	files, err := ctx.App.FindFiles("**/*.{ts,js,mjs,mts}")
+	if err != nil {
+		return ""
+	}
+
+	if len(files) == 0 {
+		return ""
+	}
+
+	return files[0]
+}

--- a/core/providers/deno/deno_test.go
+++ b/core/providers/deno/deno_test.go
@@ -1,0 +1,58 @@
+package deno
+
+import (
+	"testing"
+
+	testingUtils "github.com/railwayapp/railpack/core/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeno(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		detected     bool
+		expectedMain string
+	}{
+		{
+			name:         "deno project with main.ts",
+			path:         "../../../examples/deno-2",
+			detected:     true,
+			expectedMain: "main.ts",
+		},
+		{
+			name:     "non-deno project",
+			path:     "../../../examples/node-npm",
+			detected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testingUtils.CreateGenerateContext(t, tt.path)
+			provider := DenoProvider{}
+
+			detected, err := provider.Detect(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.detected, detected)
+
+			if detected {
+				err = provider.Initialize(ctx)
+				require.NoError(t, err)
+
+				require.Equal(t, tt.expectedMain, provider.mainFile)
+
+				err = provider.Plan(ctx)
+				require.NoError(t, err)
+
+				// Verify start command format
+				if provider.mainFile != "" {
+					expectedCmd := "deno run --allow-all " + provider.mainFile
+					require.Equal(t, expectedCmd, ctx.Deploy.StartCmd)
+				} else {
+					require.Empty(t, ctx.Deploy.StartCmd)
+				}
+			}
+		})
+	}
+}

--- a/core/providers/provider.go
+++ b/core/providers/provider.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"github.com/railwayapp/railpack/core/generate"
+	"github.com/railwayapp/railpack/core/providers/deno"
 	"github.com/railwayapp/railpack/core/providers/golang"
 	"github.com/railwayapp/railpack/core/providers/java"
 	"github.com/railwayapp/railpack/core/providers/node"
@@ -26,6 +27,7 @@ func GetLanguageProviders() []Provider {
 		&golang.GoProvider{},
 		&java.JavaProvider{},
 		&python.PythonProvider{},
+		&deno.DenoProvider{},
 		&node.NodeProvider{},
 		&staticfile.StaticfileProvider{},
 		&shell.ShellProvider{},

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
             { label: "Go", link: "/languages/golang" },
             { label: "Java", link: "/languages/java" },
             { label: "Python", link: "/languages/python" },
+            { label: "Deno", link: "/languages/deno" },
             { label: "Node", link: "/languages/node" },
             { label: "Staticfile", link: "/languages/staticfile" },
             { label: "Shell Scripts", link: "/languages/shell" },

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -15,6 +15,7 @@ the docs for each language that Railpack supports.
 - [PHP](languages/php)
 - [HTML](languages/staticfile)
 - [Java](languages/java)
+- [Deno](languages/deno)
 
 ---
 

--- a/docs/src/content/docs/languages/deno.md
+++ b/docs/src/content/docs/languages/deno.md
@@ -1,0 +1,41 @@
+---
+title: Deno
+description: Building Deno applications with Railpack
+---
+
+Railpack builds and deploys Deno applications with zero configuration.
+
+## Detection
+
+Your project will be detected as a Deno application if a `deno.json` or
+`deno.jsonc` file exists in the root directory.
+
+## Versions
+
+The Deno version is determined in the following order:
+
+- Set via the `RAILPACK_DENO_VERSION` environment variable
+- Defaults to `2`
+
+## Configuration
+
+Railpack builds your Deno application based on your project structure. The build
+process:
+
+- Installs Deno
+- Caches dependencies using `deno cache`
+- Sets up the start command based on your project configuration
+
+The start command is determined by looking for:
+
+1. A `main.ts`, `main.js`, `main.mjs`, or `main.mts` file in the project root
+2. If no main file is found, it will use the first `.ts`, `.js`, `.mjs`, or
+   `.mts` file found in your project
+
+The selected file will be run with `deno run --allow-all`.
+
+### Config Variables
+
+| Variable                | Description               | Example |
+| ----------------------- | ------------------------- | ------- |
+| `RAILPACK_DENO_VERSION` | Override the Deno version | `1.41`  |

--- a/examples/deno-2/deno.jsonc
+++ b/examples/deno-2/deno.jsonc
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "dev": "deno run --watch main.ts"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1"
+  }
+}

--- a/examples/deno-2/main.ts
+++ b/examples/deno-2/main.ts
@@ -1,0 +1,7 @@
+import * as o from "https://deno.land/x/cowsay/mod.ts";
+
+let m = o.say({
+  text: "Hello from Deno",
+});
+
+console.log(m);

--- a/examples/deno-2/main_test.ts
+++ b/examples/deno-2/main_test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "@std/assert";
+import { add } from "./main.ts";
+
+Deno.test(function addTest() {
+  assertEquals(add(2, 3), 5);
+});


### PR DESCRIPTION
Adds a simple deno provider that will

- Run `deno cache ...` at build time
- Start with `deno run --allow-all ...`

https://railpack-docs-railpack-pr-105.up.railway.app/languages/deno
