### PR TITLE
handle short node workspace patterns

### DIFF
--- a/core/providers/node/workspace.go
+++ b/core/providers/node/workspace.go
@@ -88,13 +88,16 @@ func convertWorkspacePattern(pattern string) string {
 	// npm/pnpm uses packages/* or packages/** for glob patterns
 	// - packages/* -> packages/*/package.json (single level)
 	// - packages/** -> packages/**/package.json (recursive)
-	if pattern[len(pattern)-2:] == "/*" {
+	if len(pattern) >= 2 && pattern[len(pattern)-2:] == "/*" {
 		// Single level pattern (packages/*)
 		return pattern[:len(pattern)-1] + "*/package.json"
-	} else if pattern[len(pattern)-3:] == "/**" {
+	}
+
+	if len(pattern) >= 3 && pattern[len(pattern)-3:] == "/**" {
 		// Recursive pattern (packages/**)
 		return pattern[:len(pattern)-2] + "**/package.json"
 	}
+
 	// Direct path or other pattern, just append package.json
 	return filepath.Join(pattern, "package.json")
 }

--- a/core/providers/node/workspace_test.go
+++ b/core/providers/node/workspace_test.go
@@ -82,6 +82,26 @@ func TestConvertWorkspacePattern(t *testing.T) {
 			pattern:  "packages/foo/package.json",
 			expected: "packages/foo/package.json/package.json",
 		},
+		{
+			name:     "very short pattern",
+			pattern:  "db",
+			expected: "db/package.json",
+		},
+		{
+			name:     "single character pattern",
+			pattern:  "a",
+			expected: "a/package.json",
+		},
+		{
+			name:     "empty pattern",
+			pattern:  "",
+			expected: "package.json",
+		},
+		{
+			name:     "pattern ending with slash",
+			pattern:  "apps/",
+			expected: "apps/package.json",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix out of bounds panic when workspace name is <2 chars

Fixes https://github.com/railwayapp/railpack/issues/144
