### PR TITLE
update mise to 2025.6.1

### DIFF
--- a/core/mise/install.go
+++ b/core/mise/install.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	miseVersion       = "2025.5.8"
+	miseVersion       = "2025.6.1"
 	githubReleaseBase = "https://github.com/jdx/mise/releases/download"
 )
 


### PR DESCRIPTION
https://github.com/jdx/mise/releases/tag/v2025.6.1
