### PR TITLE
support specifying install command with env var

### DIFF
--- a/core/config_test.go
+++ b/core/config_test.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/railwayapp/railpack/core/app"
+	"github.com/railwayapp/railpack/core/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateConfigFromEnvironment(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			name:    "empty environment",
+			envVars: map[string]string{},
+			expected: `{
+				"steps": {},
+				"packages": {},
+				"caches": {},
+				"deploy": {}
+			}`,
+		},
+
+		{
+			name: "kitchen sink",
+			envVars: map[string]string{
+				"RAILPACK_INSTALL_CMD":         "npm install",
+				"RAILPACK_BUILD_CMD":           "npm run build",
+				"RAILPACK_START_CMD":           "npm start",
+				"RAILPACK_PACKAGES":            "node@18 python@3.9",
+				"RAILPACK_BUILD_APT_PACKAGES":  "build-essential libssl-dev",
+				"RAILPACK_DEPLOY_APT_PACKAGES": "libssl-dev",
+			},
+			expected: `{
+				"steps": {
+					"install": {
+						"name": "install",
+						"commands": [
+							{ "src": ".", "dest": "." },
+							"npm install"
+						],
+						"secrets": ["*"],
+						"assets": {},
+						"variables": {}
+					},
+					"build": {
+						"name": "build",
+						"commands": [
+							{ "src": ".", "dest": "." },
+							"npm run build"
+						],
+						"secrets": ["*"],
+						"assets": {},
+						"variables": {}
+					}
+				},
+				"buildAptPackages": ["build-essential", "libssl-dev"],
+				"packages": {
+					"node": "18",
+					"python": "3.9"
+				},
+				"caches": {},
+				"deploy": {
+					"startCommand": "npm start",
+					"aptPackages": ["libssl-dev"]
+				},
+				"secrets": ["RAILPACK_BUILD_APT_PACKAGES", "RAILPACK_BUILD_CMD", "RAILPACK_DEPLOY_APT_PACKAGES",
+					"RAILPACK_INSTALL_CMD", "RAILPACK_PACKAGES", "RAILPACK_START_CMD"]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := app.NewEnvironment(&tt.envVars)
+			gotConfig := GenerateConfigFromEnvironment(env)
+
+			serializedConfig := config.Config{}
+			err := json.Unmarshal([]byte(tt.expected), &serializedConfig)
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(serializedConfig, *gotConfig); diff != "" {
+				t.Errorf("GenerateConfigFromEnvironment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/core/core.go
+++ b/core/core.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -113,7 +115,7 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 func GetConfig(app *app.App, env *app.Environment, options *GenerateBuildPlanOptions, logger *logger.Logger) (*c.Config, error) {
 	optionsConfig := GenerateConfigFromOptions(options)
 
-	envConfig := GenerateConfigFromEnvironment(app, env)
+	envConfig := GenerateConfigFromEnvironment(env)
 
 	fileConfig, err := GenerateConfigFromFile(app, env, options, logger)
 	if err != nil {
@@ -158,7 +160,7 @@ func GenerateConfigFromFile(app *app.App, env *app.Environment, options *Generat
 }
 
 // GenerateConfigFromEnvironment generates a config from the environment
-func GenerateConfigFromEnvironment(app *app.App, env *app.Environment) *c.Config {
+func GenerateConfigFromEnvironment(env *app.Environment) *c.Config {
 	config := c.EmptyConfig()
 
 	if env == nil {
@@ -197,9 +199,7 @@ func GenerateConfigFromEnvironment(app *app.App, env *app.Environment) *c.Config
 		config.Deploy.AptPackages = strings.Split(envAptPackages, " ")
 	}
 
-	for name := range env.Variables {
-		config.Secrets = append(config.Secrets, name)
-	}
+	config.Secrets = append(config.Secrets, slices.Sorted(maps.Keys(env.Variables))...)
 
 	return config
 }

--- a/docs/src/content/docs/config/environment-variables.md
+++ b/docs/src/content/docs/config/environment-variables.md
@@ -8,13 +8,14 @@ often prefixed with `RAILPACK_`.
 
 ## Build Configuration
 
-| Name                           | Description                                                                                                |
-| :----------------------------- | :--------------------------------------------------------------------------------------------------------- |
-| `RAILPACK_BUILD_CMD`           | Set the command to run for the build step. This overwrites any commands that come from providers           |
-| `RAILPACK_START_CMD`           | Set the command to run when the container starts                                                           |
-| `RAILPACK_PACKAGES`            | Install additional Mise packages. In the format `pkg@version`. The latest version is used if not provided. |
-| `RAILPACK_BUILD_APT_PACKAGES`  | Install additional Apt packages during build                                                               |
-| `RAILPACK_DEPLOY_APT_PACKAGES` | Install additional Apt packages in the final image                                                         |
+| Name                           | Description                                                                                                                                                                     |
+| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `RAILPACK_BUILD_CMD`           | Set the command to run for the build step. This overwrites any commands that come from providers                                                                                |
+| `RAILPACK_INSTALL_CMD`         | Set the command to run for the install step. This overwrites any commands that come from providers. All files are copied to the root of the project before running the command. |
+| `RAILPACK_START_CMD`           | Set the command to run when the container starts                                                                                                                                |
+| `RAILPACK_PACKAGES`            | Install additional Mise packages. In the format `pkg@version`. The latest version is used if not provided.                                                                      |
+| `RAILPACK_BUILD_APT_PACKAGES`  | Install additional Apt packages during build                                                                                                                                    |
+| `RAILPACK_DEPLOY_APT_PACKAGES` | Install additional Apt packages in the final image                                                                                                                              |
 
 To configure more parts of the build, it is recommended to use a [config file](/config/file).
 


### PR DESCRIPTION
`RAILPACK_INSTALL_CMD` will change the install command being run. One downside is that all local files are copied into the build context which will bust the cache more frequently.

Fixes https://github.com/railwayapp/railpack/issues/111
