### PR TITLE
feat: allow container variables to be specified

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -133,7 +133,7 @@ var BuildCommand = &cli.Command{
 func validateSecrets(plan *plan.BuildPlan, env *app.Environment) error {
 	for _, secret := range plan.Secrets {
 		if _, ok := env.Variables[secret]; !ok {
-			return fmt.Errorf("missing environment variable: %s. Please set using --env %s=%s", secret, secret, "...")
+			return fmt.Errorf("missing environment variable: %s. Please set using --secret %s=%s", secret, secret, "...")
 		}
 	}
 	return nil

--- a/cli/common.go
+++ b/cli/common.go
@@ -23,6 +23,10 @@ func commonPlanFlags() []cli.Flag {
 			Usage:   "environment variables to set",
 		},
 		&cli.StringSliceFlag{
+			Name:  "var",
+			Usage: "variables to set",
+		},
+		&cli.StringSliceFlag{
 			Name:  "previous",
 			Usage: "versions of packages used for previous builds (e.g. 'package@version')",
 		},
@@ -60,10 +64,16 @@ func GenerateBuildResultForCommand(cmd *cli.Command) (*core.BuildResult, *a.App,
 	log.Debugf("Building %s", app.Source)
 
 	envsArgs := cmd.StringSlice("env")
+	varsArgs := cmd.StringSlice("var")
 
 	env, err := a.FromEnvs(envsArgs)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating env: %w", err)
+	}
+
+	vars, err := a.ParseKeyValueStrings(varsArgs, false)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error parsing vars: %w", err)
 	}
 
 	// if --verbose is passed as a CLI global argument, enable verbose mise logging so the user don't have to understand
@@ -81,6 +91,7 @@ func GenerateBuildResultForCommand(cmd *cli.Command) (*core.BuildResult, *a.App,
 		PreviousVersions:         previousVersions,
 		ConfigFilePath:           cmd.String("config-file"),
 		ErrorMissingStartCommand: cmd.Bool("error-missing-start"),
+		Vars:                     vars,
 	}
 
 	buildResult := core.GenerateBuildPlan(app, env, generateOptions)

--- a/cli/common.go
+++ b/cli/common.go
@@ -23,8 +23,8 @@ func commonPlanFlags() []cli.Flag {
 			Usage:   "environment variables to set",
 		},
 		&cli.StringSliceFlag{
-			Name:  "var",
-			Usage: "variables to set",
+			Name:  "secret",
+			Usage: "secrets to expose (can lookup from environment)",
 		},
 		&cli.StringSliceFlag{
 			Name:  "previous",
@@ -64,16 +64,16 @@ func GenerateBuildResultForCommand(cmd *cli.Command) (*core.BuildResult, *a.App,
 	log.Debugf("Building %s", app.Source)
 
 	envsArgs := cmd.StringSlice("env")
-	varsArgs := cmd.StringSlice("var")
+	secretsArgs := cmd.StringSlice("secret")
 
-	env, err := a.FromEnvs(envsArgs)
+	env, err := a.FromEnvs(secretsArgs)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating env: %w", err)
 	}
 
-	vars, err := a.ParseKeyValueStrings(varsArgs, false)
+	vars, err := a.ParseKeyValueStrings(envsArgs, false)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error parsing vars: %w", err)
+		return nil, nil, nil, fmt.Errorf("error parsing env vars: %w", err)
 	}
 
 	// if --verbose is passed as a CLI global argument, enable verbose mise logging so the user don't have to understand

--- a/cli/common.go
+++ b/cli/common.go
@@ -20,11 +20,11 @@ func commonPlanFlags() []cli.Flag {
 		&cli.StringSliceFlag{
 			Name:    "env",
 			Aliases: []string{"e"},
-			Usage:   "environment variables to set",
+			Usage:   "environment variable available during build and runtime",
 		},
 		&cli.StringSliceFlag{
 			Name:  "secret",
-			Usage: "secrets to expose (can lookup from environment)",
+			Usage: "sensitive environment variable available at build time",
 		},
 		&cli.StringSliceFlag{
 			Name:  "previous",

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -42,7 +42,7 @@ func EmptyConfig() *Config {
 		Steps:    make(map[string]*StepConfig),
 		Packages: make(map[string]string),
 		Caches:   make(map[string]*plan.Cache),
-		Deploy:   &DeployConfig{},
+		Deploy:   &DeployConfig{Variables: make(map[string]string)},
 	}
 }
 

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -199,7 +199,8 @@ func TestMergeConfig(t *testing.T) {
 		"deploy": {
 			"aptPackages": ["curl"],
 			"startCommand": "node server.js",
-			"paths": ["/usr/local/bin", "/app/bin"]
+			"paths": ["/usr/local/bin", "/app/bin"],
+			"variables": {}
 		}
 	}`
 
@@ -252,7 +253,8 @@ func TestMergeConfig(t *testing.T) {
 		"deploy": {
 			"aptPackages": ["curl"],
 			"startCommand": "node server.js",
-			"paths": ["/usr/local/bin", "/app/bin"]
+			"paths": ["/usr/local/bin", "/app/bin"],
+			"variables": {}
 		}
 	}`
 
@@ -286,7 +288,8 @@ func TestMergeConfigStart(t *testing.T) {
 			"node": "23"
 		},
 		"deploy": {
-			"startCommand": "python app.py"
+			"startCommand": "python app.py",
+			"variables": {}
 		},
 		"steps": {},
 		"caches": {}

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -24,7 +24,7 @@ func TestGenerateConfigFromEnvironment(t *testing.T) {
 				"steps": {},
 				"packages": {},
 				"caches": {},
-				"deploy": {}
+				"deploy": {"variables": {}}
 			}`,
 		},
 
@@ -69,7 +69,8 @@ func TestGenerateConfigFromEnvironment(t *testing.T) {
 				"caches": {},
 				"deploy": {
 					"startCommand": "npm start",
-					"aptPackages": ["libssl-dev"]
+					"aptPackages": ["libssl-dev"],
+					"variables": {}
 				},
 				"secrets": ["RAILPACK_BUILD_APT_PACKAGES", "RAILPACK_BUILD_CMD", "RAILPACK_DEPLOY_APT_PACKAGES",
 					"RAILPACK_INSTALL_CMD", "RAILPACK_PACKAGES", "RAILPACK_START_CMD"]

--- a/core/core.go
+++ b/core/core.go
@@ -24,6 +24,16 @@ const (
 	defaultConfigFileName = "railpack.json"
 )
 
+// mergeVariables merges userVars into providerVars, with userVars taking precedence
+func mergeVariables(providerVars map[string]string, userVars map[string]string) {
+	if providerVars == nil {
+		return
+	}
+	for key, value := range userVars {
+		providerVars[key] = value
+	}
+}
+
 type GenerateBuildPlanOptions struct {
 	RailpackVersion          string
 	BuildCommand             string
@@ -84,6 +94,11 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 		for name, version := range options.PreviousVersions {
 			ctx.Resolver.SetPreviousVersion(name, version)
 		}
+	}
+
+	// Set user variables to be available in all steps
+	if options.Vars != nil {
+		maps.Copy(ctx.UserVariables, options.Vars)
 	}
 
 	// Figure out what providers to use
@@ -267,7 +282,7 @@ func GenerateConfigFromOptions(options *GenerateBuildPlanOptions) *c.Config {
 	}
 
 	if options.Vars != nil {
-		config.Deploy.Variables = options.Vars
+		mergeVariables(config.Deploy.Variables, options.Vars)
 	}
 
 	return config

--- a/core/core.go
+++ b/core/core.go
@@ -31,6 +31,7 @@ type GenerateBuildPlanOptions struct {
 	PreviousVersions         map[string]string
 	ConfigFilePath           string
 	ErrorMissingStartCommand bool // enabled on railway
+	Vars                     map[string]string
 }
 
 type BuildResult struct {
@@ -263,6 +264,10 @@ func GenerateConfigFromOptions(options *GenerateBuildPlanOptions) *c.Config {
 
 	if options.StartCommand != "" {
 		config.Deploy.StartCmd = options.StartCommand
+	}
+
+	if options.Vars != nil {
+		config.Deploy.Variables = options.Vars
 	}
 
 	return config

--- a/core/generate/command_step_builder.go
+++ b/core/generate/command_step_builder.go
@@ -121,6 +121,9 @@ func (b *CommandStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions)
 	step.Variables = b.Variables
 	step.Secrets = b.Secrets
 
+	// Add user variables to this step
+	maps.Copy(step.Variables, options.UserVariables)
+
 	p.Steps = append(p.Steps, *step)
 
 	return nil

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -20,6 +20,7 @@ import (
 type BuildStepOptions struct {
 	ResolvedPackages map[string]*resolver.ResolvedPackage
 	Caches           *CacheContext
+	UserVariables    map[string]string
 }
 
 type StepBuilder interface {
@@ -37,8 +38,9 @@ type GenerateContext struct {
 	Steps     []StepBuilder
 	Deploy    *DeployBuilder
 
-	Caches  *CacheContext
-	Secrets []string
+	Caches        *CacheContext
+	Secrets       []string
+	UserVariables map[string]string
 
 	SubContexts []string
 
@@ -89,6 +91,7 @@ func NewGenerateContext(app *a.App, env *a.Environment, config *config.Config, l
 		Deploy:          NewDeployBuilder(),
 		Caches:          NewCacheContext(),
 		Secrets:         []string{},
+		UserVariables:   make(map[string]string),
 		Metadata:        NewMetadata(),
 		Resolver:        resolver,
 		Logger:          logger,
@@ -165,6 +168,7 @@ func (c *GenerateContext) Generate() (*plan.BuildPlan, map[string]*resolver.Reso
 	buildStepOptions := &BuildStepOptions{
 		ResolvedPackages: resolvedPackages,
 		Caches:           c.Caches,
+		UserVariables:    c.UserVariables,
 	}
 
 	for _, stepBuilder := range c.Steps {

--- a/core/generate/deploy_builder.go
+++ b/core/generate/deploy_builder.go
@@ -1,6 +1,8 @@
 package generate
 
 import (
+	"maps"
+
 	"github.com/railwayapp/railpack/core/plan"
 )
 
@@ -72,6 +74,10 @@ func (b *DeployBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) {
 		})
 		runtimeAptStep.Caches = options.Caches.GetAptCaches()
 		runtimeAptStep.Secrets = []string{}
+
+		// Add user variables to the runtime apt step
+		maps.Copy(runtimeAptStep.Variables, options.UserVariables)
+
 		p.Steps = append(p.Steps, *runtimeAptStep)
 		baseLayer = plan.NewStepLayer(runtimeAptStep.Name)
 	}
@@ -82,4 +88,7 @@ func (b *DeployBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) {
 	p.Deploy.StartCmd = b.StartCmd
 	p.Deploy.Variables = b.Variables
 	p.Deploy.Paths = b.Paths
+
+	// Add user variables to the deploy step (in addition to config-based merging)
+	maps.Copy(p.Deploy.Variables, options.UserVariables)
 }

--- a/core/generate/image_step_builder.go
+++ b/core/generate/image_step_builder.go
@@ -1,6 +1,8 @@
 package generate
 
 import (
+	"maps"
+
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/resolver"
 )
@@ -63,6 +65,9 @@ func (b *ImageStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) e
 			options.NewAptInstallCommand(b.AptPackages),
 		}
 	}
+
+	// Add user variables to this step
+	maps.Copy(step.Variables, options.UserVariables)
 
 	p.Steps = append(p.Steps, *step)
 

--- a/core/generate/install_bin_builder.go
+++ b/core/generate/install_bin_builder.go
@@ -8,6 +8,7 @@ package generate
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/resolver"
@@ -85,6 +86,9 @@ func (b *InstallBinStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptio
 		plan.NewPathCommand(binPath),
 		plan.NewPathCommand(fmt.Sprintf("%s/bin", binPath)),
 	})
+
+	// Add user variables to this step
+	maps.Copy(step.Variables, options.UserVariables)
 
 	p.Steps = append(p.Steps, *step)
 

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -346,6 +346,9 @@ func (b *MiseStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) er
 	step.Assets = b.Assets
 	step.Secrets = []string{}
 
+	// Add user variables to this step
+	maps.Copy(step.Variables, options.UserVariables)
+
 	p.Steps = append(p.Steps, *step)
 
 	return nil

--- a/core/plan/plan.go
+++ b/core/plan/plan.go
@@ -39,7 +39,7 @@ type Deploy struct {
 func NewBuildPlan() *BuildPlan {
 	return &BuildPlan{
 		Steps:   []Step{},
-		Deploy:  Deploy{},
+		Deploy:  Deploy{Variables: make(map[string]string)},
 		Caches:  make(map[string]*Cache),
 		Secrets: []string{},
 		Exclude: []string{},

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -12,17 +12,19 @@ differences being:
 - Secrets are environment variables which never logged or saved in the build logs. They are also *only*
   available at build time and not saved to the final image (and therefore not available at runtime).
 
-Some examples of where you might use each:
+Some examples of when you might use each:
 
 - **Environment Variables**: `NODE_ENV`, `PYTHON_ENV`, `TZ`, etc.
-- **Secrets**: `SENTRY_AUTH_TOKEN` (used to report a new build to Sentry, but not required at runtime). Or an API key used to collect static assets during the build. *Do not* include `DATABASE_URL`, `STRIPE_API_KEY`, or other secrets required at runtime here (unless you need them at build time).
+- **Secrets**: `SENTRY_AUTH_TOKEN` (used to report a new build to Sentry, but not required at runtime). Or an API key used to collect static assets during the build.
+
+`DATABASE_URL`, `STRIPE_API_KEY` or other secrets required at runtime should
+not be configured in Railpack (unless you need them at build time).
 
 ## Environment Variables
 
 Environment variables can be set in a couple ways:
 
-1. Through step variables. In this case, the variable is available only during that
-   step:
+1. Within a step. In this case, the variable is available only in the context of that single step:
 
 ```json
 {
@@ -36,7 +38,7 @@ Environment variables can be set in a couple ways:
 }
 ```
 
-2. Through the deploy section for runtime variables. These variables are only available at runtime and will not be set during the build:
+1. In the deploy configuration. These variables are only available at runtime and are not set during the build:
 
 ```json
 {
@@ -48,8 +50,10 @@ Environment variables can be set in a couple ways:
 }
 ```
 
-3. Through the top-level `variables` field. These variables are available during all steps of
-   the build *and* at runtime:
+Note that you could also use `mise.toml` to configure env variables available
+only at runtime.
+
+1. The top-level `env` field. These variables are available during all steps of the build *and* at runtime:
 
 ```json
 {
@@ -59,10 +63,9 @@ Environment variables can be set in a couple ways:
 }
 ```
 
-Railpack always sets `RAILPACK_VERSION` on the final runtime image to the
-Railpack version that produced the image (for example `0.12.3`).
-
 ## Secrets
+
+Secrets are environment variables with sensitive information that you never want included in a container.
 
 The names of all secrets that should be used during the build are added to the
 top of the build plan, and each step's `secrets` array specifies which secrets
@@ -85,7 +88,8 @@ that step.
   "secrets": ["DATABASE_URL", "API_KEY", "STRIPE_LIVE_KEY"],
   "steps": {
     "build": {
-      "secrets": ["DATABASE_URL", "API_KEY"] // Only these secrets are available to this step
+      // Only these secrets are available to this step
+      "secrets": ["DATABASE_URL", "API_KEY"]
     }
   }
 }
@@ -99,7 +103,8 @@ access to all secrets defined in the build plan:
   "secrets": ["DATABASE_URL", "API_KEY", "STRIPE_LIVE_KEY"],
   "steps": {
     "build": {
-      "secrets": ["*"] // This step has access to all secrets
+      // This step has access to all secrets
+      "secrets": ["*"]
     }
   }
 }

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -116,32 +116,31 @@ If building with [the CLI](/reference/cli/#build), Railpack will check that all
 the secrets defined in the build plan have variables.
 
 ```bash
-railpack build --secret SENTRY_AUTH_TOKEN=sk_live_asdf
+railpack build --secret SENTRY_AUTH_TOKEN=sntrys_1234
 ```
 
 You can also provide environment variables with the `--env` flag. These will available to all steps and in the final image (using `railpack.json` if you need to customize when a environment variable is available).
 
 ```bash
-railpack build --env TZ=UTC --secret SENTRY_AUTH_TOKEN=sk_live_asdf
+railpack build --env TZ=UTC --secret SENTRY_AUTH_TOKEN=sntrys_1234
 ```
 
 #### Custom Frontend
 
-If building with the [BuildKit frontend](/platforms/buildkit-frontend),
-you should still provide the secrets when generating the plan with `--env`. This
-adds the secrets to the build plan. You then need to pass the secrets to Docker
-or BuildKit with the `--secret` flag.
+If building with the [BuildKit frontend](/platforms/buildkit-frontend), use
+Railpack's `--secret` flag when generating the build plan. Then pass the
+secrets to Docker or BuildKit with its `--secret` flag.
 
 ```bash
 # Generate a build plan
-railpack plan --secret STRIPE_LIVE_KEY=sk_live_asdf --out railpack-plan.json
+railpack plan --secret SENTRY_AUTH_TOKEN=sntrys_1234 --env TZ=UTC --out railpack-plan.json
 
 # Build with the custom frontend
-SENTRY_AUTH_TOKEN=asdf123456789 docker build \
+SENTRY_AUTH_TOKEN=sntrys_1234 docker build \
   --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack:railpack-frontend" \
   -f railpack-plan.json \
   --secret id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
-  --build-arg secrets-hash=asdfasdf \
+  --build-arg secrets-hash=YOUR_GENERATED_SECRETS_HASH \
   examples/node-bun
 ```
 

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -9,20 +9,26 @@ differences being:
 - Environment variables are saved in the final image and should not contain
   sensitive information. Since they are in the final image, providers can add
   variables that will be available to the app at runtime.
-- Secrets are never logged or saved in the build logs. They are also only
-  available at build time and not saved to the final image.
+- Secrets are environment variables which never logged or saved in the build logs. They are also *only*
+  available at build time and not saved to the final image (and therefore not available at runtime).
+
+Some examples of where you might use each:
+
+- **Environment Variables**: `NODE_ENV`, `PYTHON_ENV`, `TZ`, etc.
+- **Secrets**: `SENTRY_AUTH_TOKEN` (used to report a new build to Sentry, but not required at runtime). Or an API key used to collect static assets during the build. *Do not* include `DATABASE_URL`, `STRIPE_API_KEY`, or other secrets required at runtime here (unless you need them at build time).
 
 ## Environment Variables
 
-Environment variables can be set in two ways:
+Environment variables can be set in a couple ways:
 
-1. Through step variables:
+1. Through step variables. In this case, the variable is available only during that
+   step:
 
 ```json
 {
   "steps": {
     "install": {
-      "variables": {
+      "env": {
         "NODE_ENV": "production"
       }
     }
@@ -30,14 +36,25 @@ Environment variables can be set in two ways:
 }
 ```
 
-2. Through the deploy section for runtime variables:
+2. Through the deploy section for runtime variables. These variables are only available at runtime and will not be set during the build:
 
 ```json
 {
   "deploy": {
-    "variables": {
+    "env": {
       "NODE_ENV": "production"
     }
+  }
+}
+```
+
+3. Through the top-level `variables` field. These variables are available during all steps of
+   the build *and* at runtime:
+
+```json
+{
+  "env": {
+    "TZ": "America/Los_Angeles"
   }
 }
 ```
@@ -90,7 +107,7 @@ access to all secrets defined in the build plan:
 
 ### Providing Secrets
 
-You can add secrets when building or generating a build plan with the `--env`
+You can add secrets when building or generating a build plan with the `--secret`
 flag. The names of these variables will be added to the build plan as secrets.
 
 #### CLI Build
@@ -99,7 +116,13 @@ If building with [the CLI](/reference/cli/#build), Railpack will check that all
 the secrets defined in the build plan have variables.
 
 ```bash
-railpack build --env STRIPE_LIVE_KEY=sk_live_asdf
+railpack build --secret SENTRY_AUTH_TOKEN=sk_live_asdf
+```
+
+You can also provide environment variables with the `--env` flag. These will available to all steps and in the final image (using `railpack.json` if you need to customize when a environment variable is available).
+
+```bash
+railpack build --env TZ=UTC --secret SENTRY_AUTH_TOKEN=sk_live_asdf
 ```
 
 #### Custom Frontend
@@ -111,13 +134,13 @@ or BuildKit with the `--secret` flag.
 
 ```bash
 # Generate a build plan
-railpack plan --env STRIPE_LIVE_KEY=sk_live_asdf --out test/railpack-plan.json
+railpack plan --secret STRIPE_LIVE_KEY=sk_live_asdf --out railpack-plan.json
 
 # Build with the custom frontend
-STRIPE_LIVE_KEY=asdf123456789 docker build \
+SENTRY_AUTH_TOKEN=asdf123456789 docker build \
   --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack:railpack-frontend" \
-  -f test/railpack-plan.json \
-  --secret id=STRIPE_LIVE_KEY,env=STRIPE_LIVE_KEY \
+  -f railpack-plan.json \
+  --secret id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
   --build-arg secrets-hash=asdfasdf \
   examples/node-bun
 ```

--- a/docs/src/content/docs/config/file.mdx
+++ b/docs/src/content/docs/config/file.mdx
@@ -3,6 +3,8 @@ title: Configuration File
 description: Learn about the railpack.json configuration file format and options
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Railpack will look for a `railpack.json` file in the root of the directory being
 built. You can override this by setting the `RAILPACK_CONFIG_FILE` environment
 variable to a path relative to the directory being built.
@@ -317,7 +319,15 @@ Commands can also be specified using a string format:
 
 ## Deploy
 
-The deploy section configures how the container runs:
+The deploy section configures how the container runs.
+
+### Entrypoint
+
+Railpack hardcodes the container's entrypoint to `["/bin/bash", "-c"]`. This
+means your `startCommand` is executed as a shell command within a Bash
+environment. The entrypoint is not configurable.
+
+### Deploy Fields
 
 | Field          | Description                                                             |
 | :------------- | :---------------------------------------------------------------------- |


### PR DESCRIPTION
Issue I ran into when attempting to replace nixpacks with railpack in my template project:

* `--env` currently represents a secret, not an [environment variable as specified here](https://railpack.com/architecture/secrets/#_top)
* There's not a way to define a environment variable when running `railpack build` which makes it challenging to reproduce a production railway build locally.

Here's what I propose:

* Breaking change: move current `--env` functionality to `--secret`
* Add a `--env` flag which works like the `--var` flag proposed in this PR

This code is a rough draft; I need to give it another review. I wanted to get your take on this before spending more time on it.