### PR TITLE
feat: support mise config for deno version

### DIFF
--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -85,6 +85,8 @@ func (p *DenoProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 	if envVersion, varName := ctx.Env.GetConfigVariable("DENO_VERSION"); envVersion != "" {
 		miseStep.Version(deno, envVersion, varName)
 	}
+
+	miseStep.UseMiseVersions(ctx, []string{"deno"})
 }
 
 func (p *DenoProvider) findMainFile(ctx *generate.GenerateContext) string {

--- a/docs/src/content/docs/languages/deno.md
+++ b/docs/src/content/docs/languages/deno.md
@@ -15,6 +15,8 @@ Your project will be detected as a Deno application if a `deno.json` or
 The Deno version is determined in the following order:
 
 - Set via the `RAILPACK_DENO_VERSION` environment variable
+- Read from mise-compatible version files (`.deno-version`,
+  `.tool-versions`, `mise.toml`)
 - Defaults to `2`
 
 ## Configuration


### PR DESCRIPTION
Slowly moving all providers over to respecting mise version config.