### PR TITLE
update caddy version in snapshots

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
@@ -135,7 +135,7 @@
   {
    "commands": [
     {
-     "cmd": "mise install-into caddy@2.9.1 /railpack/caddy"
+     "cmd": "mise install-into caddy@2.10.0 /railpack/caddy"
     },
     {
      "path": "/railpack/caddy"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
@@ -140,7 +140,7 @@
   {
    "commands": [
     {
-     "cmd": "mise install-into caddy@2.9.1 /railpack/caddy"
+     "cmd": "mise install-into caddy@2.10.0 /railpack/caddy"
     },
     {
      "path": "/railpack/caddy"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
@@ -135,7 +135,7 @@
   {
    "commands": [
     {
-     "cmd": "mise install-into caddy@2.9.1 /railpack/caddy"
+     "cmd": "mise install-into caddy@2.10.0 /railpack/caddy"
     },
     {
      "path": "/railpack/caddy"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
@@ -140,7 +140,7 @@
   {
    "commands": [
     {
-     "cmd": "mise install-into caddy@2.9.1 /railpack/caddy"
+     "cmd": "mise install-into caddy@2.10.0 /railpack/caddy"
     },
     {
      "path": "/railpack/caddy"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
@@ -140,7 +140,7 @@
   {
    "commands": [
     {
-     "cmd": "mise install-into caddy@2.9.1 /railpack/caddy"
+     "cmd": "mise install-into caddy@2.10.0 /railpack/caddy"
     },
     {
      "path": "/railpack/caddy"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -166,7 +166,7 @@
   {
    "commands": [
     {
-     "cmd": "mise install-into caddy@2.9.1 /railpack/caddy"
+     "cmd": "mise install-into caddy@2.10.0 /railpack/caddy"
     },
     {
      "path": "/railpack/caddy"


### PR DESCRIPTION
The latest version of caddy has changed which breaks the snapshot tests. We probably don't want to be failing the tests in this case, but this fixes them for now.
