### PR TITLE
stop caching `.nuxt` directory

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
@@ -7,10 +7,6 @@
   "npm-install": {
    "directory": "/root/.npm",
    "type": "shared"
-  },
-  "nuxt": {
-   "directory": ".nuxt",
-   "type": "shared"
   }
  },
  "deploy": {
@@ -128,8 +124,7 @@
   },
   {
    "caches": [
-    "node-modules",
-    "nuxt"
+    "node-modules"
    ],
    "commands": [
     {

--- a/core/mise/mise_test.go
+++ b/core/mise/mise_test.go
@@ -88,7 +88,7 @@ func TestMiseGetAllVersions(t *testing.T) {
 			name:     "node all versions",
 			runtime:  "node",
 			version:  "18.20",
-			versions: []string{"18.20.0", "18.20.1", "18.20.2", "18.20.3", "18.20.4", "18.20.5", "18.20.6", "18.20.7"},
+			versions: []string{"18.20.0", "18.20.1", "18.20.2", "18.20.3", "18.20.4", "18.20.5", "18.20.6", "18.20.7", "18.20.8"},
 		},
 		{
 			name:     "bun all versions",

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -207,10 +207,6 @@ func (p *NodeProvider) addCaches(ctx *generate.GenerateContext, build *generate.
 	if p.isVite(ctx) {
 		build.AddCache(p.getViteCache(ctx))
 	}
-
-	if p.isNuxt() {
-		build.AddCache(ctx.Caches.AddCache("nuxt", ".nuxt"))
-	}
 }
 
 func (p *NodeProvider) shouldPrune(ctx *generate.GenerateContext) bool {

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -131,7 +131,7 @@ Including:
 - Astro: Caches `.astro/cache`
 - Nuxt:
   - Start command defaults to `node .output/server/index.mjs`
-  - Caches `.nuxt`
+  - Caches `node_modules/.cache`
 
 As well as a default cache for node modules:
 


### PR DESCRIPTION
This directory sometimes contains files need at install or runtime so cannot be confidentally cached 100% of the time. For now this PR removes that cache. _Note: the `node_modules/.cache` directory is still cached and used for Vite apps._
