### PR TITLE
add single-command local dev setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,17 @@ Please ensure your PRs:
 Note: We prefer focused, well-thought-out contributions over "drive-by" PRs that
 make superficial changes.
 
+## Setup
+
+We use [Mise](https://mise.jdx.dev/) for managing language dependencies and
+tasks for building and testing Railpack.
+
+To set up your local environment, follow these steps:
+
+```bash
+mise run setup
+```
+
 ## Testing
 
 ### Core Tests

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -49,8 +49,7 @@ through the `BUILDKIT_HOST` environment variable. The easiest way to do this is
 to run a BuildKit instance as a container:
 
 ```bash
-docker run --rm --privileged -d --name buildkit moby/buildkit
-export BUILDKIT_HOST=docker-container://buildkit
+mise run setup
 ```
 
 Now you can build your image using Railpack:

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -16,19 +16,13 @@ Install and use all versions of tools needed for Railpack
 
 ```bash
 # Assuming you are cd'd into the repo root
-mise install
-```
-
-Install all the Go dependencies
-
-```bash
-go mod tidy
+mise run setup
 ```
 
 List all the commands available
 
 ```bash
-go run cmd/cli/main.go --help
+mise run cli --help
 ```
 
 ## Building directly with Buildkit
@@ -41,7 +35,7 @@ Railpack will instantiate a BuildKit client and communicate to over GRPC in
 order to build the generated LLB.
 
 ```bash
-go run cmd/cli/main.go --verbose build examples/node-bun
+mise run cli --verbose build examples/node-bun
 ```
 
 You need to have a BuildKit instance running (see below).
@@ -60,7 +54,7 @@ Once you have an image, you can do:
 Generate a build plan for an app:
 
 ```bash
-go run cmd/cli/main.go plan examples/node-bun --out test/railpack-plan.json
+mise run cli plan examples/node-bun --out test/railpack-plan.json
 ```
 
 Build the app with Docker:
@@ -86,19 +80,6 @@ buildctl build \
 _Note the `docker load` here to load the image into Docker. However, you can
 change the [output](https://github.com/moby/buildkit?tab=readme-ov-file#output)
 or push to a registry instead._
-
-## Run BuildKit Locally
-
-If building with the `build` command, you need to have a BuildKit instance
-running with the `BUILDKIT_HOST` environment variable set to the container.
-
-```bash
-# Run a BuildKit instance as a container
-docker run --rm --privileged -d --name buildkit moby/buildkit
-
-# Set the buildkit host to the container
-export BUILDKIT_HOST=docker-container://buildkit
-```
 
 ## Mise commands
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,16 @@
+[env]
+BUILDKIT_HOST = "docker-container://buildkit"
+
+[tasks.setup]
+run = [
+  "mise install",
+  "docker run --rm --privileged -d --name buildkit moby/buildkit || true",
+  "mise run tidy",
+]
+
+[tasks.cli]
+run = "go run cmd/cli/main.go"
+
 [tasks.build]
 run = "go build -o bin/cli cmd/cli/main.go"
 


### PR DESCRIPTION
Ran into an issue where CONTRIBUTING.md was out-of-sync with docs. For ease-of-use, I think we should try to keep local development setup constrained to a single command.

- Adds a default environment variable for `BUILDKIT_HOST` to mise config
- Automatically create the buildkit host or silently fail if it's a duplicate, etc.
- Add shortcut for running the CLI from mise