### PR TITLE
Fix docker buildx example: add missing build and correct image reference

### DIFF
--- a/docs/src/content/docs/guides/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/guides/running-railpack-in-production.mdx
@@ -48,7 +48,7 @@ enabled. Pass the path to the build plan file with the `-f` flag (it does not
 need to be in the same directory as the app being built).
 
 ```sh
-docker buildx \
+docker buildx build \
   --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack:railpack-frontend" \
   -f /path/to/railpack-plan.json \
   /path/to/app/to/build

--- a/docs/src/content/docs/guides/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/guides/running-railpack-in-production.mdx
@@ -49,7 +49,7 @@ need to be in the same directory as the app being built).
 
 ```sh
 docker buildx build \
-  --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack:railpack-frontend" \
+  --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend" \
   -f /path/to/railpack-plan.json \
   /path/to/app/to/build
 ```


### PR DESCRIPTION
This pull request fixes two issues in the docker buildx command example:
	1.	Adds the missing `build` subcommand to ensure the command is valid.
	2.	Corrects the image reference from ghcr.io/railwayapp/railpack:railpack-frontend to ghcr.io/railwayapp/railpack-frontend.

Please let me know if any changes are needed. Thank you!