### PR TITLE
feat: add support for .bun-version file

### DIFF
--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -203,6 +203,7 @@ var miseConfigFiles = []string{
 	".python-version",
 	".node-version",
 	".nvmrc",
+	".bun-version",
 }
 
 func (b *MiseStepBuilder) GetSupportingMiseConfigFiles(path string) []string {

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -309,6 +309,10 @@ func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 			miseStep.Version(bun, envVersion, varName)
 		}
 
+		if bunVersionFile, err := ctx.App.ReadFile(".bun-version"); err == nil {
+			miseStep.Version(bun, string(bunVersionFile), ".bun-version")
+		}
+
 		// If we don't need node in the final image, we still want to include it for the install steps
 		// since many packages need node-gyp to install native modules
 		// in this case, we don't need a specific version, so we'll just pull from apt


### PR DESCRIPTION
Railpack now reads .bun-version files to match mise's behavior, preventing version mismatch errors when both tools are used together.