### PR TITLE
Reorder mise package version detection for Elixir

### DIFF
--- a/core/providers/elixir/elixir.go
+++ b/core/providers/elixir/elixir.go
@@ -115,22 +115,21 @@ var elixirVersionRegex = regexp.MustCompile(`(elixir:[\s].*[> ])([\w|\.]*)`)
 func (p *ElixirProvider) InstallMisePackages(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder) {
 	elixir := miseStep.Default("elixir", DEFAULT_ELIXIR_VERSION)
 
-	if envVersion, varName := ctx.Env.GetConfigVariable("ELIXIR_VERSION"); envVersion != "" {
-		miseStep.Version(elixir, envVersion, varName)
+	if mixExs, err := ctx.App.ReadFile("mix.exs"); err == nil {
+		if match := elixirVersionRegex.FindStringSubmatch(mixExs); len(match) > 2 {
+			version := utils.ExtractSemverVersion(match[2])
+			if version != "" {
+				miseStep.Version(elixir, version, "mix.exs")
+			}
+		}
 	}
 
 	if versionFile, err := ctx.App.ReadFile(".elixir-version"); err == nil {
 		miseStep.Version(elixir, strings.TrimSpace(string(versionFile)), ".elixir-version")
 	}
 
-	if mixExs, err := ctx.App.ReadFile("mix.exs"); err == nil {
-		if match := elixirVersionRegex.FindStringSubmatch(mixExs); len(match) > 2 {
-			version := utils.ExtractSemverVersion(match[2])
-			if version != "" {
-				fmt.Println("mix.exs", version)
-				miseStep.Version(elixir, version, "mix.exs")
-			}
-		}
+	if envVersion, varName := ctx.Env.GetConfigVariable("ELIXIR_VERSION"); envVersion != "" {
+		miseStep.Version(elixir, envVersion, varName)
 	}
 
 	pkgs, err := miseStep.Resolver.ResolvePackages()
@@ -148,14 +147,6 @@ func (p *ElixirProvider) InstallMisePackages(ctx *generate.GenerateContext, mise
 		miseStep.Version(erlang, compatibleErlangVersion, "default compatible OTP version")
 	}
 
-	if envVersion, varName := ctx.Env.GetConfigVariable("ERLANG_VERSION"); envVersion != "" {
-		miseStep.Version(erlang, envVersion, varName)
-	}
-
-	if versionFile, err := ctx.App.ReadFile(".erlang-version"); err == nil {
-		miseStep.Version(erlang, strings.TrimSpace(string(versionFile)), ".erlang-version")
-	}
-
 	versionParts := strings.Split(elixirVersion, "-otp-")
 	if len(versionParts) > 1 {
 		otpVersion := versionParts[1]
@@ -163,6 +154,14 @@ func (p *ElixirProvider) InstallMisePackages(ctx *generate.GenerateContext, mise
 		if _, err := utils.ParseSemver(otpSemverVersion); err == nil {
 			miseStep.Version(erlang, otpSemverVersion, "resolved compatible OTP version")
 		}
+	}
+
+	if versionFile, err := ctx.App.ReadFile(".erlang-version"); err == nil {
+		miseStep.Version(erlang, strings.TrimSpace(string(versionFile)), ".erlang-version")
+	}
+
+	if envVersion, varName := ctx.Env.GetConfigVariable("ERLANG_VERSION"); envVersion != "" {
+		miseStep.Version(erlang, envVersion, varName)
 	}
 }
 


### PR DESCRIPTION
When detecting which version of Elixir & Erlang to install, it _seemed_ like the order was reversed. I would expect an explicit environment variable to have the highest priority, then `.elixir-version`, and finally falling back to `mix.exs` or the default as a last resort. Instead, it would always use the value in `mix.exs` if available, since the last call to `.Version` wins.

I say "seemed" because I notice that most providers have this potentially incorrect ordering. At a glance, `gradle`, `node`, `python`, `ruby`, and `rust` all do not treat the environment variable as highest priority. If this PR is merged it may warrant addressing those providers as well, but I did not have confidence in my ability to choose the correct ordering for those ecosystems.