### PR TITLE
List all languages on "Getting Started" docs

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -18,6 +18,7 @@ the docs for each language that Railpack supports.
 - [Deno](languages/deno)
 - [Rust](languages/rust)
 - [Ruby](languages/ruby)
+- [Shell scripts](langauges/shell)
 
 ---
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -9,16 +9,15 @@ The easiest way to use Railpack is to deploy on a platform like Railway. Builds
 should work out of the box with minimal configuration. From there, you can see
 the docs for each language that Railpack supports.
 
-- [PHP](languages/php)
-- [Go](languages/golang)
-- [Java](languages/java)
-- [Python](languages/python)
-- [Deno](languages/deno)
-- [Ruby](langauges/ruby)
-- [Rust](languages/rust)
 - [Node](languages/node)
+- [Python](languages/python)
+- [Go](languages/golang)
+- [PHP](languages/php)
 - [HTML](languages/staticfile)
-- [Shell scripts](languages/shell)
+- [Java](languages/java)
+- [Deno](languages/deno)
+- [Rust](languages/rust)
+- [Ruby](languages/ruby)
 
 ---
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -9,13 +9,16 @@ The easiest way to use Railpack is to deploy on a platform like Railway. Builds
 should work out of the box with minimal configuration. From there, you can see
 the docs for each language that Railpack supports.
 
-- [Node](languages/node)
-- [Python](languages/python)
-- [Go](languages/golang)
 - [PHP](languages/php)
-- [HTML](languages/staticfile)
+- [Go](languages/golang)
 - [Java](languages/java)
+- [Python](languages/python)
 - [Deno](languages/deno)
+- [Ruby](langauges/ruby)
+- [Rust](languages/rust)
+- [Node](languages/node)
+- [HTML](languages/staticfile)
+- [Shell scripts](languages/shell)
 
 ---
 


### PR DESCRIPTION
Momentarily got confused on whether Rust was supported since the Getting Started page seemed not to acknowledge the announcement in the recent newsletter that Rust was added.

Properly added every supported language to the list on the Getting Started docs page.