### PR TITLE
Add configurable skippable commands list to pretty print output

### DIFF
--- a/core/prettyPrint.go
+++ b/core/prettyPrint.go
@@ -270,6 +270,10 @@ func getStepsToPrint(br *BuildResult) []*plan.Step {
 	return execSteps
 }
 
+var skippableCommands = []string{
+	"mkdir -p /app/node_modules/.cache",
+}
+
 func getCommandsToPrint(commands []plan.Command) []plan.ExecCommand {
 	if commands == nil {
 		return []plan.ExecCommand{}
@@ -278,10 +282,21 @@ func getCommandsToPrint(commands []plan.Command) []plan.ExecCommand {
 	execCommands := []plan.ExecCommand{}
 	for _, cmd := range commands {
 		if execCmd, ok := cmd.(plan.ExecCommand); ok {
-			execCommands = append(execCommands, execCmd)
+			if !isSkippableCommand(execCmd.Cmd) {
+				execCommands = append(execCommands, execCmd)
+			}
 		}
 	}
 	return execCommands
+}
+
+func isSkippableCommand(cmd string) bool {
+	for _, skippable := range skippableCommands {
+		if cmd == skippable {
+			return true
+		}
+	}
+	return false
 }
 
 func formatSource(pkg *resolver.ResolvedPackage) string {


### PR DESCRIPTION
Adds a configurable list of commands to filter out from pretty print build output. This reduces noise by hiding utility commands like cache directory creation from the displayed build steps.