### PR TITLE
fix: support node projects without dependencies

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -126,6 +126,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -99,6 +99,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
@@ -85,6 +85,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
@@ -99,6 +99,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
@@ -89,6 +89,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
@@ -1,9 +1,5 @@
 {
  "caches": {
-  "next": {
-   "directory": "/app/.next/cache",
-   "type": "shared"
-  },
   "node-modules": {
    "directory": "/app/node_modules/.cache",
    "type": "shared"
@@ -71,7 +67,7 @@
     },
     {
      "cmd": "sh -c 'mise trust -a \u0026\u0026 mise install'",
-     "customName": "install mise packages: node"
+     "customName": "install mise packages: bun, node"
     }
    ],
    "inputs": [
@@ -105,11 +101,7 @@
      "src": "package.json"
     },
     {
-     "dest": "package-lock.json",
-     "src": "package-lock.json"
-    },
-    {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [
@@ -128,16 +120,12 @@
   },
   {
    "caches": [
-    "node-modules",
-    "next"
+    "node-modules"
    ],
    "commands": [
     {
      "dest": ".",
      "src": "."
-    },
-    {
-     "cmd": "npm run build"
     }
    ],
    "inputs": [
@@ -148,10 +136,7 @@
    "name": "build",
    "secrets": [
     "*"
-   ],
-   "variables": {
-    "NEXT_TELEMETRY_DISABLED": "1"
-   }
+   ]
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -120,6 +120,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -104,6 +104,9 @@
      "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
@@ -85,6 +85,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -94,6 +94,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -94,6 +94,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
@@ -94,6 +94,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": ".",
      "src": "."
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -99,6 +99,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
@@ -94,6 +94,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
@@ -102,6 +102,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
@@ -102,6 +102,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
@@ -93,6 +93,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": ".",
      "src": "."
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
@@ -98,6 +98,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -111,6 +111,9 @@
      "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
@@ -89,6 +89,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
@@ -98,6 +98,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
@@ -89,6 +89,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
@@ -89,6 +89,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -115,6 +115,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
@@ -131,6 +131,9 @@
      "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
@@ -96,6 +96,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
@@ -95,6 +95,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
@@ -105,6 +105,9 @@
      "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
@@ -105,6 +105,9 @@
      "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -205,6 +205,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -205,6 +205,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
@@ -165,6 +165,9 @@
      "path": "/app/node_modules/.bin"
     },
     {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
      "dest": "package.json",
      "src": "package.json"
     },

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -18,7 +18,8 @@ const (
 	DEFAULT_NODE_VERSION = "22"
 	DEFAULT_BUN_VERSION  = "latest"
 
-	COREPACK_HOME = "/opt/corepack"
+	COREPACK_HOME      = "/opt/corepack"
+	NODE_MODULES_CACHE = "/app/node_modules/.cache"
 )
 
 var (
@@ -258,6 +259,12 @@ func (p *NodeProvider) InstallNodeDeps(ctx *generate.GenerateContext, install *g
 			plan.NewExecShellCommand("npm i -g corepack@latest && corepack enable && corepack prepare --activate"),
 		})
 	}
+	install.AddCommands([]plan.Command{
+		// it's possible for a package.json to exist without any dependencies, in which case node_modules is not generated
+		// and bun.lockb, etc are not generated either. However, this path is used to compute the cache key, so we ensure
+		// it exists on the filesystem to avoid a docker cache key computation error.
+		plan.NewExecCommand(fmt.Sprintf("mkdir -p %s", NODE_MODULES_CACHE)),
+	})
 
 	p.packageManager.installDependencies(ctx, p.workspace, install)
 }

--- a/examples/node-bun-no-deps/app.js
+++ b/examples/node-bun-no-deps/app.js
@@ -1,0 +1,1 @@
+console.log("hi from bun without a lock")

--- a/examples/node-bun-no-deps/package.json
+++ b/examples/node-bun-no-deps/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "name-of-project",
+  "version": "0.1.0",
+  "description": "stuff goes here...",
+  "main": "app.js",
+  "scripts": {
+    "start": "bun run app.js",
+    "dev": "bun --watch app.js"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "bun": ">=1.0.0"
+  }
+}

--- a/examples/node-bun-no-deps/readme.md
+++ b/examples/node-bun-no-deps/readme.md
@@ -1,0 +1,1 @@
+https://github.com/railwayapp/railpack/issues/233

--- a/examples/node-bun-no-deps/test.json
+++ b/examples/node-bun-no-deps/test.json
@@ -1,0 +1,5 @@
+[
+  {
+    "expectedOutput": "hi from bun without a lock"
+  }
+]


### PR DESCRIPTION
Code comment explains what this is solving. The alternative is attempting to determine if a node_modules folder
is created by the install command, which would be brittle. Easier to just ensure all cache folders exist since
we cannot reliably determine if they won't be created.

fixes https://github.com/railwayapp/railpack/issues/233
