### PR TITLE
Default to PNPM 9

### DIFF
--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -14,6 +14,8 @@ const (
 	PackageManagerBun   PackageManager = "bun"
 	PackageManagerYarn1 PackageManager = "yarn1"
 	PackageManagerYarn2 PackageManager = "yarn2"
+
+	DEFAULT_PNPM_VERSION = "9"
 )
 
 func (p PackageManager) Name() string {
@@ -189,7 +191,7 @@ func (p PackageManager) SupportingInstallFiles(ctx *generate.GenerateContext) []
 func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext, packageJson *PackageJson, packages *generate.MiseStepBuilder) {
 	// Pnpm
 	if p == PackageManagerPnpm {
-		pnpm := packages.Default("pnpm", "latest")
+		pnpm := packages.Default("pnpm", DEFAULT_PNPM_VERSION)
 
 		lockfile, err := ctx.App.ReadFile("pnpm-lock.yaml")
 		if err == nil {


### PR DESCRIPTION
PNPM 10 requires approving which build scripts can run by either using the `pnpm approve-builds` command interactively, or by updating the `pnpm-workspace.yaml` file. To make Railpack work with PNPM generically, this PR defaults to PNPM 9. Users can specify pnpm 10 with the `package.json.packageManager` field.

https://github.com/pnpm/pnpm/issues/9326
