### PR TITLE
fix: hard fail on invalid railpack.json

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -36,7 +36,7 @@ func commonPlanFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:  "config-file",
-			Usage: "path to config file to use",
+			Usage: "relative path to railpack config file (default: railpack.json)",
 		},
 		&cli.BoolFlag{
 			Name:  "error-missing-start",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
@@ -25,15 +25,9 @@
      "target/."
     ],
     "step": "build"
-   },
-   {
-    "include": [
-     "."
-    ],
-    "step": "install"
    }
   ],
-  "startCommand": "java -jar target/java-zulu-version-1.0-SNAPSHOT.jar"
+  "startCommand": "java  $JAVA_OPTS -jar target/*jar"
  },
  "steps": [
   {
@@ -126,27 +120,6 @@
     "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
-  },
-  {
-   "commands": [
-    {
-     "cmd": "sh -c 'mvn clean compile'",
-     "customName": "mvn clean compile"
-    },
-    {
-     "cmd": "sh -c 'mvn package'",
-     "customName": "mvn package"
-    }
-   ],
-   "inputs": [
-    {
-     "step": "packages:mise"
-    }
-   ],
-   "name": "install",
-   "secrets": [
-    "*"
-   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
@@ -25,9 +25,15 @@
      "target/."
     ],
     "step": "build"
+   },
+   {
+    "include": [
+     "."
+    ],
+    "step": "install"
    }
   ],
-  "startCommand": "java  $JAVA_OPTS -jar target/*jar"
+  "startCommand": "java -jar target/java-zulu-version-1.0-SNAPSHOT.jar"
  },
  "steps": [
   {
@@ -120,6 +126,27 @@
     "MISE_NODE_VERIFY": "false",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "sh -c 'mvn clean compile'",
+     "customName": "mvn clean compile"
+    },
+    {
+     "cmd": "sh -c 'mvn package'",
+     "customName": "mvn package"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    }
+   ],
+   "name": "install",
+   "secrets": [
+    "*"
+   ]
   }
  ]
 }

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/tailscale/hujson"
+	"github.com/railwayapp/railpack/internal/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -134,7 +134,7 @@ func (a *App) FindFilesWithContent(pattern string, regex *regexp.Regexp) []strin
 	return matches
 }
 
-// ReadFile reads the contents of a file
+// ReadFile reads the contents of a file within the application source directory
 func (a *App) ReadFile(name string) (string, error) {
 	path := filepath.Join(a.Source, name)
 	data, err := os.ReadFile(path)
@@ -153,7 +153,7 @@ func (a *App) ReadJSON(name string, v interface{}) error {
 		return err
 	}
 
-	jsonBytes, err := standardizeJSON([]byte(data))
+	jsonBytes, err := utils.StandardizeJSON([]byte(data))
 	if err != nil {
 		return err
 	}
@@ -215,13 +215,4 @@ func (a *App) stripSourcePath(absPath string) (string, error) {
 		return "", errors.New("failed to parse source path")
 	}
 	return rel, nil
-}
-
-func standardizeJSON(b []byte) ([]byte, error) {
-	ast, err := hujson.Parse(b)
-	if err != nil {
-		return b, err
-	}
-	ast.Standardize()
-	return ast.Pack(), nil
 }

--- a/core/core.go
+++ b/core/core.go
@@ -148,9 +148,10 @@ func GenerateConfigFromFile(app *app.App, env *app.Environment, options *Generat
 		return config, nil
 	}
 
+	// if a JSON file was provided, we should hard fail if we cannot parse it
 	if err := app.ReadJSON(configFileName, config); err != nil {
 		logger.LogWarn("Failed to read config file `%s`\nUse the following schema to validate your config file: %s\n", configFileName, c.SchemaUrl)
-		return config, nil
+		return nil, err
 	}
 
 	logger.LogInfo("Using config file `%s`", configFileName)

--- a/core/core.go
+++ b/core/core.go
@@ -164,13 +164,9 @@ func GenerateConfigFromFile(app *app.App, env *app.Environment, options *Generat
 		configFileName = envConfigFileName
 	}
 
