### PR TITLE
Include all files except target directory in Rust deployment

### DIFF
--- a/core/providers/rust/rust.go
+++ b/core/providers/rust/rust.go
@@ -56,7 +56,8 @@ func (p *RustProvider) Plan(ctx *generate.GenerateContext) error {
 	maps.Copy(ctx.Deploy.Variables, p.GetRustEnvVars(ctx))
 	ctx.Deploy.AddInputs([]plan.Layer{
 		plan.NewStepLayer(build.Name(), plan.Filter{
-			Include: []string{"/app/bin"},
+			Include: []string{"."},
+			Exclude: []string{"target"},
 		}),
 	})
 	ctx.Deploy.StartCmd = p.GetStartCommand(ctx)


### PR DESCRIPTION
Fix Rust deployment to include all necessary files in the deployed image by changing the filter to include everything except the target directory.