### PR TITLE
fix(docs): buildctl syntax in running in production

### DIFF
--- a/docs/src/content/docs/guides/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/guides/running-railpack-in-production.mdx
@@ -61,7 +61,7 @@ buildctl build \
   --local context=/path/to/app/to/build \
   --local dockerfile=/path/to/dir/containing/railpack-plan.json \
   --frontend=gateway.v0 \
-  --opt source=ghcr.io/railwayapp/railpack:railpack-frontend \
+  --opt source=ghcr.io/railwayapp/railpack-frontend \
   --output type=docker,name=test
 ```
 


### PR DESCRIPTION
`ghcr.io/railwayapp/railpack:railpack-frontend`, the currently referenced syntax, doesn't exist.