-	// unless an absolute path, assume relative to the app source directory
-	var absConfigFileName string
-	if !filepath.IsAbs(configFileName) {
-		absConfigFileName = filepath.Join(app.Source, configFileName)
-	} else {
-		absConfigFileName = configFileName
-	}
+	// always assume config file path is relative to the app source directory
+	// https://github.com/railwayapp/railpack/pull/226
+	absConfigFileName := filepath.Join(app.Source, configFileName)
 
 	if _, err := os.Stat(absConfigFileName); err != nil && os.IsNotExist(err) {
 		// if a specific path was specified, we should indicate that it was not found and hard fail

--- a/core/core.go
+++ b/core/core.go
@@ -80,7 +80,7 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 		return &BuildResult{Success: false, Logs: logger.Logs}
 	}
 
-	// Set the preivous versions
+	// Set the previous versions
 	if options.PreviousVersions != nil {
 		for name, version := range options.PreviousVersions {
 			ctx.Resolver.SetPreviousVersion(name, version)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/railwayapp/railpack/core/app"
+	"github.com/railwayapp/railpack/core/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,6 +17,7 @@ func TestMain(m *testing.M) {
 	os.Exit(v)
 }
 
+// generate snapshot plan JSON for each build example and assert against it
 func TestGenerateBuildPlanForExamples(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
@@ -58,4 +60,56 @@ func TestGenerateBuildPlanForExamples(t *testing.T) {
 			snaps.MatchStandaloneJSON(t, plan)
 		})
 	}
+}
+
+func TestGenerateConfigFromFile_NotFound(t *testing.T) {
+	// Use an existing example app directory so relative paths resolve
+	appPath := "../examples/config-file"
+	userApp, err := app.NewApp(appPath)
+	require.NoError(t, err)
+
+	env := app.NewEnvironment(nil)
+	l := logger.NewLogger()
+
+	options := &GenerateBuildPlanOptions{ConfigFilePath: "does-not-exist.railpack.json"}
+	cfg, genErr := GenerateConfigFromFile(userApp, env, options, l)
+
+	require.Error(t, genErr, "expected an error when explicit config file does not exist")
+	require.Nil(t, cfg, "config should be nil on error")
+}
+
+func TestGenerateConfigFromFile_Malformed(t *testing.T) {
+	appPath := "../examples/config-file"
+	userApp, err := app.NewApp(appPath)
+	require.NoError(t, err)
+
+	env := app.NewEnvironment(nil)
+	l := logger.NewLogger()
+
+	options := &GenerateBuildPlanOptions{ConfigFilePath: "railpack.malformed.json"}
+	cfg, genErr := GenerateConfigFromFile(userApp, env, options, l)
+
+	require.Error(t, genErr, "expected an error for malformed JSON config file")
+	require.Nil(t, cfg, "config should be nil on error")
+}
+
+// Ensure that providing an absolute path to a valid config file works
+func TestGenerateConfigFromFile_AbsolutePath(t *testing.T) {
+	appPath := "../examples/config-file"
+	userApp, err := app.NewApp(appPath)
+	require.NoError(t, err)
+
+	absConfigPath, err := filepath.Abs(filepath.Join(appPath, "railpack.json"))
+	require.NoError(t, err)
+
+	env := app.NewEnvironment(nil)
+	l := logger.NewLogger()
+
+	options := &GenerateBuildPlanOptions{ConfigFilePath: absConfigPath}
+	cfg, genErr := GenerateConfigFromFile(userApp, env, options, l)
+
+	require.NoError(t, genErr, "expected no error for absolute config path")
+	require.NotNil(t, cfg, "config should not be nil")
+	// Basic sanity check: provider should be carried through from example config
+	require.Equal(t, "node", cfg.Provider)
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -92,24 +92,3 @@ func TestGenerateConfigFromFile_Malformed(t *testing.T) {
 	require.Error(t, genErr, "expected an error for malformed JSON config file")
 	require.Nil(t, cfg, "config should be nil on error")
 }
-
-// Ensure that providing an absolute path to a valid config file works
-func TestGenerateConfigFromFile_AbsolutePath(t *testing.T) {
-	appPath := "../examples/config-file"
-	userApp, err := app.NewApp(appPath)
-	require.NoError(t, err)
-
-	absConfigPath, err := filepath.Abs(filepath.Join(appPath, "railpack.json"))
-	require.NoError(t, err)
-
-	env := app.NewEnvironment(nil)
-	l := logger.NewLogger()
-
-	options := &GenerateBuildPlanOptions{ConfigFilePath: absConfigPath}
-	cfg, genErr := GenerateConfigFromFile(userApp, env, options, l)
-
-	require.NoError(t, genErr, "expected no error for absolute config path")
-	require.NotNil(t, cfg, "config should not be nil")
-	// Basic sanity check: provider should be carried through from example config
-	require.Equal(t, "node", *cfg.Provider)
-}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -111,5 +111,5 @@ func TestGenerateConfigFromFile_AbsolutePath(t *testing.T) {
 	require.NoError(t, genErr, "expected no error for absolute config path")
 	require.NotNil(t, cfg, "config should not be nil")
 	// Basic sanity check: provider should be carried through from example config
-	require.Equal(t, "node", cfg.Provider)
+	require.Equal(t, "node", *cfg.Provider)
 }

--- a/examples/config-file/railpack.malformed.json
+++ b/examples/config-file/railpack.malformed.json
@@ -1,0 +1,6 @@
+{
+  "steps": {
+    "commands": ["npm install"]
+  },
+  "invalid": json syntax here
+}

--- a/examples/config-file/test.json
+++ b/examples/config-file/test.json
@@ -8,6 +8,11 @@
   },
   {
     "expectedOutput": "Hello via Bun",
-    "configFile": "railpack.invalid.json"
+    "configFile": "railpack.invalid.json",
+    "shouldFail": true
+  },
+  {
+    "configFile": "railpack.malformed.json",
+    "shouldFail": true
   }
 ]

