### PR TITLE
fix: improved buildkit error message

### DIFF
--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -47,12 +47,17 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 
 	buildkitHost := os.Getenv("BUILDKIT_HOST")
 	if buildkitHost == "" {
-		log.Error("BUILDKIT_HOST environment variable is not set")
-		return fmt.Errorf("BUILDKIT_HOST environment variable is not set")
+		return fmt.Errorf(`BUILDKIT_HOST environment variable is not set.
+
+To start a local BuildKit daemon and set the environment variable run:
+
+	docker run --rm --privileged -d --name buildkit moby/buildkit
+	export BUILDKIT_HOST='docker-container://buildkit'`)
 	}
 
 	log.Debugf("Connecting to buildkit host: %s", buildkitHost)
 
+	// connecting to the buildkit host does *not* mean the specified build container is running
 	c, err := client.New(ctx, buildkitHost)
 	if err != nil {
 		return fmt.Errorf("failed to connect to buildkit: %w", err)
@@ -62,7 +67,15 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 	// Get the buildkit info early so we can ensure we can connect to the buildkit host
 	info, err := c.Info(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get buildkit info: %w", err)
+		log.Debugf("error getting buildkit info: %v", err)
+		return fmt.Errorf(`failed to get buildkit information.
+
+Most likely the $BUILDKIT_HOST is not running. Here's an example of how to start the build container:
+
+	docker run --rm --privileged -d --name buildkit moby/buildkit
+
+Use 'railpack --verbose' to view more error details.
+		`)
 	}
 
 	buildPlatform := opts.Platform

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [env]
 BUILDKIT_HOST = "docker-container://buildkit"
+_.path = './bin'
 
 [tasks.setup]
 run = [


### PR DESCRIPTION
The first-run error messages are pretty hard to understand for a new user who is running this locally.

We need a documentation section for this, but for now an improved error message walking the user through what do and where to look feels like a good first step.
