### PR TITLE
test: add green status message for integration tests

### DIFF
--- a/integration_tests/run_test.go
+++ b/integration_tests/run_test.go
@@ -125,6 +125,8 @@ func TestExamplesIntegration(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				t.Parallel()
 
+				fmt.Printf("\033[32mRunning: examples/%s\033[0m\n", entry.Name())
+
 				userApp, err := app.NewApp(examplePath)
 				if err != nil {
 					t.Fatalf("failed to create app: %v", err)


### PR DESCRIPTION
Add colored "Running: examples/..." output at the start of each integration test case to make it easier to identify which test failed in CI.