### PR TITLE
check all workspace package jsons when deciding if we should copy all files into install step

### DIFF
--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -232,7 +232,7 @@ func (p *NodeProvider) InstallNodeDeps(ctx *generate.GenerateContext, install *g
 		})
 	}
 
-	p.packageManager.installDependencies(ctx, p.packageJson, install)
+	p.packageManager.installDependencies(ctx, p.workspace, install)
 }
 
 func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder) {

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -44,11 +44,20 @@ func (p PackageManager) RunScriptCommand(cmd string) string {
 	return "node " + cmd
 }
 
-func (p PackageManager) installDependencies(ctx *generate.GenerateContext, packageJson *PackageJson, install *generate.CommandStepBuilder) {
-	hasPreInstall := packageJson.Scripts != nil && packageJson.Scripts["preinstall"] != ""
-	hasPostInstall := packageJson.Scripts != nil && packageJson.Scripts["postinstall"] != ""
-	hasPrepare := packageJson.Scripts != nil && packageJson.Scripts["prepare"] != ""
-	usesLocalFile := p.usesLocalFile(ctx)
+func (p PackageManager) installDependencies(ctx *generate.GenerateContext, workspace *Workspace, install *generate.CommandStepBuilder) {
+	packageJsons := workspace.AllPackageJson()
+
+	hasPreInstall := false
+	hasPostInstall := false
+	hasPrepare := false
+	usesLocalFile := false
+
+	for _, packageJson := range packageJsons {
+		hasPreInstall = hasPreInstall || (packageJson.Scripts != nil && packageJson.Scripts["preinstall"] != "")
+		hasPostInstall = hasPostInstall || (packageJson.Scripts != nil && packageJson.Scripts["postinstall"] != "")
+		hasPrepare = hasPrepare || (packageJson.Scripts != nil && packageJson.Scripts["prepare"] != "")
+		usesLocalFile = usesLocalFile || p.usesLocalFile(ctx)
+	}
 
 	// If there are any pre/post install scripts, we need the entire app to be copied
 	// This is to handle things like patch-package

--- a/core/providers/node/workspace.go
+++ b/core/providers/node/workspace.go
@@ -139,3 +139,13 @@ func (w *Workspace) HasDependency(dependency string) bool {
 
 	return false
 }
+
+func (w *Workspace) AllPackageJson() []*PackageJson {
+	packageJsons := []*PackageJson{w.PackageJson}
+
+	for _, pkg := range w.Packages {
+		packageJsons = append(packageJsons, pkg.PackageJson)
+	}
+
+	return packageJsons
+}

--- a/core/providers/node/workspace_test.go
+++ b/core/providers/node/workspace_test.go
@@ -111,3 +111,38 @@ func TestConvertWorkspacePattern(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkspaceAllPackageJson(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		numExpected int
+	}{
+		{
+			name:        "npm workspaces",
+			path:        "../../../examples/node-npm-workspaces",
+			numExpected: 3,
+		},
+		{
+			name:        "pnpm workspaces",
+			path:        "../../../examples/node-pnpm-workspaces",
+			numExpected: 3,
+		},
+		{
+			name:        "no workspaces",
+			path:        "../../../examples/node-npm",
+			numExpected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testingUtils.CreateGenerateContext(t, tt.path)
+			workspace, err := NewWorkspace(ctx.App)
+			require.NoError(t, err)
+
+			all := workspace.AllPackageJson()
+			require.Equal(t, tt.numExpected, len(all))
+		})
+	}
+}


### PR DESCRIPTION
If there are pre/post install scripts in any of the package.json files, we should copy the entire app into the build context for the install step so that those scripts can successfully run.

Fixes https://github.com/railwayapp/railpack/issues/143
