### PR TITLE
add 404 page in docs `Caddyfile`

### DIFF
--- a/docs/Caddyfile
+++ b/docs/Caddyfile
@@ -49,5 +49,12 @@
 
 	file_server
 
-	try_files {path} {path}.html {path}/index.html /index.html
+	try_files {path} {path}.html {path}/index.html 
+	handle_errors {
+        @404 {
+            expression {http.error.status_code} == 404
+        }
+        rewrite @404 ./404/index.html
+        file_server
+    }
 }

--- a/docs/Caddyfile
+++ b/docs/Caddyfile
@@ -54,7 +54,7 @@
         @404 {
             expression {http.error.status_code} == 404
         }
-        rewrite @404 ./404/index.html
+        rewrite @404 ./404.html
         file_server
     }
 }


### PR DESCRIPTION
## Summary 
Use the dedicated 404 page instead of redirecting to index page on 404 errors.

## Why ?

As of now, when you go on an [nonexistent](https://railpack.com/nonexistent) page in the railpack docs website , you get redirected to the home page, while there is a dedicated 404 page for the website. 

## How ?
- I updated the Caddyfile to show the custom 404 page whenever there is a not found error. 
- I also removed the last `index.html` in the `try_files` instruction as it would always fall back to the index page in that case. this is actually good for SPAs, but the docs website is not a SPA.
