### PR TITLE
copy over entire app in install if using local dep

### DIFF
--- a/core/providers/node/package_json.go
+++ b/core/providers/node/package_json.go
@@ -2,6 +2,8 @@ package node
 
 import (
 	"encoding/json"
+	"maps"
+	"strings"
 )
 
 type WorkspacesConfig struct {
@@ -49,6 +51,20 @@ func (p *PackageJson) hasDependency(dependency string) bool {
 
 	if p.DevDependencies != nil {
 		if _, ok := p.DevDependencies[dependency]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *PackageJson) hasLocalDependency() bool {
+	allDeps := make(map[string]string)
+	maps.Copy(allDeps, p.Dependencies)
+	maps.Copy(allDeps, p.DevDependencies)
+
+	for _, dependency := range allDeps {
+		if strings.HasPrefix(dependency, "file:") {
 			return true
 		}
 	}


### PR DESCRIPTION
If a `package.json` file in the app uses a local dependency (e.g. `file:...`), we should copy over the entire local context into the build context so it is available at install step.
