### PR TITLE
refactor: replace HasMatch with HasFile for specific file paths

### DIFF
--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -325,7 +325,7 @@ func (b *MiseStepBuilder) GetSupportingMiseConfigFiles(path string) []string {
 	files := []string{}
 
 	for _, file := range miseConfigFiles {
-		if b.app.HasMatch(file) {
+		if b.app.HasFile(file) {
 			files = append(files, file)
 		}
 	}

--- a/core/generate/template.go
+++ b/core/generate/template.go
@@ -18,7 +18,7 @@ func (c *GenerateContext) TemplateFiles(potentialFiles []string, defaultContents
 	filename := ""
 
 	for _, potentialFilename := range potentialFiles {
-		if c.App.HasMatch(potentialFilename) {
+		if c.App.HasFile(potentialFilename) {
 			c, err := c.App.ReadFile(potentialFilename)
 			if err != nil {
 				return nil, err

--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -25,7 +25,7 @@ func (p *DenoProvider) Name() string {
 }
 
 func (p *DenoProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	hasDenoJson := ctx.App.HasMatch("deno.json") || ctx.App.HasMatch("deno.jsonc")
+	hasDenoJson := ctx.App.HasFile("deno.json") || ctx.App.HasFile("deno.jsonc")
 	return hasDenoJson, nil
 }
 
@@ -94,7 +94,7 @@ func (p *DenoProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 func (p *DenoProvider) findMainFile(ctx *generate.GenerateContext) string {
 	files := []string{"main.ts", "main.js", "main.mjs", "main.mts"}
 	for _, file := range files {
-		if ctx.App.HasMatch(file) {
+		if ctx.App.HasFile(file) {
 			return file
 		}
 	}

--- a/core/providers/elixir/elixir.go
+++ b/core/providers/elixir/elixir.go
@@ -29,7 +29,7 @@ func (p *ElixirProvider) Name() string {
 }
 
 func (p *ElixirProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	hasMixFile := ctx.App.HasMatch("mix.exs")
+	hasMixFile := ctx.App.HasFile("mix.exs")
 	return hasMixFile, nil
 }
 

--- a/core/providers/golang/golang.go
+++ b/core/providers/golang/golang.go
@@ -23,7 +23,7 @@ func (p *GoProvider) Name() string {
 }
 
 func (p *GoProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	return p.isGoMod(ctx) || p.isGoWorkspace(ctx) || ctx.App.HasMatch("main.go"), nil
+	return p.isGoMod(ctx) || p.isGoWorkspace(ctx) || ctx.App.HasFile("main.go"), nil
 }
 
 func (p *GoProvider) Initialize(ctx *generate.GenerateContext) error {
@@ -91,13 +91,13 @@ func (p *GoProvider) Build(ctx *generate.GenerateContext, build *generate.Comman
 		// For workspaces without explicit module selection, try to find a module with main package
 		packages := p.GoWorkspacePackages(ctx)
 		for _, pkg := range packages {
-			if ctx.App.HasMatch(filepath.Join(pkg, "main.go")) {
+			if ctx.App.HasFile(filepath.Join(pkg, "main.go")) {
 				ctx.Logger.LogInfo("Building workspace module: %s", pkg)
 				buildCmd = fmt.Sprintf("%s ./%s", baseBuildCmd, pkg)
 				break
 			}
 		}
-	} else if ctx.App.HasMatch("main.go") {
+	} else if ctx.App.HasFile("main.go") {
 		// Fallback to building the main package if no other build command is specified
 		buildCmd = fmt.Sprintf("%s main.go", baseBuildCmd)
 	}
@@ -131,14 +131,14 @@ func (p *GoProvider) InstallGoDeps(ctx *generate.GenerateContext, install *gener
 
 	if p.isGoMod(ctx) {
 		install.AddCommand(plan.NewCopyCommand("go.mod"))
-		if ctx.App.HasMatch("go.sum") {
+		if ctx.App.HasFile("go.sum") {
 			install.AddCommand(plan.NewCopyCommand("go.sum"))
 		}
 	}
 
 	if p.isGoWorkspace(ctx) {
 		install.AddCommand(plan.NewCopyCommand("go.work"))
-		if ctx.App.HasMatch("go.work.sum") {
+		if ctx.App.HasFile("go.work.sum") {
 			install.AddCommand(plan.NewCopyCommand("go.work.sum"))
 		}
 	}
@@ -146,7 +146,7 @@ func (p *GoProvider) InstallGoDeps(ctx *generate.GenerateContext, install *gener
 	workspacePackages := p.GoWorkspacePackages(ctx)
 	for _, pkgPath := range workspacePackages {
 		install.AddCommand(plan.NewCopyCommand(filepath.Join(pkgPath, "go.mod")))
-		if ctx.App.HasMatch(filepath.Join(pkgPath, "go.sum")) {
+		if ctx.App.HasFile(filepath.Join(pkgPath, "go.sum")) {
 			install.AddCommand(plan.NewCopyCommand(filepath.Join(pkgPath, "go.sum")))
 		}
 	}
@@ -236,7 +236,7 @@ func (p *GoProvider) hasCGOEnabled(ctx *generate.GenerateContext) bool {
 }
 
 func (p *GoProvider) isGoMod(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("go.mod")
+	return ctx.App.HasFile("go.mod")
 }
 
 func (p *GoProvider) GoWorkspacePackages(ctx *generate.GenerateContext) []string {
@@ -260,7 +260,7 @@ func (p *GoProvider) GoWorkspacePackages(ctx *generate.GenerateContext) []string
 }
 
 func (p *GoProvider) isGoWorkspace(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("go.work")
+	return ctx.App.HasFile("go.work")
 }
 
 func (p *GoProvider) CleansePlan(buildPlan *plan.BuildPlan) {}

--- a/core/providers/java/gradle.go
+++ b/core/providers/java/gradle.go
@@ -13,7 +13,7 @@ const (
 )
 
 func (p *JavaProvider) usesGradle(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("gradlew")
+	return ctx.App.HasFile("gradlew")
 }
 
 func (p *JavaProvider) setGradleVersion(ctx *generate.GenerateContext) {
@@ -24,7 +24,7 @@ func (p *JavaProvider) setGradleVersion(ctx *generate.GenerateContext) {
 		miseStep.Version(gradle, envVersion, envName)
 	}
 
-	if !ctx.App.HasMatch("gradle/wrapper/gradle-wrapper.properties") {
+	if !ctx.App.HasFile("gradle/wrapper/gradle-wrapper.properties") {
 		return
 	}
 
@@ -65,7 +65,7 @@ func (p *JavaProvider) gradleCache(ctx *generate.GenerateContext) string {
 
 func (p *JavaProvider) readBuildGradle(ctx *generate.GenerateContext) string {
 	filePath := "build.gradle"
-	if !ctx.App.HasMatch(filePath) {
+	if !ctx.App.HasFile(filePath) {
 		filePath = "build.gradle.kts"
 	}
 	result, err := ctx.App.ReadFile(filePath)

--- a/core/providers/java/maven.go
+++ b/core/providers/java/maven.go
@@ -9,7 +9,7 @@ import (
 const MAVEN_CACHE_KEY = "maven"
 
 func (p *JavaProvider) getMavenExe(ctx *generate.GenerateContext) string {
-	if ctx.App.HasMatch("mvnw") && ctx.App.HasMatch(".mvn/wrapper/maven-wrapper.properties") {
+	if ctx.App.HasFile("mvnw") && ctx.App.HasFile(".mvn/wrapper/maven-wrapper.properties") {
 		return "./mvnw"
 	}
 

--- a/core/providers/node/angular.go
+++ b/core/providers/node/angular.go
@@ -14,7 +14,7 @@ const (
 
 func (p *NodeProvider) isAngular(ctx *generate.GenerateContext) bool {
 	hasAngularDep := p.hasDependency("@angular/core")
-	hasAngularConfig := ctx.App.HasMatch("angular.json")
+	hasAngularConfig := ctx.App.HasFile("angular.json")
 	hasAngularBuildCommand := strings.Contains(strings.ToLower(p.packageJson.GetScript("build")), "ng build")
 
 	return hasAngularDep && hasAngularConfig && hasAngularBuildCommand

--- a/core/providers/node/astro.go
+++ b/core/providers/node/astro.go
@@ -19,7 +19,7 @@ func (p *NodeProvider) isAstroPackage(pkg *WorkspacePackage, ctx *generate.Gener
 		astroConfigTs = pkg.Path + "/astro.config.ts"
 	}
 
-	hasAstroConfig := ctx.App.HasMatch(astroConfigMjs) || ctx.App.HasMatch(astroConfigTs)
+	hasAstroConfig := ctx.App.HasFile(astroConfigMjs) || ctx.App.HasFile(astroConfigTs)
 	hasAstroBuildCommand := strings.Contains(strings.ToLower(pkg.PackageJson.GetScript("build")), "astro build")
 
 	return hasAstroConfig && hasAstroBuildCommand
@@ -58,12 +58,12 @@ func (p *NodeProvider) getAstroOutputDirectory(ctx *generate.GenerateContext) st
 func (p *NodeProvider) getAstroConfigFileContents(ctx *generate.GenerateContext) string {
 	configFile := ""
 
-	if ctx.App.HasMatch("astro.config.mjs") {
+	if ctx.App.HasFile("astro.config.mjs") {
 		contents, err := ctx.App.ReadFile("astro.config.mjs")
 		if err == nil {
 			configFile = contents
 		}
-	} else if ctx.App.HasMatch("astro.config.ts") {
+	} else if ctx.App.HasFile("astro.config.ts") {
 		contents, err := ctx.App.ReadFile("astro.config.ts")
 		if err == nil {
 			configFile = contents

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -58,7 +58,7 @@ func (p *NodeProvider) Initialize(ctx *generate.GenerateContext) error {
 }
 
 func (p *NodeProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	return ctx.App.HasMatch("package.json"), nil
+	return ctx.App.HasFile("package.json"), nil
 }
 
 func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
@@ -413,13 +413,13 @@ func (p *NodeProvider) getPackageManager(app *app.App) PackageManager {
 	}
 
 	// Fall back to file-based detection
-	if app.HasMatch("pnpm-lock.yaml") {
+	if app.HasFile("pnpm-lock.yaml") {
 		return PackageManagerPnpm
-	} else if app.HasMatch("bun.lockb") || app.HasMatch("bun.lock") {
+	} else if app.HasFile("bun.lockb") || app.HasFile("bun.lock") {
 		return PackageManagerBun
-	} else if app.HasMatch(".yarnrc.yml") || app.HasMatch(".yarnrc.yaml") {
+	} else if app.HasFile(".yarnrc.yml") || app.HasFile(".yarnrc.yaml") {
 		return PackageManagerYarnBerry
-	} else if app.HasMatch("yarn.lock") {
+	} else if app.HasFile("yarn.lock") {
 		return PackageManagerYarn1
 	}
 
@@ -446,7 +446,7 @@ func (p *NodeProvider) getPackageManager(app *app.App) PackageManager {
 
 func (p *NodeProvider) GetPackageJson(app *app.App) (*PackageJson, error) {
 	packageJson := NewPackageJson()
-	if !app.HasMatch("package.json") {
+	if !app.HasFile("package.json") {
 		return packageJson, nil
 	}
 

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -101,7 +101,7 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 
 	switch p {
 	case PackageManagerNpm:
-		hasLockfile := ctx.App.HasMatch("package-lock.json")
+		hasLockfile := ctx.App.HasFile("package-lock.json")
 		if hasLockfile {
 			install.AddCommand(plan.NewExecCommand("npm ci"))
 		} else {
@@ -120,7 +120,7 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 			install.AddCommand(plan.NewExecCommand("pnpm add -g node-gyp"))
 		}
 
-		hasLockfile := ctx.App.HasMatch("pnpm-lock.yaml")
+		hasLockfile := ctx.App.HasFile("pnpm-lock.yaml")
 		if hasLockfile {
 			install.AddCommand(plan.NewExecCommand("pnpm install --frozen-lockfile --prefer-offline"))
 		} else {
@@ -195,7 +195,7 @@ func (p PackageManager) pruneYarnBerry(ctx *generate.GenerateContext, prune *gen
 
 func (p PackageManager) getPackageJsonFromContext(ctx *generate.GenerateContext) (*PackageJson, error) {
 	packageJson := NewPackageJson()
-	if !ctx.App.HasMatch("package.json") {
+	if !ctx.App.HasFile("package.json") {
 		return packageJson, nil
 	}
 

--- a/core/providers/node/react_router.go
+++ b/core/providers/node/react_router.go
@@ -18,11 +18,11 @@ const (
 func (p *NodeProvider) getReactRouterOutputDirectory(ctx *generate.GenerateContext) string {
 	configContent := ""
 
-	if ctx.App.HasMatch(ReactRouterConfigJS) {
+	if ctx.App.HasFile(ReactRouterConfigJS) {
 		if content, err := ctx.App.ReadFile(ReactRouterConfigJS); err == nil {
 			configContent = content
 		}
-	} else if ctx.App.HasMatch(ReactRouterConfigTS) {
+	} else if ctx.App.HasFile(ReactRouterConfigTS) {
 		if content, err := ctx.App.ReadFile(ReactRouterConfigTS); err == nil {
 			configContent = content
 		}
@@ -62,7 +62,7 @@ func (p *NodeProvider) isReactRouterPackage(pkg *WorkspacePackage, ctx *generate
 		rrConfigTS = pkg.Path + "/" + ReactRouterConfigTS
 	}
 
-	hasRRConfig := ctx.App.HasMatch(rrConfigJS) || ctx.App.HasMatch(rrConfigTS)
+	hasRRConfig := ctx.App.HasFile(rrConfigJS) || ctx.App.HasFile(rrConfigTS)
 	hasBuildCommand := pkg.PackageJson.HasScript("build")
 	hasRRBuildCommand := strings.Contains(strings.ToLower(pkg.PackageJson.GetScript("build")), "react-router build")
 	hasRRPackage := pkg.PackageJson.hasDependency("@react-router/dev")

--- a/core/providers/node/vite.go
+++ b/core/providers/node/vite.go
@@ -23,7 +23,7 @@ func (p *NodeProvider) isVitePackage(pkg *WorkspacePackage, ctx *generate.Genera
 		viteConfigTS = pkg.Path + "/vite.config.ts"
 	}
 
-	hasViteConfig := ctx.App.HasMatch(viteConfigJS) || ctx.App.HasMatch(viteConfigTS)
+	hasViteConfig := ctx.App.HasFile(viteConfigJS) || ctx.App.HasFile(viteConfigTS)
 
 	// SvelteKit does not build as a static site by default
 	if p.isSvelteKitPackage(pkg) {
@@ -44,12 +44,12 @@ func (p *NodeProvider) isVite(ctx *generate.GenerateContext) bool {
 func (p *NodeProvider) getViteOutputDirectory(ctx *generate.GenerateContext) string {
 	configContent := ""
 
-	if ctx.App.HasMatch("vite.config.js") {
+	if ctx.App.HasFile("vite.config.js") {
 		content, err := ctx.App.ReadFile("vite.config.js")
 		if err == nil {
 			configContent = content
 		}
-	} else if ctx.App.HasMatch("vite.config.ts") {
+	} else if ctx.App.HasFile("vite.config.ts") {
 		content, err := ctx.App.ReadFile("vite.config.ts")
 		if err == nil {
 			configContent = content

--- a/core/providers/node/workspace.go
+++ b/core/providers/node/workspace.go
@@ -37,7 +37,7 @@ func NewWorkspace(app *app.App) (*Workspace, error) {
 	}
 
 	// Try to read PNPM workspace config first
-	if app.HasMatch("pnpm-workspace.yaml") {
+	if app.HasFile("pnpm-workspace.yaml") {
 		var pnpmWorkspace PnpmWorkspace
 		if err := app.ReadYAML("pnpm-workspace.yaml", &pnpmWorkspace); err == nil && len(pnpmWorkspace.Packages) > 0 {
 			workspace.Root.PackageJson.Workspaces = pnpmWorkspace.Packages

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -36,8 +36,8 @@ func (p *PhpProvider) Name() string {
 }
 
 func (p *PhpProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	return ctx.App.HasMatch("index.php") ||
-		ctx.App.HasMatch("composer.json"), nil
+	return ctx.App.HasFile("index.php") ||
+		ctx.App.HasFile("composer.json"), nil
 }
 
 func (p *PhpProvider) Initialize(ctx *generate.GenerateContext) error {
@@ -350,7 +350,7 @@ func (p *PhpProvider) needsRedisExtension(ctx *generate.GenerateContext, compose
 }
 
 func (p *PhpProvider) usesLaravel(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("artisan")
+	return ctx.App.HasFile("artisan")
 }
 
 type ConfigFiles struct {

--- a/core/providers/python/django.go
+++ b/core/providers/python/django.go
@@ -45,7 +45,7 @@ func (p *PythonProvider) getDjangoStartCommand(ctx *generate.GenerateContext) st
 }
 
 func (p *PythonProvider) isDjango(ctx *generate.GenerateContext) bool {
-	hasManage := ctx.App.HasMatch("manage.py")
+	hasManage := ctx.App.HasFile("manage.py")
 	importsDjango := p.usesDep(ctx, "django")
 
 	return hasManage && importsDjango

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -31,7 +31,7 @@ func (p *PythonProvider) Initialize(ctx *generate.GenerateContext) error {
 }
 
 func (p *PythonProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	hasPython := ctx.App.HasMatch("main.py") ||
+	hasPython := ctx.App.HasFile("main.py") ||
 		p.hasRequirements(ctx) ||
 		p.hasPyproject(ctx) ||
 		p.hasPipfile(ctx)
@@ -120,7 +120,7 @@ func (p *PythonProvider) GetStartCommand(ctx *generate.GenerateContext) string {
 
 func (p *PythonProvider) getMainPythonFile(ctx *generate.GenerateContext) string {
 	for _, file := range []string{"main.py", "app.py", "bot.py", "hello.py", "server.py"} {
-		if ctx.App.HasMatch(file) {
+		if ctx.App.HasFile(file) {
 			return file
 		}
 	}
@@ -179,7 +179,7 @@ func (p *PythonProvider) InstallPipenv(ctx *generate.GenerateContext, install *g
 		plan.NewPathCommand(VENV_PATH + "/bin"),
 	})
 
-	if ctx.App.HasMatch("Pipfile.lock") {
+	if ctx.App.HasFile("Pipfile.lock") {
 		install.AddCommands([]plan.Command{
 			plan.NewCopyCommand("Pipfile"),
 			plan.NewCopyCommand("Pipfile.lock"),
@@ -484,27 +484,27 @@ func parseVersionFromPipfile(ctx *generate.GenerateContext) (string, string) {
 }
 
 func (p *PythonProvider) hasRequirements(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("requirements.txt")
+	return ctx.App.HasFile("requirements.txt")
 }
 
 func (p *PythonProvider) hasPyproject(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("pyproject.toml")
+	return ctx.App.HasFile("pyproject.toml")
 }
 
 func (p *PythonProvider) hasPipfile(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("Pipfile")
+	return ctx.App.HasFile("Pipfile")
 }
 
 func (p *PythonProvider) hasPoetry(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("poetry.lock")
+	return ctx.App.HasFile("poetry.lock")
 }
 
 func (p *PythonProvider) hasPdm(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("pdm.lock")
+	return ctx.App.HasFile("pdm.lock")
 }
 
 func (p *PythonProvider) hasUv(ctx *generate.GenerateContext) bool {
-	return ctx.App.HasMatch("uv.lock")
+	return ctx.App.HasFile("uv.lock")
 }
 
 func (p *PythonProvider) isFasthtml(ctx *generate.GenerateContext) bool {

--- a/core/providers/ruby/ruby.go
+++ b/core/providers/ruby/ruby.go
@@ -28,7 +28,7 @@ func (p *RubyProvider) Initialize(ctx *generate.GenerateContext) error {
 }
 
 func (p *RubyProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	hasRuby := ctx.App.HasMatch("Gemfile")
+	hasRuby := ctx.App.HasFile("Gemfile")
 	return hasRuby, nil
 }
 
@@ -121,20 +121,20 @@ func (p *RubyProvider) GetStartCommand(ctx *generate.GenerateContext) string {
 	// TODO we auto-run migrations for django, but not for rails, why the difference?
 
 	if p.usesRails(ctx) {
-		if app.HasMatch("rails") {
+		if app.HasFile("rails") {
 			return "bundle exec rails server -b 0.0.0.0 -p ${PORT:-3000}"
 		} else {
-			if !app.HasMatch("bin/rails") {
+			if !app.HasFile("bin/rails") {
 				ctx.Logger.LogWarn("bin/rails not found, run `bundle binstubs railties` to avoid potential startup problems")
 			}
 
 			return "bundle exec bin/rails server -b 0.0.0.0 -p ${PORT:-3000} -e $RAILS_ENV"
 		}
-	} else if app.HasMatch("config/environment.rb") && app.HasMatch("script") {
+	} else if app.HasFile("config/environment.rb") && app.HasMatch("script") {
 		return "bundle exec ruby script/server -p ${PORT:-3000}"
-	} else if app.HasMatch("config.ru") {
+	} else if app.HasFile("config.ru") {
 		return "bundle exec rackup config.ru -p ${PORT:-3000}"
-	} else if app.HasMatch("Rakefile") {
+	} else if app.HasFile("Rakefile") {
 		return "bundle exec rake"
 	}
 

--- a/core/providers/rust/rust.go
+++ b/core/providers/rust/rust.go
@@ -27,7 +27,7 @@ func (p *RustProvider) Name() string {
 }
 
 func (p *RustProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
-	hasCargoToml := ctx.App.HasMatch("Cargo.toml")
+	hasCargoToml := ctx.App.HasFile("Cargo.toml")
 	return hasCargoToml, nil
 }
 
@@ -252,7 +252,7 @@ func (p *RustProvider) getBins(ctx *generate.GenerateContext) ([]string, error) 
 
 	name := p.getAppName(ctx)
 	if name != "" {
-		if ctx.App.HasMatch("src/main.rs") {
+		if ctx.App.HasFile("src/main.rs") {
 			bins = append(bins, name)
 		}
 	}
@@ -409,7 +409,7 @@ func (p *RustProvider) findBinaryInWorkspace(ctx *generate.GenerateContext, work
 		}
 
 		// Check for src/main.rs which definitely indicates a binary
-		hasMainRs := ctx.App.HasMatch(fmt.Sprintf("%s/src/main.rs", member))
+		hasMainRs := ctx.App.HasFile(fmt.Sprintf("%s/src/main.rs", member))
 		if hasMainRs {
 			return manifest.Package.Name, nil
 		}
@@ -426,7 +426,7 @@ func (p *RustProvider) findBinaryInWorkspace(ctx *generate.GenerateContext, work
 		}
 
 		// If no lib.rs exists, it might be a binary
-		hasLibRs := ctx.App.HasMatch(fmt.Sprintf("%s/src/lib.rs", member))
+		hasLibRs := ctx.App.HasFile(fmt.Sprintf("%s/src/lib.rs", member))
 		if !hasLibRs {
 			return manifest.Package.Name, nil
 		}

--- a/core/providers/staticfile/staticfile.go
+++ b/core/providers/staticfile/staticfile.go
@@ -122,7 +122,7 @@ func getRootDir(ctx *generate.GenerateContext) (string, error) {
 
 	if ctx.App.HasMatch("public") {
 		return "public", nil
-	} else if ctx.App.HasMatch("index.html") {
+	} else if ctx.App.HasFile("index.html") {
 		return ".", nil
 	}
 
@@ -130,7 +130,7 @@ func getRootDir(ctx *generate.GenerateContext) (string, error) {
 }
 
 func getStaticfileConfig(ctx *generate.GenerateContext) (*StaticfileConfig, error) {
-	if !ctx.App.HasMatch(StaticfileConfigName) {
+	if !ctx.App.HasFile(StaticfileConfigName) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Replace fuzzy matching (HasMatch) with exact file path checks (HasFile) in all providers where specific files are being checked. This prevents false positives from glob pattern matching when checking for specific file names.

Directory checks (e.g. src/bin, node_modules, public, script) continue to use HasMatch as they need pattern/directory matching.