### PR TITLE
use all secrets for the node install step if there are pre/post scripts

### DIFF
--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -54,6 +54,9 @@ func (p PackageManager) installDependencies(ctx *generate.GenerateContext, packa
 		install.AddCommands([]plan.Command{
 			plan.NewCopyCommand(".", "."),
 		})
+
+		// Use all secrets for the install step if there are any pre/post install scripts
+		install.UseSecrets([]string{"*"})
 	} else {
 		for _, file := range p.SupportingInstallFiles(ctx.App) {
 			install.AddCommands([]plan.Command{


### PR DESCRIPTION
We can't know if any of the pre/post install scripts require variables,
so we add them all.
