### PR TITLE
test: pass GITHUB_TOKEN to docker containers running the railpack buildplan

### DIFF
--- a/integration_tests/run_test.go
+++ b/integration_tests/run_test.go
@@ -129,6 +129,10 @@ func runContainerWithTimeout(t *testing.T, imageName, expectedOutput string, env
 	for key, value := range envs {
 		args = append(args, "-e", fmt.Sprintf("%s=%s", key, value))
 	}
+	// Pass through GITHUB_TOKEN if it exists, this avoids mise timeouts inside the container
+	if githubToken := os.Getenv("GITHUB_TOKEN"); githubToken != "" {
+		args = append(args, "-e", fmt.Sprintf("GITHUB_TOKEN=%s", githubToken))
+	}
 	args = append(args, imageName)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)


### PR DESCRIPTION
this should eliminate the 403 errors