--- a/examples/java-zulu-version/railpack.json
+++ b/examples/java-zulu-version/railpack.json
@@ -6,7 +6,7 @@
   },
   "steps": {
     "install": {
-      "commands": [mvn clean compile", "mvn package"]
+      "commands": ["mvn clean compile", "mvn package"]
     }
   },
   "deploy": {

--- a/examples/java-zulu-version/railpack.json
+++ b/examples/java-zulu-version/railpack.json
@@ -3,13 +3,5 @@
   "provider": "java",
   "packages": {
     "java": "zulu-8.86"
-  },
-  "steps": {
-    "install": {
-      "commands": ["mvn clean compile", "mvn package"]
-    }
-  },
-  "deploy": {
-    "startCommand": "java -jar target/java-zulu-version-1.0-SNAPSHOT.jar"
   }
 }

--- a/integration_tests/run_test.go
+++ b/integration_tests/run_test.go
@@ -28,6 +28,7 @@ type TestCase struct {
 	Envs           map[string]string `json:"envs"`
 	ConfigFilePath string            `json:"configFile"`
 	JustBuild      bool              `json:"justBuild"`
+	ShouldFail     bool              `json:"shouldFail"`
 }
 
 func TestExamplesIntegration(t *testing.T) {
@@ -78,6 +79,16 @@ func TestExamplesIntegration(t *testing.T) {
 				buildResult := core.GenerateBuildPlan(userApp, env, &core.GenerateBuildPlanOptions{
 					ConfigFilePath: testCase.ConfigFilePath,
 				})
+
+				// Handle case where we expect the build to fail
+				if testCase.ShouldFail {
+					if buildResult.Success {
+						t.Fatalf("expected build to fail, but it succeeded")
+					}
+					// Test passes - build failed as expected
+					return
+				}
+
 				if !buildResult.Success {
 					t.Fatalf("failed to generate build plan: %v", buildResult.Logs)
 				}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/tailscale/hujson"
 )
 
 func RemoveDuplicates[T comparable](sliceList []T) []T {
@@ -158,4 +160,14 @@ type Semver struct {
 	Major int
 	Minor int
 	Patch int
+}
+
+// convert hujson/extended JSON into standardized json
+func StandardizeJSON(b []byte) ([]byte, error) {
+	ast, err := hujson.Parse(b)
+	if err != nil {
+		return b, err
+	}
+	ast.Standardize()
+	return ast.Pack(), nil
 }


### PR DESCRIPTION
I noticed this while debugging my project's build failure. I kept getting a message about malformed `railpack.json` even though I did not provide one directly. It seems as through the generated `railpack.json` was incorrect but it did not cause the build to hard fail, it continued on without the generated `railpack.json`.

This change ensures that if invalid railpack.json is encountered, the CLI hard fails.

## Breaking Change

Previously, if JSON did not conform to the schema it would just be ignored and the build would continue. With this change, the build will halt and force the user to fix or discard their schema. I prefer this more explicit approach.