### PR TITLE
fix: fail early if no shell start script is detected, stop globbing shell script

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -90,6 +90,14 @@ func (a *App) findGlob(pattern string) ([]string, error) {
 	return matches, nil
 }
 
+// Check if a relative file exists in the app's source directory
+func (a *App) HasFile(path string) bool {
+	fullPath := filepath.Join(a.Source, path)
+
+	_, err := os.Stat(fullPath)
+	return !os.IsNotExist(err)
+}
+
 // HasMatch checks if a path matching a glob exists (files or directories)
 func (a *App) HasMatch(pattern string) bool {
 	files, err := a.FindFiles(pattern)

--- a/core/providers/shell/shell.go
+++ b/core/providers/shell/shell.go
@@ -1,7 +1,8 @@
 package shell
 
 import (
-	"github.com/charmbracelet/log"
+	"errors"
+
 	"github.com/railwayapp/railpack/core/generate"
 	"github.com/railwayapp/railpack/core/plan"
 )
@@ -24,6 +25,11 @@ func (p *ShellProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
 
 func (p *ShellProvider) Initialize(ctx *generate.GenerateContext) error {
 	p.scriptName = getScript(ctx)
+
+	if p.scriptName == "" {
+		return errors.New("start shell script could not be found")
+	}
+
 	return nil
 }
 
@@ -54,19 +60,21 @@ func (p *ShellProvider) StartCommandHelp() string {
 	return ""
 }
 
+// determine shell script to use for container start
 func getScript(ctx *generate.GenerateContext) string {
-	if scriptName, envVarName := ctx.Env.GetConfigVariable("SHELL_SCRIPT"); scriptName != "" {
-		hasScript := ctx.App.HasMatch(scriptName)
-		if hasScript {
-			return scriptName
-		}
-
-		log.Warnf("%s %s script not found", envVarName, scriptName)
+	scriptName, envVarName := ctx.Env.GetConfigVariable("SHELL_SCRIPT")
+	if scriptName == "" {
+		scriptName = StartScriptName
 	}
 
-	hasScript := ctx.App.HasMatch(StartScriptName)
-	if hasScript {
-		return StartScriptName
+	if ctx.App.HasFile(scriptName) {
+		return scriptName
+	}
+
+	if envVarName != "" {
+		ctx.Logger.LogWarn("%s %s script not found", envVarName, scriptName)
+	} else {
+		ctx.Logger.LogWarn("script %s not found", scriptName)
 	}
 
 	return ""

--- a/core/providers/shell/shell_test.go
+++ b/core/providers/shell/shell_test.go
@@ -42,11 +42,19 @@ func TestInitialize(t *testing.T) {
 		name           string
 		path           string
 		wantScriptName string
+		hasError       bool
 	}{
 		{
 			name:           "default script",
 			path:           "../../../examples/shell-script",
 			wantScriptName: StartScriptName,
+			hasError:       false,
+		},
+		{
+			name:           "default script",
+			path:           "../../../examples/config-file",
+			wantScriptName: "",
+			hasError:       true,
 		},
 	}
 
@@ -55,8 +63,13 @@ func TestInitialize(t *testing.T) {
 			ctx := testingUtils.CreateGenerateContext(t, tt.path)
 			provider := ShellProvider{}
 			err := provider.Initialize(ctx)
-			require.NoError(t, err)
-			require.Equal(t, tt.wantScriptName, provider.scriptName)
+
+			if tt.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantScriptName, provider.scriptName)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I ran into this issue while working on standardizing local layer additions for docker ignore support.

* The start script is sent through a file globbing match. Fuzzy matching against the start script for a container seems like a bad idea. We should opt to be more explicit here.
* If a start script is not detected, but the shell provider is specified (either inferred or specified in the railpack.json) the user gets an obscure `chmod +x` during build, which is hard to read and understand

I have it on my TODO to look through other providers to ensure start scripts are not fuzzy matched.

**Question:** `app.HasMatch` is in a lot of places throughout the codebase where you would intuitively expect the input path _must_ correspond to a single, particular file. Is there an architectural reason why file glob matches are used instead?