### PR TITLE
Enable jemalloc by default in Ruby setups

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
@@ -42,6 +42,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -53,8 +54,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [
@@ -127,6 +128,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -147,6 +149,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -157,8 +160,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
@@ -42,6 +42,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -53,8 +54,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y cargo libyaml-dev rustc'",
-     "customName": "install apt packages: cargo libyaml-dev rustc"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y cargo libjemalloc-dev libyaml-dev rustc'",
+     "customName": "install apt packages: cargo libjemalloc-dev libyaml-dev rustc"
     }
    ],
    "inputs": [
@@ -127,6 +128,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -147,6 +149,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -157,8 +160,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-execjs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-execjs_1.snap.json
@@ -42,6 +42,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -53,8 +54,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [
@@ -127,6 +128,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -147,6 +149,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -157,8 +160,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
@@ -42,6 +42,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -53,8 +54,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [
@@ -131,6 +132,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -151,6 +153,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -161,8 +164,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
@@ -42,6 +42,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -53,8 +54,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y cargo libyaml-dev rustc'",
-     "customName": "install apt packages: cargo libyaml-dev rustc"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y cargo libjemalloc-dev libyaml-dev rustc'",
+     "customName": "install apt packages: cargo libjemalloc-dev libyaml-dev rustc"
     }
    ],
    "inputs": [
@@ -127,6 +128,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -147,6 +149,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -157,8 +160,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
@@ -43,6 +43,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -54,8 +55,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [
@@ -131,6 +132,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -154,6 +156,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -164,8 +167,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
@@ -43,6 +43,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -54,8 +55,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y cargo libyaml-dev rustc'",
-     "customName": "install apt packages: cargo libyaml-dev rustc"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y cargo libjemalloc-dev libyaml-dev rustc'",
+     "customName": "install apt packages: cargo libjemalloc-dev libyaml-dev rustc"
     }
    ],
    "inputs": [
@@ -131,6 +132,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -157,6 +159,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -167,8 +170,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y default-libmysqlclient-dev libicu-dev libmagickwand-dev libpq-dev libvips-dev libxml2-dev libxslt-dev libyaml-dev'",
-     "customName": "install apt packages: default-libmysqlclient-dev libicu-dev libmagickwand-dev libpq-dev libvips-dev libxml2-dev libxslt-dev libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y default-libmysqlclient-dev libicu-dev libjemalloc-dev libmagickwand-dev libpq-dev libvips-dev libxml2-dev libxslt-dev libyaml-dev'",
+     "customName": "install apt packages: default-libmysqlclient-dev libicu-dev libjemalloc-dev libmagickwand-dev libpq-dev libvips-dev libxml2-dev libxslt-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
@@ -42,6 +42,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -53,8 +54,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [
@@ -127,6 +128,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -147,6 +149,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -157,8 +160,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
@@ -42,6 +42,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -53,8 +54,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [
@@ -127,6 +128,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -147,6 +149,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -157,8 +160,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
@@ -66,6 +66,7 @@
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
+   "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
    "MALLOC_ARENA_MAX": "2"
   }
  },
@@ -77,8 +78,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [
@@ -151,6 +152,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -255,6 +257,7 @@
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/bundle",
     "GEM_PATH": "/usr/local/bundle",
+    "LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
     "MALLOC_ARENA_MAX": "2"
    }
   },
@@ -265,8 +268,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libyaml-dev'",
-     "customName": "install apt packages: libyaml-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libjemalloc-dev libyaml-dev'",
+     "customName": "install apt packages: libjemalloc-dev libyaml-dev"
     }
    ],
    "inputs": [

--- a/core/providers/ruby/ruby.go
+++ b/core/providers/ruby/ruby.go
@@ -194,7 +194,7 @@ func (p *RubyProvider) Build(ctx *generate.GenerateContext, build *generate.Comm
 }
 
 func (p *RubyProvider) AddRuntimeDeps(ctx *generate.GenerateContext) {
-	packages := []string{"libyaml-dev"}
+	packages := []string{"libyaml-dev", "libjemalloc-dev"}
 
 	if p.usesPostgres(ctx) {
 		packages = append(packages, "libpq-dev")
@@ -250,6 +250,7 @@ func (p *RubyProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 	}
 
 	miseStep.AddSupportingAptPackage("libyaml-dev")
+	miseStep.AddSupportingAptPackage("libjemalloc-dev")
 	version := p.getRubyVersion(ctx)
 	version = utils.ExtractSemverVersion(version)
 	semver, err := utils.ParseSemver(version)
@@ -275,6 +276,7 @@ func (p *RubyProvider) GetRubyEnvVars(ctx *generate.GenerateContext) map[string]
 		"GEM_PATH":         "/usr/local/bundle",
 		"GEM_HOME":         "/usr/local/bundle",
 		"MALLOC_ARENA_MAX": "2",
+		"LD_PRELOAD":       "/usr/lib/x86_64-linux-gnu/libjemalloc.so",
 	}
 }
 


### PR DESCRIPTION
Ruby memory allocation happens using the glibc implementation of malloc(3), which is a general purpose implementation of malloc. [jemalloc](https://github.com/facebook/jemalloc) is used to replace that implementation with a more optimized version of malloc(3) which gives memory optimizations for free without code changes required.

References:
- https://x.com/nateberkopec/status/1826390160113803353
- https://x.com/nateberkopec/status/1881356160076320959

We've seen similar benefits in my company's production environment. Why not bring it to all Ruby apps running on Railway?