### PR TITLE
java: Add production build flag

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
@@ -72,7 +72,7 @@
      "src": "."
     },
     {
-     "cmd": "./gradlew clean build -x check -x test"
+     "cmd": "./gradlew clean build -x check -x test -Pproduction"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
@@ -72,7 +72,7 @@
      "src": "."
     },
     {
-     "cmd": "mvn -DoutputFile=target/mvn-dependency-list.log -B -DskipTests clean dependency:list install"
+     "cmd": "mvn -DoutputFile=target/mvn-dependency-list.log -B -DskipTests clean dependency:list install -Pproduction"
     }
    ],
    "inputs": [

--- a/core/providers/java/java.go
+++ b/core/providers/java/java.go
@@ -40,7 +40,7 @@ func (p *JavaProvider) Plan(ctx *generate.GenerateContext) error {
 			build.AddCommand(plan.NewExecCommand("chmod +x gradlew"))
 		}
 
-		build.AddCommand(plan.NewExecCommand("./gradlew clean build -x check -x test"))
+		build.AddCommand(plan.NewExecCommand("./gradlew clean build -x check -x test -Pproduction"))
 		build.AddCache(p.gradleCache(ctx))
 	} else {
 		ctx.Logger.LogInfo("Using Maven")
@@ -52,7 +52,7 @@ func (p *JavaProvider) Plan(ctx *generate.GenerateContext) error {
 			build.AddCommand(plan.NewExecCommand("chmod +x mvnw"))
 		}
 
-		build.AddCommand(plan.NewExecCommand(fmt.Sprintf("%s -DoutputFile=target/mvn-dependency-list.log -B -DskipTests clean dependency:list install", p.getMavenExe(ctx))))
+		build.AddCommand(plan.NewExecCommand(fmt.Sprintf("%s -DoutputFile=target/mvn-dependency-list.log -B -DskipTests clean dependency:list install -Pproduction", p.getMavenExe(ctx))))
 		build.AddCache(p.mavenCache(ctx))
 	}
 


### PR DESCRIPTION
This is used in Spring Boot to, for instance, disable the Vaadin debug server (which will break at runtime if it can't find a source directory, which is not provided at runtime).
