### PR TITLE
build: move dive to a dev-only toolset, bump bun version

### DIFF
--- a/mise.dev.toml
+++ b/mise.dev.toml
@@ -1,0 +1,2 @@
+[tools]
+"go:github.com/wagoodman/dive" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -56,9 +56,7 @@ run = "bun run dev"
 [tools]
 go = "1.23.4"
 golangci-lint = "1.63.4"
-bun = "1.2"
-node = "22"
-"go:github.com/wagoodman/dive" = "latest"
+bun = "latest"
 
 [settings]
 experimental = true


### PR DESCRIPTION
I need to update the dev docs to use MISE_ENV, etc but this at least will make the builds less flakey. Dive was failing to install.