### PR TITLE
Fix broken link to Shell scripts in getting-started.mdx

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -19,7 +19,7 @@ the docs for each language that Railpack supports.
 - [Deno](languages/deno)
 - [Rust](languages/rust)
 - [Elixir](languages/elixir)
-- [Shell scripts](langauges/shell)
+- [Shell scripts](languages/shell)
 
 ---
 


### PR DESCRIPTION
Noticed link was broken due to typo