### PR TITLE
fix: backoff retries when mise fails

### DIFF
--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -155,8 +155,11 @@ func (m *Mise) runCmdWithEnv(extraEnv []string, args ...string) (string, error) 
 		fmt.Sprintf("MISE_DATA_DIR=%s", dataDir),
 		fmt.Sprintf("MISE_STATE_DIR=%s", stateDir),
 		fmt.Sprintf("MISE_SYSTEM_DIR=%s", systemDir),
-		"MISE_HTTP_TIMEOUT=120s",
-		"MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=120s",
+		// TODO doesn't HTTP timeout apply to fetch remote versions too?
+		"MISE_HTTP_TIMEOUT=60s",
+		"MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=60s",
+		// allows for a 2m outage on mise (10ms base backoff retry)
+		"MISE_HTTP_RETRIES=5",
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	)
 


### PR DESCRIPTION
Mise registries can intermittently fail. This should help reduce the chances of the build failing because of this.

Example: 
```
> mise install-into caddy@2.10.2 /railpack/caddy:
0.174 mise caddy@2.10.2    install
5.176 mise ERROR error sending request for url (https://mise-versions.jdx.dev/aqua-registry/caddyserver/caddy/registry.yaml)
5.176 mise ERROR operation timed out
5.176 mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```