### PR TITLE
docs: RAILPACK_GO_WORKSPACE_MODULE example correction

### DIFF
--- a/docs/src/content/docs/languages/golang.md
+++ b/docs/src/content/docs/languages/golang.md
@@ -73,7 +73,7 @@ Example workspace structure:
 To build a specific module:
 
 ```bash
-RAILPACK_GO_WORKSPACE_MODULE=api railpack build
+RAILPACK_GO_WORKSPACE_MODULE=api
 ```
 
 ### CGO Support


### PR DESCRIPTION
- removed the extra `railpack build` suffix after the specified workspace in `RAILPACK_GO_WORKSPACE_MODULE`