### PR TITLE
fix: support + character in environment variable names

### DIFF
--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -22,7 +22,7 @@ func NewEnvironment(variables *map[string]string) *Environment {
 // FromEnvs collects variables from the given environment variable names
 func FromEnvs(envs []string) (*Environment, error) {
 	env := NewEnvironment(nil)
-	re := regexp.MustCompile(`([A-Za-z0-9_-]*)(?:=?)(.*)`)
+	re := regexp.MustCompile(`([A-Za-z0-9_+\-]*)(?:=?)(.*)`)
 
 	for _, e := range envs {
 		matches := re.FindStringSubmatch(e)

--- a/core/app/environment_test.go
+++ b/core/app/environment_test.go
@@ -13,6 +13,7 @@ func TestFromEnvs(t *testing.T) {
 		"RAILPACK_APT_PACKAGES=apt1,apt2",
 		"COMMA=this has, a comma",
 		"RAILPACK_TRUTHY_CASE=True ",
+		"HELLO+WORLD=boop",
 	})
 
 	require.NoError(t, err)
@@ -21,4 +22,5 @@ func TestFromEnvs(t *testing.T) {
 	require.Equal(t, env.GetVariable("RAILPACK_APT_PACKAGES"), "apt1,apt2")
 	require.Equal(t, env.GetVariable("COMMA"), "this has, a comma")
 	require.Equal(t, env.IsConfigVariableTruthy("TRUTHY_CASE"), true)
+	require.Equal(t, env.GetVariable("HELLO+WORLD"), "boop")
 }


### PR DESCRIPTION
Fixes environment variable parsing to support the `+` character in variable names.

Previously, environment variables like `HELLO+WORLD=boop` would be incorrectly parsed as `HELLO` with value `+WORLD=boop` due to an overly restrictive regex pattern.