### PR TITLE
ensure that the /root/.cache directory exists

### DIFF
--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -68,3 +68,6 @@ ENV MISE_INSTALL_PATH=/usr/local/bin/mise \
 # Copy mise binary from builder
 COPY --from=ghcr.io/railwayapp/railpack-mise:latest /tmp/mise/target/serious/mise /usr/local/bin/
 RUN chmod +x /usr/local/bin/mise
+
+# Make sure the cache directory exists
+RUN mkdir -p /root/.cache


### PR DESCRIPTION
So we can copy it over from the build to runtime image
