### PR TITLE
Fix Vite detection to require both config and build script

### DIFF
--- a/core/providers/node/vite.go
+++ b/core/providers/node/vite.go
@@ -27,7 +27,7 @@ func (p *NodeProvider) isVitePackage(pkg *WorkspacePackage, ctx *generate.Genera
 		return false
 	}
 
-	return hasViteConfig || hasViteBuildCommand
+	return hasViteConfig && hasViteBuildCommand
 }
 
 func (p *NodeProvider) isVite(ctx *generate.GenerateContext) bool {

--- a/core/providers/node/vite.go
+++ b/core/providers/node/vite.go
@@ -12,6 +12,10 @@ const (
 )
 
 func (p *NodeProvider) isVitePackage(pkg *WorkspacePackage, ctx *generate.GenerateContext) bool {
+	hasViteBuildCommand := strings.Contains(strings.ToLower(pkg.PackageJson.GetScript("build")), "vite build")
+	hasVitePackage := pkg.PackageJson.hasDependency("vite")
+	hasBuildCommand := pkg.PackageJson.HasScript("build")
+
 	viteConfigJS := "vite.config.js"
 	viteConfigTS := "vite.config.ts"
 	if pkg.Path != "" {
@@ -20,14 +24,17 @@ func (p *NodeProvider) isVitePackage(pkg *WorkspacePackage, ctx *generate.Genera
 	}
 
 	hasViteConfig := ctx.App.HasMatch(viteConfigJS) || ctx.App.HasMatch(viteConfigTS)
-	hasViteBuildCommand := strings.Contains(strings.ToLower(pkg.PackageJson.GetScript("build")), "vite build")
 
 	// SvelteKit does not build as a static site by default
 	if p.isSvelteKitPackage(pkg) {
 		return false
 	}
 
-	return hasViteConfig && hasViteBuildCommand
+	// We only consider a package "vite" if
+	// 1. It has a vite package.json dependency
+	// 2. It has a build command. This is to ensure that there will actually be a directory to serve
+	// 3. It has a vite config file OR has a vite build command in the build command
+	return hasVitePackage && hasBuildCommand && (hasViteBuildCommand || hasViteConfig)
 }
 
 func (p *NodeProvider) isVite(ctx *generate.GenerateContext) bool {


### PR DESCRIPTION
Fixes Vite detection logic to require both a Vite config file and a build script, preventing incorrect detection of Vite projects.

- Changed Vite detection from OR to AND logic for config and build script presence