### PR TITLE
Copy rel/ folder for elixir releases

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
@@ -126,6 +126,10 @@
      "src": "config/runtime.exs*"
     },
     {
+     "dest": ".",
+     "src": "rel*"
+    },
+    {
      "cmd": "mix release"
     }
    ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
@@ -129,6 +129,10 @@
      "src": "config/runtime.exs*"
     },
     {
+     "dest": ".",
+     "src": "rel*"
+    },
+    {
      "cmd": "mix release"
     }
    ],

--- a/core/providers/elixir/elixir.go
+++ b/core/providers/elixir/elixir.go
@@ -104,6 +104,7 @@ func (p *ElixirProvider) Build(ctx *generate.GenerateContext, build *generate.Co
 	build.AddCommands([]plan.Command{
 		plan.NewExecCommand("mix compile"),
 		plan.NewCopyCommand("config/runtime.exs*", "config/"),
+		plan.NewCopyCommand("rel*", "."),
 		plan.NewExecCommand("mix release"),
 	})
 


### PR DESCRIPTION
The `rel` folder is used by Elixir `mix release` to allow developers to specify runtime configuration options when the release is run. Specifically this is important to allow clustering to work on Railway.