### PR TITLE
Go workspace support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,6 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Go workspace file
-go.work
-
 node_modules
 
 # End of https://www.toptal.com/developers/gitignore/api/go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,4 +37,4 @@ with support for Node, Python, Go, PHP, and more.
 # Workflow
 
 - Be sure to run `mise run check` when you're done making code changes
-- Prefer running focused tests over the full test suite for performance
+- Don't run tests manually unless instructed to do so

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
@@ -1,0 +1,144 @@
+{
+ "caches": {
+  "apt": {
+   "directory": "/var/cache/apt",
+   "type": "locked"
+  },
+  "apt-lists": {
+   "directory": "/var/lib/apt/lists",
+   "type": "locked"
+  },
+  "go-build": {
+   "directory": "/root/.cache/go-build",
+   "type": "shared"
+  }
+ },
+ "deploy": {
+  "base": {
+   "step": "packages:apt:runtime"
+  },
+  "inputs": [
+   {
+    "include": [
+     "."
+    ],
+    "step": "build"
+   }
+  ],
+  "startCommand": "./out"
+ },
+ "steps": [
+  {
+   "assets": {
+    "mise.toml": "[mise.toml]"
+   },
+   "commands": [
+    {
+     "path": "/mise/shims"
+    },
+    {
+     "customName": "create mise config",
+     "name": "mise.toml",
+     "path": "/etc/mise/config.toml"
+    },
+    {
+     "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
+     "customName": "install mise packages: go"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
+    }
+   ],
+   "name": "packages:mise",
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
+  },
+  {
+   "caches": [
+    "go-build"
+   ],
+   "commands": [
+    {
+     "path": "/go/bin"
+    },
+    {
+     "dest": "go.work",
+     "src": "go.work"
+    },
+    {
+     "dest": "api/go.mod",
+     "src": "api/go.mod"
+    },
+    {
+     "dest": "shared/go.mod",
+     "src": "shared/go.mod"
+    },
+    {
+     "cmd": "go mod download"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    }
+   ],
+   "name": "install",
+   "secrets": [
+    "*"
+   ],
+   "variables": {
+    "CGO_ENABLED": "0",
+    "GOBIN": "/go/bin",
+    "GOPATH": "/go"
+   }
+  },
+  {
+   "caches": [
+    "go-build"
+   ],
+   "commands": [
+    {
+     "dest": ".",
+     "src": "."
+    },
+    {
+     "cmd": "go build -ldflags=\"-w -s\" -o out ./api"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "install"
+    }
+   ],
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
+  },
+  {
+   "caches": [
+    "apt",
+    "apt-lists"
+   ],
+   "commands": [
+    {
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y tzdata'",
+     "customName": "install apt packages: tzdata"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:latest"
+    }
+   ],
+   "name": "packages:apt:runtime"
+  }
+ ]
+}

