### PR TITLE
test: login to ghcr.io to increase rate limits

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,6 +31,7 @@ jobs:
   test:
     needs: find-examples
     runs-on: ubuntu-latest
+    # packages:read is not available by default and is required for docker login to ghcr.io
     permissions:
       contents: read
       packages: read
@@ -47,6 +48,7 @@ jobs:
       - name: Set up BuildKit GHA cache
         uses: crazy-max/ghaction-github-runtime@v3
 
+      # Not strictly required, but authenticating increases rate limits and reduces 429 errors
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
We were getting 429 errors on CI. Let's see if this fixes it.