### PR TITLE
fix(docs): clarify provider list on homepage

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
 	<Card title="Zero-config" icon="star">
-		Support for Node, Python, Go, and PHP out of the box. (more coming soon!). First class support for Vite, Astro, and CRA static sites.
+		Support for Node, Python, Go, PHP, Java, Ruby, and more of the box. First class support for Vite, Astro, and CRA static sites.
 	</Card>
 
 	<Card title="Built on BuildKit" icon="rocket">


### PR DESCRIPTION
It currently makes it seem like we still have only four providers, which isn't true.