### PR TITLE
elixir use secrets with prefix

### DIFF
--- a/core/providers/elixir/elixir.go
+++ b/core/providers/elixir/elixir.go
@@ -44,6 +44,7 @@ func (p *ElixirProvider) Plan(ctx *generate.GenerateContext) error {
 	install := ctx.NewCommandStep("install")
 	install.AddInput(plan.NewStepLayer(miseStep.Name()))
 	install.Secrets = []string{}
+	install.UseSecretsWithPrefixes([]string{"MIX", "ERL", "ELIXIR", "OTP"})
 	installOutputPaths := p.Install(ctx, install)
 	maps.Copy(install.Variables, p.GetEnvVars(ctx))
 


### PR DESCRIPTION
Follow up to https://github.com/railwayapp/railpack/pull/157. Ensure install cache is busted when any `MIX*` et al. secrets change.
