### PR TITLE
Update default versions for Go, Python, Ruby, and Rust providers

### DIFF
--- a/core/providers/golang/golang.go
+++ b/core/providers/golang/golang.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	DEFAULT_GO_VERSION = "1.23"
+	DEFAULT_GO_VERSION = "1.25"
 	GO_BUILD_CACHE_KEY = "go-build"
 	GO_BINARY_NAME     = "out"
 	GO_PATH            = "/go"

--- a/core/providers/golang/golang_test.go
+++ b/core/providers/golang/golang_test.go
@@ -37,7 +37,7 @@ func TestGolang(t *testing.T) {
 			detected:     true,
 			hasGoMod:     false,
 			hasWorkspace: true,
-			goVersion:    "1.23",
+			goVersion:    "1.25",
 		},
 		{
 			name:     "node",

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DEFAULT_PYTHON_VERSION = "3.11"
+	DEFAULT_PYTHON_VERSION = "3.13"
 	UV_CACHE_DIR           = "/opt/uv-cache"
 	PIP_CACHE_DIR          = "/opt/pip-cache"
 	VENV_PATH              = "/app/.venv"

--- a/core/providers/ruby/ruby.go
+++ b/core/providers/ruby/ruby.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	DEFAULT_RUBY_VERSION = "3.4.2"
+	DEFAULT_RUBY_VERSION = "3.4.6"
 )
 
 type RubyProvider struct{}

--- a/core/providers/rust/rust.go
+++ b/core/providers/rust/rust.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DEFAULT_RUST_VERSION = "1.85.1"
+	DEFAULT_RUST_VERSION = "1.89"
 	CARGO_REGISTRY_CACHE = "/root/.cargo/registry"
 	CARGO_GIT_CACHE      = "/root/.cargo/git"
 	CARGO_TARGET_CACHE   = "target"


### PR DESCRIPTION
Updates default language versions across multiple providers to their latest stable releases.

- **Go**: Updated from 1.23 to 1.25
- **Python**: Updated from 3.11 to 3.13
- **Ruby**: Updated from 3.4.2 to 3.4.6
- **Rust**: Updated from 1.85.1 to 1.89