### PR TITLE
Mise github token

### DIFF
--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -34,6 +34,7 @@ type BuildWithBuildkitClientOptions struct {
 	ImportCache  string
 	ExportCache  string
 	CacheKey     string
+	GitHubToken  string
 }
 
 func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWithBuildkitClientOptions) error {
@@ -73,6 +74,7 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 		BuildPlatform: buildPlatform,
 		SecretsHash:   opts.SecretsHash,
 		CacheKey:      opts.CacheKey,
+		GitHubToken:   opts.GitHubToken,
 	})
 	if err != nil {
 		return fmt.Errorf("error converting plan to LLB: %w", err)

--- a/buildkit/convert.go
+++ b/buildkit/convert.go
@@ -15,9 +15,18 @@ import (
 
 type ConvertPlanOptions struct {
 	BuildPlatform BuildPlatform
-	SecretsHash   string
-	CacheKey      string
-	SessionID     string
+
+	// Hash of all the secrets values that can be used to invalidate the layer cache when a secret changes
+	SecretsHash string
+
+	// Unique value prepended to all cache mount keys
+	CacheKey string
+
+	// BuildKit session ID
+	SessionID string
+
+	// Token used to make authenticated API requests to GitHub to increase rate limits
+	GitHubToken string
 }
 
 const (
@@ -35,7 +44,7 @@ func ConvertPlanToLLB(plan *p.BuildPlan, opts ConvertPlanOptions) (*llb.State, *
 	)
 
 	cacheStore := build_llb.NewBuildKitCacheStore(opts.CacheKey)
-	graph, err := build_llb.NewBuildGraph(plan, &localState, cacheStore, opts.SecretsHash, &platform)
+	graph, err := build_llb.NewBuildGraph(plan, &localState, cacheStore, opts.SecretsHash, &platform, opts.GitHubToken)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildkit/frontend.go
+++ b/buildkit/frontend.go
@@ -28,6 +28,8 @@ const (
 	secretsHash = "secrets-hash"
 
 	cacheKey = "cache-key"
+
+	githubToken = "github-token"
 )
 
 func StartFrontend() {
@@ -46,6 +48,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 
 	cacheKey := buildArgs[cacheKey]
 	secretsHash := buildArgs[secretsHash]
+	githubToken := buildArgs[githubToken]
 
 	// TODO: Support building for multiple platforms
 	buildPlatform, err := validatePlatform(opts)
@@ -68,6 +71,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		SecretsHash:   secretsHash,
 		CacheKey:      cacheKey,
 		SessionID:     c.BuildOpts().SessionID,
+		GitHubToken:   githubToken,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error converting plan to LLB: %w", err)

--- a/cli/build.go
+++ b/cli/build.go
@@ -61,12 +61,12 @@ var BuildCommand = &cli.Command{
 			return nil
 		}
 
-		serializedPlan, err := json.MarshalIndent(buildResult.Plan, "", "  ")
-		if err != nil {
-			return cli.Exit(err, 1)
-		}
-
 		if cmd.Bool("show-plan") {
+			serializedPlan, err := json.MarshalIndent(buildResult.Plan, "", "  ")
+			if err != nil {
+				return cli.Exit(err, 1)
+			}
+
 			fmt.Println(string(serializedPlan))
 		}
 
@@ -91,6 +91,7 @@ var BuildCommand = &cli.Command{
 			SecretsHash:  secretsHash,
 			Secrets:      env.Variables,
 			Platform:     platform,
+			GitHubToken:  os.Getenv("GITHUB_TOKEN"),
 		})
 		if err != nil {
 			return cli.Exit(err, 1)

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	MisePackageStepName = "packages:mise"
+	MiseInstallCommand  = "sh -c 'mise trust -a && mise install'"
 )
 
 type MiseStepBuilder struct {
@@ -174,7 +175,7 @@ func (b *MiseStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) er
 			plan.NewFileCommand("/etc/mise/config.toml", "mise.toml", plan.FileOptions{
 				CustomName: "create mise config",
 			}),
-			plan.NewExecCommand("sh -c 'mise trust -a && mise install'", plan.ExecOptions{
+			plan.NewExecCommand(MiseInstallCommand, plan.ExecOptions{
 				CustomName: "install mise packages: " + strings.Join(pkgNames, ", "),
 			}),
 		})

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -20,8 +20,9 @@ const (
 )
 
 type Mise struct {
-	binaryPath string
-	cacheDir   string
+	binaryPath  string
+	cacheDir    string
+	githubToken string
 }
 
 const (
@@ -34,9 +35,12 @@ func New(cacheDir string) (*Mise, error) {
 		return nil, fmt.Errorf("failed to ensure mise is installed: %w", err)
 	}
 
+	githubToken := os.Getenv("GITHUB_TOKEN")
+
 	return &Mise{
-		binaryPath: binaryPath,
-		cacheDir:   cacheDir,
+		binaryPath:  binaryPath,
+		cacheDir:    cacheDir,
+		githubToken: githubToken,
 	}, nil
 }
 
@@ -113,6 +117,10 @@ func (m *Mise) runCmd(args ...string) (string, error) {
 		"MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=120s",
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	)
+
+	if m.githubToken != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GITHUB_TOKEN=%s", m.githubToken))
+	}
 
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("failed to run mise command '%s': %w\n%s\n\n%s",


### PR DESCRIPTION
Ability to pass a GitHub token to the `mise install` command to increase rate limits.

The token passed should not be considered secure as the user of railpack can craft build plans to get the token.

Todo

- [ ] Update docs
