### PR TITLE
Skip pnpm mise install if using corepack

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -68,7 +68,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node, pnpm"
+     "customName": "install mise packages: node"
     }
    ],
    "inputs": [

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -80,6 +80,10 @@ func (b *MiseStepBuilder) Version(name resolver.PackageRef, version string, sour
 	b.Resolver.Version(name, version, source)
 }
 
+func (b *MiseStepBuilder) SkipMiseInstall(name resolver.PackageRef) {
+	b.Resolver.SetSkipMiseInstall(name, true)
+}
+
 func (b *MiseStepBuilder) Name() string {
 	return b.DisplayName
 }
@@ -153,7 +157,8 @@ func (b *MiseStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) er
 		packagesToInstall := make(map[string]string)
 		for _, pkg := range b.MisePackages {
 			resolved, ok := options.ResolvedPackages[pkg.Name]
-			if ok && resolved.ResolvedVersion != nil {
+
+			if ok && resolved.ResolvedVersion != nil && !b.Resolver.Get(pkg.Name).SkipMiseInstall {
 				packagesToInstall[pkg.Name] = *resolved.ResolvedVersion
 			}
 		}

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -239,7 +239,7 @@ func (p *NodeProvider) InstallNodeDeps(ctx *generate.GenerateContext, install *g
 		install.AddVariables(map[string]string{
 			"COREPACK_HOME": COREPACK_HOME,
 		})
-		ctx.Logger.LogInfo("Using Corepack")
+		ctx.Logger.LogInfo("Installing %s with Corepack", p.packageManager)
 
 		install.AddCommands([]plan.Command{
 			plan.NewCopyCommand("package.json"),

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -220,6 +220,9 @@ func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext,
 		name, version := p.parsePackageManagerField(packageJson)
 		if name == "pnpm" && version != "" {
 			packages.Version(pnpm, version, "package.json > packageManager")
+
+			// We want to skip installing with Mise and just install with corepack instead
+			packages.SkipMiseInstall(pnpm)
 		}
 	}
 

--- a/core/resolver/resolver.go
+++ b/core/resolver/resolver.go
@@ -19,10 +19,16 @@ type Resolver struct {
 }
 
 type RequestedPackage struct {
-	Name               string
-	Version            string
-	Source             string
+	Name    string
+	Version string
+	Source  string
+
+	// If set, the resolver will use this function to determine if a version is available
 	IsVersionAvailable func(version string) bool
+
+	// If true, the package will not be installed with mise
+	// but the version will still be resolved and displayed in the output
+	SkipMiseInstall bool
 }
 
 type ResolvedPackage struct {
@@ -140,4 +146,8 @@ func (r *Resolver) SetPreviousVersion(name, version string) {
 
 func (r *Resolver) SetVersionAvailable(ref PackageRef, isVersionAvailable func(version string) bool) {
 	r.packages[ref.Name].IsVersionAvailable = isVersionAvailable
+}
+
+func (r *Resolver) SetSkipMiseInstall(ref PackageRef, skipMiseInstall bool) {
+	r.packages[ref.Name].SkipMiseInstall = skipMiseInstall
 }


### PR DESCRIPTION
If PNPM is being installed with Corepack, we don't need to also install it with Mise. We still want to show it in the packages output at the top of the build plan though.

I think we will probably want to extend this pattern support specifying the package source (e.g. mise, nix, none). But this is a simple start.

One of the main reasons we want to avoid install PNPM with Mise (besides unnecessary compute) is that PNPM installs pull from GitHub releases which consumes the unauthed rate limit.