--- a/core/providers/golang/golang_test.go
+++ b/core/providers/golang/golang_test.go
@@ -9,12 +9,13 @@ import (
 
 func TestGolang(t *testing.T) {
 	tests := []struct {
-		name       string
-		path       string
-		detected   bool
-		hasGoMod   bool
-		goVersion  string
-		cgoEnabled bool
+		name         string
+		path         string
+		detected     bool
+		hasGoMod     bool
+		hasWorkspace bool
+		goVersion    string
+		cgoEnabled   bool
 	}{
 		{
 			name:      "go mod",
@@ -29,6 +30,14 @@ func TestGolang(t *testing.T) {
 			detected:  true,
 			hasGoMod:  true,
 			goVersion: "1.18",
+		},
+		{
+			name:         "go workspaces",
+			path:         "../../../examples/go-workspaces",
+			detected:     true,
+			hasGoMod:     false,
+			hasWorkspace: true,
+			goVersion:    "1.23",
 		},
 		{
 			name:     "node",
@@ -53,11 +62,17 @@ func TestGolang(t *testing.T) {
 				require.NoError(t, err)
 
 				require.Equal(t, tt.hasGoMod, provider.isGoMod(ctx))
+				require.Equal(t, tt.hasWorkspace, provider.isGoWorkspace(ctx))
 				require.Equal(t, tt.cgoEnabled, provider.hasCGOEnabled(ctx))
 
 				if tt.goVersion != "" {
 					goVersion := ctx.Resolver.Get("go")
 					require.Equal(t, tt.goVersion, goVersion.Version)
+				}
+
+				if tt.hasWorkspace {
+					packages := provider.GoWorkspacePackages(ctx)
+					require.Greater(t, len(packages), 0, "workspace should have at least one package")
 				}
 			}
 		})

--- a/docs/src/content/docs/languages/golang.md
+++ b/docs/src/content/docs/languages/golang.md
@@ -11,6 +11,7 @@ Your project will be detected as a Go application if any of these conditions are
 met:
 
 - A `go.mod` file exists in the root directory
+- A `go.work` file exists in the root directory (Go workspaces)
 - A `main.go` file exists in the root directory
 
 ## Versions
@@ -32,18 +33,48 @@ process:
 
 Railpack determines the main package to build in the following order:
 
-1. The package specified by the `RAILPACK_GO_BIN` environment variable
-2. The root directory if it contains Go files
-3. The first subdirectory in the `cmd/` directory
-4. The `main.go` file in the root directory
+1. The module specified by the `RAILPACK_GO_WORKSPACE_MODULE` environment variable (for workspaces)
+2. The package specified by the `RAILPACK_GO_BIN` environment variable
+3. The root directory if it contains Go files
+4. The first subdirectory in the `cmd/` directory
+5. For workspaces: the first module containing a `main.go` file
+6. The `main.go` file in the root directory
 
 ### Config Variables
 
-| Variable              | Description                                  | Example  |
-| --------------------- | -------------------------------------------- | -------- |
-| `RAILPACK_GO_VERSION` | Override the Go version                      | `1.22`   |
-| `RAILPACK_GO_BIN`     | Specify which command in cmd/ to build       | `server` |
-| `CGO_ENABLED`         | Enable CGO for non-static binary compilation | `1`      |
+| Variable                       | Description                                  | Example  |
+| ------------------------------ | -------------------------------------------- | -------- |
+| `RAILPACK_GO_VERSION`          | Override the Go version                      | `1.22`   |
+| `RAILPACK_GO_BIN`              | Specify which command in cmd/ to build       | `server` |
+| `RAILPACK_GO_WORKSPACE_MODULE` | Specify which workspace module to build      | `api`    |
+| `CGO_ENABLED`                  | Enable CGO for non-static binary compilation | `1`      |
+
+### Go Workspaces
+
+Railpack supports Go workspaces (introduced in Go 1.18) for multi-module projects:
+
+- Detects projects with a `go.work` file at the root
+- Automatically discovers and copies all module dependencies
+- Builds the first module with a `main.go` file by default
+- Use `RAILPACK_GO_WORKSPACE_MODULE` to specify which module to build
+
+Example workspace structure:
+
+```
+├── go.work
+├── api/
+│   ├── go.mod
+│   └── main.go
+└── shared/
+    ├── go.mod
+    └── lib.go
+```
+
+To build a specific module:
+
+```bash
+RAILPACK_GO_WORKSPACE_MODULE=api railpack build
+```
 
 ### CGO Support
 

--- a/examples/go-workspaces/api/go.mod
+++ b/examples/go-workspaces/api/go.mod
@@ -1,0 +1,3 @@
+module example.com/api
+
+go 1.23

--- a/examples/go-workspaces/api/main.go
+++ b/examples/go-workspaces/api/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("This is the api")
+}

--- a/examples/go-workspaces/go.work
+++ b/examples/go-workspaces/go.work
@@ -1,0 +1,6 @@
+go 1.23
+
+use (
+	./api
+	./shared
+)

--- a/examples/go-workspaces/shared/go.mod
+++ b/examples/go-workspaces/shared/go.mod
@@ -1,0 +1,3 @@
+module example.com/shared
+
+go 1.23

--- a/examples/go-workspaces/shared/shared.go
+++ b/examples/go-workspaces/shared/shared.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("This is the shared package")
+}


### PR DESCRIPTION
- Add support for Go workspaces (go.work files)
- Automatically discover and build modules in workspace projects
- Support GO_WORKSPACE_MODULE environment variable for explicit module selection
