### PR TITLE
No secrets for Elixir install step

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
@@ -93,9 +93,6 @@
     }
    ],
    "name": "install",
-   "secrets": [
-    "*"
-   ],
    "variables": {
     "ELIXIR_ERL_OPTIONS": "+fnu",
     "LANG": "en_US.UTF-8",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
@@ -96,9 +96,6 @@
     }
    ],
    "name": "install",
-   "secrets": [
-    "*"
-   ],
    "variables": {
     "ELIXIR_ERL_OPTIONS": "+fnu",
     "LANG": "en_US.UTF-8",

--- a/core/providers/elixir/elixir.go
+++ b/core/providers/elixir/elixir.go
@@ -43,6 +43,7 @@ func (p *ElixirProvider) Plan(ctx *generate.GenerateContext) error {
 
 	install := ctx.NewCommandStep("install")
 	install.AddInput(plan.NewStepLayer(miseStep.Name()))
+	install.Secrets = []string{}
 	installOutputPaths := p.Install(ctx, install)
 	maps.Copy(install.Variables, p.GetEnvVars(ctx))
 


### PR DESCRIPTION
As far as I'm aware, there are no useful environment variables that can be set when installing dependencies for an Elixir app. Technically, [Mix does accept some](https://hexdocs.pm/mix/Mix.html#module-environment-variables) but they are to configure paths when building, which don't make sense for users to override when building inside Railpack.

By removing all secrets we ensure the cache won't get busted, significantly speeding up builds.