### PR TITLE
Display error message when unable to read railpack config

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -149,7 +149,7 @@ func GenerateConfigFromFile(app *app.App, env *app.Environment, options *Generat
 	}
 
 	if err := app.ReadJSON(configFileName, config); err != nil {
-		logger.LogWarn("Failed to read config file `%s`\nUse the following schema to validate your config file: %s\n", configFileName, c.SchemaUrl)
+		logger.LogWarn("Failed to read config file `%s`: %s\nUse the following schema to validate your config file: %s\n", configFileName, err.Error(), c.SchemaUrl)
 		return config, nil
 	}
 


### PR DESCRIPTION
The following happened and I don't know what I did wrong, so reporting the failure so the user has more breadcrumbs, even if it's to report the bug to us properly

<img width="518" alt="Captura de Tela 2025-03-26 às 14 01 02" src="https://github.com/user-attachments/assets/39915b67-881a-4143-8bcf-a8caf1d9c251" />
