### PR TITLE
Make all secrets available to all commands

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
@@ -15,7 +15,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.4.5-bookworm"
+     "image": "dunglas/frankenphp:php8.4.6-bookworm"
     }
    ],
    "name": "packages:image"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
@@ -14,12 +14,6 @@
     "include": [
      "."
     ],
-    "step": "doesNotUseSecrets"
-   },
-   {
-    "include": [
-     "."
-    ],
     "step": "usesSecrets"
    }
   ],
@@ -62,24 +56,6 @@
    "variables": {
     "NOT_SECRET": "not secret"
    }
-  },
-  {
-   "commands": [
-    {
-     "dest": ".",
-     "src": "."
-    },
-    {
-     "cmd": "sh -c './run.sh true'",
-     "customName": "./run.sh true"
-    }
-   ],
-   "inputs": [
-    {
-     "step": "packages:mise"
-    }
-   ],
-   "name": "doesNotUseSecrets"
   },
   {
    "commands": [

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -45,8 +45,11 @@ Environment variables can be set in two ways:
 ## Secrets
 
 The names of all secrets that should be used during the build are added to the
-top of the build plan. Each step that needs access to secrets must include them
-in its `secrets` field.
+top of the build plan, and each step's `secrets` array specifies which secrets
+should invalidate that step's layer cache when their values change. While all
+secrets are available to every command as environment variables, only the ones
+listed in a step's `secrets` array will trigger a cache invalidation if
+modified.
 
 Under the hood, Railpack uses [BuildKit secrets
 mounts](https://docs.docker.com/build/building/secrets/) to supply an exec

--- a/examples/secrets/railpack.json
+++ b/examples/secrets/railpack.json
@@ -17,11 +17,6 @@
       "variables": {
         "NOT_SECRET": "not secret"
       }
-    },
-
-    "doesNotUseSecrets": {
-      "commands": [{ "src": ".", "dest": "." }, "./run.sh true"],
-      "secrets": []
     }
   },
 

--- a/examples/secrets/run.sh
+++ b/examples/secrets/run.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# cache bust 1
-
-# Check if argument is provided and if it equals "true"
-INVERT_BEHAVIOR=${1:-false}
-
 # List of required secrets
 REQUIRED_SECRETS=(
   "MY_SECRET"
@@ -22,39 +17,25 @@ echo "Checking for required secrets..."
 for secret in "${REQUIRED_SECRETS[@]}"; do
   if [ -z "${!secret}" ]; then
     missing_secrets+=("$secret")
-    if [ "$INVERT_BEHAVIOR" = "true" ]; then
-      echo "✅ Secret not defined (as required): $secret"
-    else
-      echo "❌ Missing secret: $secret"
-    fi
+    echo "❌ Missing secret: $secret"
   else
     defined_secrets+=("$secret")
     # Check if the secret value contains "error"
     if [ "${!secret}" = "error" ]; then
       error_value_secrets+=("$secret")
       echo "❌ Secret $secret contains invalid value 'error'"
-    elif [ "$INVERT_BEHAVIOR" = "true" ]; then
-      echo "❌ Found secret when it should be undefined: $secret"
     else
       echo "✅ Found secret: $secret = ${!secret}"
     fi
   fi
 done
 
-if [ "$INVERT_BEHAVIOR" = "true" ]; then
-  if [ ${#defined_secrets[@]} -ne 0 ]; then
-    echo "Error: Found ${#defined_secrets[@]} secrets when none should be defined"
-    exit 1
-  fi
-  echo "Success: No secrets are defined (as required)"
-else
-  if [ ${#missing_secrets[@]} -ne 0 ]; then
-    echo "Error: Missing ${#missing_secrets[@]} required secrets"
-    exit 1
-  fi
-  if [ ${#error_value_secrets[@]} -ne 0 ]; then
-    echo "Error: ${#error_value_secrets[@]} secrets contain the invalid value 'error'"
-    exit 1
-  fi
-  echo "Success: All required secrets are available and valid"
+if [ ${#missing_secrets[@]} -ne 0 ]; then
+  echo "Error: Missing ${#missing_secrets[@]} required secrets"
+  exit 1
 fi
+if [ ${#error_value_secrets[@]} -ne 0 ]; then
+  echo "Error: ${#error_value_secrets[@]} secrets contain the invalid value 'error'"
+  exit 1
+fi
+echo "Success: All required secrets are available and valid"


### PR DESCRIPTION
Addresses the following issue where some environment variables are not available to all commands. This PR changes that so all secrets are available to all commands, but the step `secrets` array is used to specify what secrets will invalidate the cache when the values change.

https://station.railway.com/feedback/feedback-railpack-409fc7d5#5n04
