### PR TITLE
Fix ruby version detection

### DIFF
--- a/core/providers/ruby/ruby_test.go
+++ b/core/providers/ruby/ruby_test.go
@@ -59,6 +59,11 @@ func TestRubyVersionDetection_Examples(t *testing.T) {
 			path:   "../../../examples/ruby-no-version",
 			expect: "3.4.4",
 		},
+		{
+			desc:   "Gemfile with single version constraint (ruby-single-version)",
+			path:   "../../../examples/ruby-single-version",
+			expect: "3.4.2",
+		},
 	}
 
 	for _, c := range cases {

--- a/core/providers/ruby/ruby_test.go
+++ b/core/providers/ruby/ruby_test.go
@@ -3,6 +3,7 @@ package ruby
 import (
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
 	testingUtils "github.com/railwayapp/railpack/core/testing"
@@ -35,4 +36,79 @@ func TestDetect(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestRubyVersionDetection_Examples(t *testing.T) {
+	cases := []struct {
+		desc   string
+		path   string
+		expect string
+	}{
+		{
+			desc:   ".ruby-version present (ruby-3)",
+			path:   "../../../examples/ruby-3",
+			expect: "3.2.1",
+		},
+		{
+			desc:   "Gemfile.lock with version (ruby-vanilla)",
+			path:   "../../../examples/ruby-vanilla",
+			expect: "3.4.2",
+		},
+		{
+			desc:   "Gemfile with version constraint < 3.5.0 (ruby-no-version)",
+			path:   "../../../examples/ruby-no-version",
+			expect: "3.4.4",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx := testingUtils.CreateGenerateContext(t, c.path)
+			miseStep := ctx.GetMiseStepBuilder()
+			provider := RubyProvider{}
+			provider.InstallMisePackages(ctx, miseStep)
+
+			resolvedPackages, err := miseStep.Resolver.ResolvePackages()
+			require.NoError(t, err)
+
+			resolvedPkg, exists := resolvedPackages["ruby"]
+			if !exists {
+				t.Fatalf("ruby package not found in resolved packages")
+			}
+
+			if resolvedPkg.ResolvedVersion == nil {
+				t.Fatalf("ruby package version not resolved")
+			}
+
+			require.Equal(t, c.expect, *resolvedPkg.ResolvedVersion)
+		})
+	}
+}
+
+func TestRubyVersionConstraintResolution(t *testing.T) {
+	t.Run("constraint_resolution_works", func(t *testing.T) {
+		ctx := testingUtils.CreateGenerateContext(t, "../../../examples/ruby-no-version")
+
+		miseStep := ctx.GetMiseStepBuilder()
+		provider := RubyProvider{}
+		provider.InstallMisePackages(ctx, miseStep)
+
+		resolvedPackages, err := miseStep.Resolver.ResolvePackages()
+		require.NoError(t, err)
+
+		resolvedPkg, exists := resolvedPackages["ruby"]
+		require.True(t, exists, "ruby package should be found in resolved packages")
+		require.NotNil(t, resolvedPkg.ResolvedVersion, "ruby package version should be resolved")
+
+		actualVersion := *resolvedPkg.ResolvedVersion
+
+		v, err := semver.NewVersion(actualVersion)
+		require.NoError(t, err)
+		require.True(t, v.Major() == 3 && v.Minor() >= 2 && v.Minor() < 5,
+			"Resolved version %s should be >= 3.2.0 and < 3.5.0", actualVersion)
+
+		require.True(t, v.Minor() >= 4, "Should resolve to a recent version, got %s", actualVersion)
+
+		require.Equal(t, "3.4.4", actualVersion, "Should resolve to the highest stable version under 3.5.0")
+	})
 }

--- a/core/resolver/resolver.go
+++ b/core/resolver/resolver.go
@@ -151,3 +151,7 @@ func (r *Resolver) SetVersionAvailable(ref PackageRef, isVersionAvailable func(v
 func (r *Resolver) SetSkipMiseInstall(ref PackageRef, skipMiseInstall bool) {
 	r.packages[ref.Name].SkipMiseInstall = skipMiseInstall
 }
+
+func (r *Resolver) GetMise() *mise.Mise {
+	return r.mise
+}

--- a/examples/ruby-no-version/Gemfile
+++ b/examples/ruby-no-version/Gemfile
@@ -1,5 +1,5 @@
-
 source 'https://rubygems.org'
+ruby '>= 3.2.0', '< 3.5.0'
 
+gem 'puma', '~> 5.6'
 gem 'sinatra'
-gem "puma", "~> 5.6"

--- a/examples/ruby-single-version/Gemfile
+++ b/examples/ruby-single-version/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+ruby '3.4.2'
+
+gem 'puma', '~> 5.6'
+gem 'sinatra'

--- a/examples/ruby-single-version/Gemfile.lock
+++ b/examples/ruby-single-version/Gemfile.lock
@@ -1,0 +1,20 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    puma (5.6.7)
+      nio4r (~> 2.0)
+    sinatra (3.0.5)
+      mustermann (~> 3.0)
+      rack (~> 3.0)
+      rack-protection (= 3.0.5)
+      tilt (~> 2.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  puma (~> 5.6)
+  sinatra
+
+BUNDLED WITH
+   2.4.22 

--- a/examples/ruby-single-version/app.rb
+++ b/examples/ruby-single-version/app.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  "Hello from Ruby #{RUBY_VERSION}!"
+end

--- a/examples/ruby-single-version/config.ru
+++ b/examples/ruby-single-version/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 h1:dIS
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2/go.mod h1:gCLVsLfv1egrcZu+GoJATN5ts75F2s62ih/457eWzOw=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=


### PR DESCRIPTION

This occurred because the regex pattern for extracting Ruby version constraints from Gemfiles was too restrictive and only matched single version numbers, not multi-part constraints like `ruby '>= 3.2.0', '< 3.5.0'`.

This fix enables Railpack to properly handle Ruby applications with version constraints in their Gemfiles, such as [Mastodon](https://github.com/mastodon/mastodon/blob/main/Gemfile) and other modern Ruby applications that specify version ranges rather than exact versions.

## Problem
The original regex pattern `ruby (?:'|")(.*)(?:'|")[^>]"` was designed to match single version strings but failed to properly extract complex version constraints that are common in modern Ruby applications.

## Fix
1. **Fixed regex pattern**: Updated `gemfileVersionRegex` to `ruby\s+(?:'|")([^'"]+)(?:'|")` to properly capture full version constraints
2. **Enhanced version filtering**: Added logic to skip preview/dev/rc versions when resolving constraints, ensuring only stable Ruby versions are selected
3. **Improved constraint resolution**: Integrated with Mise's `GetAllVersions` method and `github.com/Masterminds/semver/v3` to dynamically resolve the highest version satisfying the constraint
4. **Updated priority order**: Ensured constraint-based version resolution takes precedence over other version sources

## Tests
- Added comprehensive tests using real example projects
