### PR TITLE
docs: clarify .bun-version as community convention

### DIFF
--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -315,6 +315,7 @@ var miseConfigFiles = []string{
 	".python-version",
 	".node-version",
 	".nvmrc",
+	// .bun-version is a community convention, not officially supported by Bun
 	".bun-version",
 }
 

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -317,6 +317,8 @@ func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 			miseStep.Version(bun, envVersion, varName)
 		}
 
+		// .bun-version is a community convention for specifying the Bun version.
+		// It is not officially supported by Bun itself, but is recognized by version managers like mise.
 		if bunVersionFile, err := ctx.App.ReadFile(".bun-version"); err == nil {
 			miseStep.Version(bun, string(bunVersionFile), ".bun-version")
 		}


### PR DESCRIPTION
Add comments noting that .bun-version is a community convention for specifying the Bun version and is not officially supported by Bun itself, though it is recognized by version managers like mise.