### PR TITLE
fix: adding metadata for framework detection

### DIFF
--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -448,8 +448,6 @@ func (p *PythonProvider) addMetadata(ctx *generate.GenerateContext) {
 
 	ctx.Metadata.Set("pythonPackageManager", pkgManager)
 	ctx.Metadata.Set("pythonRuntime", p.getRuntime(ctx))
-	ctx.Metadata.SetBool("pythonDjango", p.isDjango(ctx))
-	ctx.Metadata.SetBool("pythonFlask", p.isFlask(ctx))
 }
 
 func (p *PythonProvider) usesDep(ctx *generate.GenerateContext, dep string) bool {


### PR DESCRIPTION
did a quick audit on providers which detect frameworks to add some reporting metadata. This is the only one that was missing.

Man did claude fail out on this too.