### PR TITLE
docs: clarify Ruby detection logic

### DIFF
--- a/docs/src/content/docs/languages/ruby.md
+++ b/docs/src/content/docs/languages/ruby.md
@@ -8,9 +8,8 @@ language-specific tools and frameworks.
 
 ## Detection
 
-Your project will be detected as a Ruby application if any of these conditions are met:
-
-- A `Gemfile` file is present
+Your project is detected as a Ruby application if a `Gemfile` is present in
+the root directory.
 
 ## Versions
 


### PR DESCRIPTION
Update the Detection section to accurately reflect the implementation in ruby.go, which only checks for a Gemfile in the root directory. The previous wording suggested multiple conditions when only one exists.