### PR TITLE
Run mix assets.setup if it exists

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
@@ -85,6 +85,9 @@
     },
     {
      "cmd": "mix deps.compile"
+    },
+    {
+     "cmd": "mix assets.setup"
     }
    ],
    "inputs": [

--- a/core/providers/elixir/elixir.go
+++ b/core/providers/elixir/elixir.go
@@ -86,6 +86,9 @@ func (p *ElixirProvider) Install(ctx *generate.GenerateContext, install *generat
 		plan.NewCopyCommand("config/prod.exs*", "config/"),
 		plan.NewExecCommand("mix deps.compile"),
 	})
+	if matches := ctx.App.FindFilesWithContent("mix.exs", regexp.MustCompile(`assets\.setup`)); len(matches) > 0 {
+		install.AddCommand(plan.NewExecCommand("mix assets.setup"))
+	}
 	return []string{"deps", "_build", "config", "mix.exs", "mix.lock", MIX_ROOT}
 }
 

--- a/docs/src/content/docs/languages/elixir.md
+++ b/docs/src/content/docs/languages/elixir.md
@@ -30,6 +30,7 @@ Railpack builds your Elixir application based on your project structure. The bui
 
 - Installs Elixir and Erlang
 - Gets and compiles dependencies using `mix deps.get --only prod` and `mix deps.compile`
+- If defined, prepares assets using `mix assets.setup`
 - If defined, deploys assets and ecto using `mix assets.deploy` and `mix ecto.deploy`
 - Compiles a release for the project using `mix compile` and `mix release`
 - Sets up the start command from your release binary


### PR DESCRIPTION
By running `mix assets.setup` in the install step it can better use the cache, rather than waiting until `mix assets.deploy` is called in the build step.