### PR TITLE
fix: remove python3-dev apt package

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -63,8 +63,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libpq-dev python3-dev'",
-     "customName": "install apt packages: libpq-dev python3-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libpq-dev'",
+     "customName": "install apt packages: libpq-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "pip": {
    "directory": "/opt/pip-cache",
    "type": "shared"
@@ -56,24 +48,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -93,7 +67,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "pip": {
    "directory": "/opt/pip-cache",
    "type": "shared"
@@ -56,24 +48,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -93,7 +67,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -1,14 +1,4 @@
 {
- "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  }
- },
  "deploy": {
   "base": {
    "image": "ghcr.io/railwayapp/railpack-runtime:latest"
@@ -52,24 +42,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -89,7 +61,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "pip": {
    "directory": "/opt/pip-cache",
    "type": "shared"
@@ -56,24 +48,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -93,7 +67,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -1,14 +1,4 @@
 {
- "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  }
- },
  "deploy": {
   "base": {
    "image": "ghcr.io/railwayapp/railpack-runtime:latest"
@@ -52,24 +42,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -89,7 +61,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -1,14 +1,4 @@
 {
- "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  }
- },
  "deploy": {
   "base": {
    "image": "ghcr.io/railwayapp/railpack-runtime:latest"
@@ -52,24 +42,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -89,7 +61,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -63,8 +63,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libcairo2-dev libpq-dev python3-dev'",
-     "customName": "install apt packages: libcairo2-dev libpq-dev python3-dev"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libcairo2-dev libpq-dev'",
+     "customName": "install apt packages: libcairo2-dev libpq-dev"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "uv": {
    "directory": "/opt/uv-cache",
    "type": "shared"
@@ -57,24 +49,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -98,7 +72,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "uv": {
    "directory": "/opt/uv-cache",
    "type": "shared"
@@ -57,24 +49,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -98,7 +72,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "uv": {
    "directory": "/opt/uv-cache",
    "type": "shared"
@@ -57,24 +49,6 @@
  },
  "steps": [
   {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y python3-dev'",
-     "customName": "install apt packages: python3-dev"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-builder:latest"
-    }
-   ],
-   "name": "packages:apt:build"
-  },
-  {
    "assets": {
     "mise.toml": "[mise.toml]"
    },
@@ -98,7 +72,7 @@
    ],
    "inputs": [
     {
-     "step": "packages:apt:build"
+     "image": "ghcr.io/railwayapp/railpack-builder:latest"
     }
    ],
    "name": "packages:mise",


### PR DESCRIPTION
This work started because of this build error:

```
/mise/installs/poetry/2.1.4/venv/bin/python: error while loading shared libraries: libexpat.so.1: cannot open shared object file: No such file or directory
```

This error appeared after [merging this PR](https://github.com/railwayapp/railpack/pull/249) which switched to the default mise backend for poetry instead of `pipx`.

This error occured because:

* `python3-dev` was installed. I don't see a reason why this package is included by default since mise manages this runtime.
* However, the `python3-dev` package was not included in the runtime.
* Poetry has an option `POETRY_VIRTUALENVS_OPTIONS_ALWAYS_COPY`, although: (a) it is disabled by default (b) we do not switch this default and (c) the default mise backend (asdf) does not either. Additionally, this does not seem to apply to `python` which poetry does not manage.
* However, the `python3-dev` binary is copied into poetry's own venv during installation. This is linked to libraries which are removed after the build phase is complete. And therefore, when `poetry` is run it fails because of a missing library.
* After some digging it looks like the poetry install script creates a venv using the python venv module, which has an option to either use symlinks or copy the python version. The `symlinks=` option is _disabled_ by the default poetry installation script, which is really interesting. The mise install script [attempts to reverse this default](https://github.com/mise-plugins/mise-poetry/blob/11d0c1e873a09f5663cc8079e744bf782c3235c4/bin/install#L48-L53), but my guess is it's failing here.
* Additionally, `poetry` defaults to recommending pipx for installation and not the install script which the default mise backend uses.

The fix here is to remove the unneeded `python3-dev` package (which is done here) and expand the poetry-related tests to actually run against the poetry binary instead of a raw `python ...` start command.

The other meta-learning here is we shouldn't always assume the mise default (especially if it's coming from the asdf ecosystem) is the right one. It's worth putting some time into the ensuring we have the right backends set for important packages.