### PR TITLE
build: use railpack as the binary output name

### DIFF
--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -19,10 +19,19 @@ Install and use all versions of tools needed for Railpack
 mise run setup
 ```
 
-List all the commands available
+Use the `cli` task to run the railpack CLI (this is like `railpack --help`)
 
 ```bash
 mise run cli --help
+```
+
+If you want to compile a development build of railpack to use elsewhere on your machine:
+
+```bash
+mise run build
+
+# add the railpack repo `bin/` directory to your path to use the newly-compiled railpack on your machine
+export PATH="$PWD/bin:$PATH"
 ```
 
 ## Building directly with Buildkit

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ run = [
 run = "go run cmd/cli/main.go"
 
 [tasks.build]
-run = "go build -o bin/cli cmd/cli/main.go"
+run = "go build -o bin/railpack cmd/cli/main.go"
 
 [tasks.clean]
 run = "rm -rf bin dist docs/dist"


### PR DESCRIPTION
using a consistent name makes it easier to add `$PWD/bin/` to your path
for testing the new build across scripts or other systems locally.
