### PR TITLE
chore: mise update 2025.9.18

### DIFF
--- a/core/mise/install.go
+++ b/core/mise/install.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	miseVersion       = "2025.9.17"
+	miseVersion       = "2025.9.18"
 	githubReleaseBase = "https://github.com/jdx/mise/releases/download"
 )
 


### PR DESCRIPTION
Update mise to 2025.9.18