### PR TITLE
fix: fit variable name width

### DIFF
--- a/docs/src/content/docs/config/environment-variables.md
+++ b/docs/src/content/docs/config/environment-variables.md
@@ -8,14 +8,14 @@ often prefixed with `RAILPACK_`.
 
 ## Build Configuration
 
-| Name                           | Description                                                                                                                                                                     |
-| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `RAILPACK_BUILD_CMD`           | Set the command to run for the build step. This overwrites any commands that come from providers                                                                                |
-| `RAILPACK_INSTALL_CMD`         | Set the command to run for the install step. This overwrites any commands that come from providers. All files are copied to the root of the project before running the command. |
-| `RAILPACK_START_CMD`           | Set the command to run when the container starts                                                                                                                                |
-| `RAILPACK_PACKAGES`            | Install additional Mise packages. In the format `pkg@version`. The latest version is used if not provided.                                                                      |
-| `RAILPACK_BUILD_APT_PACKAGES`  | Install additional Apt packages during build                                                                                                                                    |
-| `RAILPACK_DEPLOY_APT_PACKAGES` | Install additional Apt packages in the final image                                                                                                                              |
+| <div style="width:250px">Name</div> | Description                                                                                                                                                                     |
+| :---------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `RAILPACK_BUILD_CMD`                | Set the command to run for the build step. This overwrites any commands that come from providers                                                                                |
+| `RAILPACK_INSTALL_CMD`              | Set the command to run for the install step. This overwrites any commands that come from providers. All files are copied to the root of the project before running the command. |
+| `RAILPACK_START_CMD`                | Set the command to run when the container starts                                                                                                                                |
+| `RAILPACK_PACKAGES`                 | Install additional Mise packages. In the format `pkg@version`. The latest version is used if not provided.                                                                      |
+| `RAILPACK_BUILD_APT_PACKAGES`       | Install additional Apt packages during build                                                                                                                                    |
+| `RAILPACK_DEPLOY_APT_PACKAGES`      | Install additional Apt packages in the final image                                                                                                                              |
 
 To configure more parts of the build, it is recommended to use a [config file](/config/file).
 


### PR DESCRIPTION
I understand that this is a pretty hacky approach but it seems to work at all resolutions. It looks very messy without this change.

Old:
<img width="818" height="627" alt="image" src="https://github.com/user-attachments/assets/74714b32-3aa7-4548-8f5a-58f3e9b8b496" />

New:
<img width="793" height="543" alt="image" src="https://github.com/user-attachments/assets/b527abe0-fb9d-4987-82c1-dd5b99544c2f" />
