### PR TITLE
feat: support for expanded platform arguments

### DIFF
--- a/buildkit/platform.go
+++ b/buildkit/platform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/containerd/platforms"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -32,7 +33,27 @@ func DetermineBuildPlatformFromHost() BuildPlatform {
 	return PlatformLinuxAMD64
 }
 
+func ParsePlatform(platformStr string) (BuildPlatform, error) {
+	if platformStr == "" {
+		return DetermineBuildPlatformFromHost(), nil
+	}
+
+	platform, err := platforms.Parse(platformStr)
+	if err != nil {
+		return BuildPlatform{}, fmt.Errorf("invalid platform format: %s. Must be one of: linux/amd64, linux/arm64, etc", platformStr)
+	}
+
+	return BuildPlatform{
+		OS:           platform.OS,
+		Architecture: platform.Architecture,
+		Variant:      platform.Variant,
+	}, nil
+}
+
 func (p BuildPlatform) String() string {
+	if p.Variant != "" {
+		return fmt.Sprintf("%s/%s/%s", p.OS, p.Architecture, p.Variant)
+	}
 	return fmt.Sprintf("%s/%s", p.OS, p.Architecture)
 }
 

--- a/buildkit/platform_test.go
+++ b/buildkit/platform_test.go
@@ -1,0 +1,71 @@
+package buildkit
+
+import (
+	"testing"
+)
+
+func TestParsePlatform(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected BuildPlatform
+		wantErr  bool
+	}{
+		{
+			name:  "empty string returns host platform",
+			input: "",
+			expected: func() BuildPlatform {
+				return DetermineBuildPlatformFromHost()
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "linux/arm64/v8",
+			input: "linux/arm64/v8",
+			expected: BuildPlatform{
+				OS:           "linux",
+				Architecture: "arm64",
+				Variant:      "v8",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid input",
+			input:   "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePlatform(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParsePlatform() expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParsePlatform() error = %v", err)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("ParsePlatform() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildPlatformString(t *testing.T) {
+	platform := BuildPlatform{
+		OS:           "linux",
+		Architecture: "arm64",
+		Variant:      "v8",
+	}
+	expected := "linux/arm64/v8"
+
+	got := platform.String()
+	if got != expected {
+		t.Errorf("BuildPlatform.String() = %v, want %v", got, expected)
+	}
+}

--- a/cli/build.go
+++ b/cli/build.go
@@ -86,7 +86,7 @@ var BuildCommand = &cli.Command{
 
 		secretsHash := getSecretsHash(env)
 
-		platform, err := getPlatform(cmd.String("platform"))
+		platform, err := buildkit.ParsePlatform(cmd.String("platform"))
 		if err != nil {
 			return cli.Exit(err, 1)
 		}
@@ -108,21 +108,6 @@ var BuildCommand = &cli.Command{
 
 		return nil
 	},
-}
-
-func getPlatform(platformStr string) (buildkit.BuildPlatform, error) {
-	var platform buildkit.BuildPlatform
-	if platformStr == "" {
-		platform = buildkit.DetermineBuildPlatformFromHost()
-	} else if platformStr == "linux/arm64" {
-		platform = buildkit.PlatformLinuxARM64
-	} else if platformStr != "linux/amd64" {
-		return buildkit.BuildPlatform{}, fmt.Errorf("unsupported platform: %s. Must be one of: linux/amd64, linux/arm64", platformStr)
-	} else {
-		platform = buildkit.PlatformLinuxAMD64
-	}
-
-	return platform, nil
 }
 
 func validateSecrets(plan *plan.BuildPlan, env *app.Environment) error {


### PR DESCRIPTION
Confusing that `linux/arm64/v8` caused an error. Additionally, we can just use the parsing from `containerd` so we'll track with any platform additions in the future.
