### PR TITLE
fix: gracefully handle resolution failures for packages with SkipMiseInstall=true

### DIFF
--- a/core/resolver/resolver.go
+++ b/core/resolver/resolver.go
@@ -99,7 +99,12 @@ func (r *Resolver) ResolvePackages() (map[string]*ResolvedPackage, error) {
 			var err error
 			latestVersion, err = r.mise.GetLatestVersion(name, fuzzyVersion)
 			if err != nil {
-				return nil, err
+				// If we are not installign with Mise, then we don't need to error if we can't resolve the version
+				if pkg.SkipMiseInstall {
+					latestVersion = fuzzyVersion
+				} else {
+					return nil, err
+				}
 			}
 		}
 


### PR DESCRIPTION
Packages with SkipMiseInstall=true (like pnpm/yarn using corepack) now gracefully fall back to the requested version when mise resolution fails, instead of failing the entire build.