### PR TITLE
prefer `python_full_version` in `Pipfile`

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
@@ -15,7 +15,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.4.5-bookworm"
+     "image": "dunglas/frankenphp:php8.4.6-bookworm"
     }
    ],
    "name": "packages:image"


### PR DESCRIPTION
If both `python_version` and `python_full_version` exist in a `Pipfile`, we should prefer getting the version from the full version.
