### PR TITLE
docs: can't eliminate sh usage for apt

### DIFF
--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -177,6 +177,7 @@ func (o *BuildStepOptions) NewAptInstallCommand(pkgs []string) plan.Command {
 	pkgs = utils.RemoveDuplicates(pkgs)
 	sort.Strings(pkgs)
 
+	// sh -c is required because && is a shell operator that needs a shell to interpret it
 	return plan.NewExecCommand("sh -c 'apt-get update && apt-get install -y "+strings.Join(pkgs, " ")+"'", plan.ExecOptions{
 		CustomName: "install apt packages: " + strings.Join(pkgs, " "),
 	})

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -187,6 +187,8 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, build *generate.Comm
 	p.addCaches(ctx, build)
 }
 
+// adds framework-specific caches for packages that match the given framework check.
+// It creates uniquely named caches for each package's framework subdirectory to optimize build performance.
 func (p *NodeProvider) addFrameworkCaches(ctx *generate.GenerateContext, build *generate.CommandStepBuilder, frameworkName string, frameworkCheck func(*WorkspacePackage, *generate.GenerateContext) bool, cacheSubPath string) {
 	if packages, err := p.getPackagesWithFramework(ctx, frameworkCheck); err == nil {
 		for _, pkg := range packages {
@@ -196,6 +198,7 @@ func (p *NodeProvider) addFrameworkCaches(ctx *generate.GenerateContext, build *
 			} else {
 				cacheName = fmt.Sprintf("%s-%s", frameworkName, strings.ReplaceAll(strings.TrimSuffix(pkg.Path, "/"), "/", "-"))
 			}
+			// in this case, pkg.Path represents the relative path to a workspace package from the root of your repository
 			cacheDir := path.Join("/app", pkg.Path, cacheSubPath)
 			build.AddCache(ctx.Caches.AddCache(cacheName, cacheDir))
 		}

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -209,6 +209,8 @@ func (p *PhpProvider) DeployWithNode(ctx *generate.GenerateContext, nodeProvider
 	if isLaravel {
 		build.AddCommands([]plan.Command{
 			plan.NewExecShellCommand("mkdir -p storage/framework/{sessions,views,cache,testing} storage/logs bootstrap/cache && chmod -R a+rw storage"),
+			// config values like APP_KEY are resolved and baked into bootstrap/cache/config.php. Runtime env vars are ignored
+			// for cached configs, leading to MissingAppKeyException if APP_KEY was unset at cache time.
 			plan.NewExecCommand("php artisan config:cache"),
 			plan.NewExecCommand("php artisan event:cache"),
 			plan.NewExecCommand("php artisan route:cache"),

--- a/core/providers/ruby/ruby.go
+++ b/core/providers/ruby/ruby.go
@@ -118,6 +118,8 @@ func (p *RubyProvider) GetStartCommand(ctx *generate.GenerateContext) string {
 	startCommand := ""
 	app := ctx.App
 
+	// TODO we auto-run migrations for django, but not for rails, why the difference?
+
 	if p.usesRails(ctx) {
 		if app.HasMatch("rails") {
 			return "bundle exec rails server -b 0.0.0.0 -p ${PORT:-3000}"


### PR DESCRIPTION
Makes sense why we are using `sh -c` for these. At least it's documented now.
