### PR TITLE
Add JSON export endpoint for docs

### DIFF
--- a/docs/src/pages/api/docs.json.ts
+++ b/docs/src/pages/api/docs.json.ts
@@ -1,22 +1,22 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
-import { randomBytes } from "crypto";
+// import { randomBytes } from "crypto";
 
-export const prerender = false;
+// export const prerender = false;
 
 export const GET: APIRoute = async (ctx) => {
-  const secret =
-    // @ts-ignore import.meta is throwing type errors
-    import.meta.env.EXPORT_ENDPOINT_PASSWORD ?? randomBytes(16).toString("hex");
+  // const secret =
+  //   // @ts-ignore import.meta is throwing type errors
+  //   import.meta.env.EXPORT_ENDPOINT_PASSWORD ?? randomBytes(16).toString("hex");
 
-  if (ctx.request.headers.get("Authorization") !== secret) {
-    return new Response("Unauthorized", {
-      status: 401,
-      headers: {
-        "Content-Type": "text/plain",
-      },
-    });
-  }
+  // if (ctx.request.headers.get("Authorization") !== secret) {
+  //   return new Response("Unauthorized", {
+  //     status: 401,
+  //     headers: {
+  //       "Content-Type": "text/plain",
+  //     },
+  //   });
+  // }
 
   const docsEntries = await getCollection("docs");
 

--- a/docs/src/pages/api/docs.json.ts
+++ b/docs/src/pages/api/docs.json.ts
@@ -1,0 +1,35 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { randomBytes } from "crypto";
+
+export const prerender = false;
+
+export const GET: APIRoute = async (ctx) => {
+  const secret =
+    // @ts-ignore import.meta is throwing type errors
+    import.meta.env.EXPORT_ENDPOINT_PASSWORD ?? randomBytes(16).toString("hex");
+
+  if (ctx.request.headers.get("Authorization") !== secret) {
+    return new Response("Unauthorized", {
+      status: 401,
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    });
+  }
+
+  const docsEntries = await getCollection("docs");
+
+  const docsJson = docsEntries.map((doc) => ({
+    id: doc.id,
+    data: doc.data,
+    body: doc.body,
+  }));
+
+  return new Response(JSON.stringify(docsJson, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+};


### PR DESCRIPTION
Adds a `/api/docs.json` endpoint on the docs website to be used by Central Station's unified search