### PR TITLE
Move MISE_NODE_VERIFY variable to mise_step_builder.go

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -113,6 +113,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
@@ -54,6 +54,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
@@ -50,6 +50,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
@@ -50,6 +50,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
@@ -57,6 +57,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
@@ -57,6 +57,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
@@ -57,6 +57,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
@@ -59,6 +59,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },
@@ -114,6 +115,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
@@ -59,6 +59,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },
@@ -114,6 +115,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -107,6 +107,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -102,6 +102,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -107,6 +107,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
@@ -102,6 +102,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
@@ -102,6 +102,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -98,6 +98,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -102,6 +102,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -98,6 +98,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -98,6 +98,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -107,6 +107,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -107,6 +107,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
@@ -93,6 +93,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
@@ -93,6 +93,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
@@ -93,6 +93,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
@@ -93,6 +93,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
@@ -94,6 +94,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
@@ -94,6 +94,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
@@ -93,6 +93,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
@@ -93,6 +93,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces-glob_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces-glob_1.snap.json
@@ -59,6 +59,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces_1.snap.json
@@ -59,6 +59,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
@@ -63,6 +63,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-version_1.snap.json
@@ -63,6 +63,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-multiple-bins_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-multiple-bins_1.snap.json
@@ -63,6 +63,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-openssl_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-openssl_1.snap.json
@@ -63,6 +63,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-ring_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-ring_1.snap.json
@@ -63,6 +63,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-rocket_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-rocket_1.snap.json
@@ -63,6 +63,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
@@ -59,6 +59,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
@@ -59,6 +59,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -55,6 +55,7 @@
     "MISE_CONFIG_DIR": "/mise",
     "MISE_DATA_DIR": "/mise",
     "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
   },

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -138,6 +138,9 @@ func (b *MiseStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) er
 			"MISE_CACHE_DIR":    "/mise/cache",
 			"MISE_SHIMS_DIR":    "/mise/shims",
 			"MISE_INSTALLS_DIR": "/mise/installs",
+			// Don't verify the asset because recently released versions don't have a public key to verify against
+			// https://github.com/railwayapp/railpack/issues/207
+			"MISE_NODE_VERIFY": "false",
 		})
 		maps.Copy(step.Variables, b.Variables)
 

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -288,10 +288,6 @@ func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 		if nodeVersionFile, err := ctx.App.ReadFile(".node-version"); err == nil {
 			miseStep.Version(node, string(nodeVersionFile), ".node-version")
 		}
-
-		// Don't verify the asset because recently released versions don't have a public key to verify against
-		// https://github.com/railwayapp/railpack/issues/207
-		miseStep.Variables["MISE_NODE_VERIFY"] = "false"
 	}
 
 	// Bun


### PR DESCRIPTION
This centralizes the MISE_NODE_VERIFY=false configuration in the mise step builder where other mise environment variables are set, rather than having it in the node provider.