### PR TITLE
fix(install): handle GitHub API throttling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,7 @@ download() {
   fi
 
   $cmd && return 0 || rc=$?
-  
+
   error "Command failed (exit code $rc): ${BLUE}${cmd}${NO_COLOR}"
   printf "\n" >&2
   info "This is likely due to railpack not yet supporting your configuration."
@@ -310,7 +310,7 @@ is_build_available() {
 UNINSTALL=0
 HELP=0
 
-DEFAULT_VERSION=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | grep -o '"tag_name": "v.*"' | cut -d'"' -f4 | cut -c2-)
+DEFAULT_VERSION=$(curl --fail --silent --show-error ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | grep -o '"tag_name": "v.*"' | cut -d'"' -f4 | cut -c2-)
 
 # defaults
 if [ -z "${RAILPACK_VERSION-}" ]; then
@@ -466,12 +466,12 @@ install "${EXT}"
 printf "$GREEN"
 cat <<'EOF'
 
-   ____       _ _                  _    
+   ____       _ _                  _
   |  _ \ __ _(_) |_ __   __ _  ___| | __
   | |_) / _` | | | '_ \ / _` |/ __| |/ /
-  |  _ < (_| | | | |_) | (_| | (__|   < 
+  |  _ < (_| | | | |_) | (_| | (__|   <
   |_| \_\__,_|_|_| .__/ \__,_|\___|_|\_\
-                  |_|                     
+                  |_|
 
   Railpack is now installed!
   Run 'railpack --help' to get started


### PR DESCRIPTION
Currently, any HTTP error status code from GitHub is silently ignored and causes an empty `DEFAULT_VERSION`, which results in empty `RAILPACK_VERSION`:

```
1.207 > Installing railpack, please wait…
1.392 x Command failed (exit code 22): curl --fail --silent --location --output /tmp/tmp.aItYylRdux-railpack.1756412569.tar.gz https://github.com/railwayapp/railpack/releases/download/v/railpack-v-x86_64-unknown-linux-musl.tar.gz
1.392 
1.392 > This is likely due to railpack not yet supporting your configuration.
1.392 > If you would like to see a build for your configuration,
1.392 > please create an issue requesting a build for x86_64-unknown-linux-musl:
1.392 > https://github.com/railwayapp/railpack/issues/new/
```
(Notice the lonely `v` without numbers in the URL.)

This PR includes two fixes to handle the case where GitHub's API throttles anonymous requests:

* by adding `--fail` and `--show-error`, any HTTP error status will be printed (instead of "not yet supporting your configuration" red herring)
* by using `GITHUB_TOKEN` (if set), we can avoid throttling altogether by authenticating the request (note that this is set when running in GitHub CI)