### PR TITLE
Add --ignore-scripts flag to package manager prune commands

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -235,7 +235,7 @@
    ],
    "commands": [
     {
-     "cmd": "npm prune --omit=dev"
+     "cmd": "npm prune --omit=dev --ignore-scripts"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -235,7 +235,7 @@
    ],
    "commands": [
     {
-     "cmd": "npm prune --omit=dev"
+     "cmd": "npm prune --omit=dev --ignore-scripts"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
@@ -193,7 +193,7 @@
    ],
    "commands": [
     {
-     "cmd": "npm prune --omit=dev"
+     "cmd": "npm prune --omit=dev --ignore-scripts"
     }
    ],
    "inputs": [

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -129,14 +129,14 @@ func (p PackageManager) PruneDeps(ctx *generate.GenerateContext, prune *generate
 
 	switch p {
 	case PackageManagerNpm:
-		prune.AddCommand(plan.NewExecCommand("npm prune --omit=dev"))
+		prune.AddCommand(plan.NewExecCommand("npm prune --omit=dev --ignore-scripts"))
 	case PackageManagerPnpm:
-		prune.AddCommand(plan.NewExecCommand("pnpm prune --prod"))
+		prune.AddCommand(plan.NewExecCommand("pnpm prune --prod --ignore-scripts"))
 	case PackageManagerBun:
 		// Prune is not supported in Bun. https://github.com/oven-sh/bun/issues/3605
-		prune.AddCommand(plan.NewExecShellCommand("rm -rf node_modules && bun install --production"))
+		prune.AddCommand(plan.NewExecShellCommand("rm -rf node_modules && bun install --production --ignore-scripts"))
 	case PackageManagerYarn1:
-		prune.AddCommand(plan.NewExecCommand("yarn install --production=true"))
+		prune.AddCommand(plan.NewExecCommand("yarn install --production=true --ignore-scripts"))
 	case PackageManagerYarnBerry:
 		p.pruneYarnBerry(ctx, prune)
 	}
@@ -155,6 +155,7 @@ func (p PackageManager) pruneYarnBerry(ctx *generate.GenerateContext, prune *gen
 	}
 
 	// Yarn 2 and 4+ support workspaces focus (also fallback for unknown versions)
+	// Note: yarn workspaces focus doesn't support --ignore-scripts flag
 	prune.AddCommand(plan.NewExecCommand("yarn workspaces focus --production --all"))
 }
 

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -136,7 +136,7 @@ func (p PackageManager) PruneDeps(ctx *generate.GenerateContext, prune *generate
 		// Prune is not supported in Bun. https://github.com/oven-sh/bun/issues/3605
 		prune.AddCommand(plan.NewExecShellCommand("rm -rf node_modules && bun install --production --ignore-scripts"))
 	case PackageManagerYarn1:
-		prune.AddCommand(plan.NewExecCommand("yarn install --production=true --ignore-scripts"))
+		prune.AddCommand(plan.NewExecCommand("yarn install --production=true"))
 	case PackageManagerYarnBerry:
 		p.pruneYarnBerry(ctx, prune)
 	}


### PR DESCRIPTION
This PR adds the `--ignore-scripts` flag to all package manager prune commands to prevent development scripts (like husky hooks) from running during the dependency pruning phase.

### Problem

Many Node.js projects use husky for git hooks, which installs scripts that run during package installation and pruning. When Railpack prunes development dependencies, these scripts can:

- **Fails the build** - Husky scripts often expect git repositories and fail in CI environments
- **Slows down build** - Running unnecessary scripts during pruning adds time to the build process  
- **Cause inconsistent behavior** - Scripts that work locally may fail in production builds

### Error

```bash
#27 3.258 > @chatwoot/chatwoot@4.3.0 prepare /app
#27 3.258 > husky install
#27 3.258
#27 3.265 sh: 1: husky: not found
#27 3.266  ELIFECYCLE  Command failed.
#27 ERROR: process "pnpm prune --prod" did not complete successfully: exit code: 1

#24 bundle install
```

### Example
```json
{
  "scripts": {
    "postinstall": "husky install"
  },
  "devDependencies": {
    "husky": "^8.0.0"
  }
}
```

When Railpack runs `npm prune --omit=dev`, it would also run the `postinstall` script, which tries to set up git hooks. This fails in CI environments where there's no git repository, causing build failures.

## What this PR changes

### Before
```bash
npm prune --omit=dev
pnpm prune --prod  
yarn install --production=true
```

### After
```bash
npm prune --omit=dev --ignore-scripts
pnpm prune --prod --ignore-scripts
yarn install --production=true --ignore-scripts
```

Pruning happens after installation, so critical postinstall scripts have already run but I may have missed something so feel free to correct. 

