### PR TITLE
fix: migrate from NPM_CONFIG_PRODUCTION to NPM_CONFIG_OMIT

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -252,7 +252,7 @@
    ],
    "commands": [
     {
-     "cmd": "npm prune --omit=dev --ignore-scripts"
+     "cmd": "npm prune --ignore-scripts"
     }
    ],
    "inputs": [
@@ -262,7 +262,7 @@
    ],
    "name": "prune:node",
    "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
+    "NPM_CONFIG_OMIT": "dev,optional"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -252,7 +252,7 @@
    ],
    "commands": [
     {
-     "cmd": "npm prune --omit=dev --ignore-scripts"
+     "cmd": "npm prune --ignore-scripts"
     }
    ],
    "inputs": [
@@ -262,7 +262,7 @@
    ],
    "name": "prune:node",
    "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
+    "NPM_CONFIG_OMIT": "dev,optional"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
@@ -205,7 +205,7 @@
    ],
    "commands": [
     {
-     "cmd": "npm prune --omit=dev --ignore-scripts"
+     "cmd": "npm prune --ignore-scripts"
     }
    ],
    "inputs": [
@@ -215,7 +215,7 @@
    ],
    "name": "prune:node",
    "variables": {
-    "NPM_CONFIG_PRODUCTION": "true"
+    "NPM_CONFIG_OMIT": "dev,optional"
    }
   },
   {

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -287,7 +287,7 @@ func (p *NodeProvider) shouldPrune(ctx *generate.GenerateContext) bool {
 
 func (p *NodeProvider) PruneNodeDeps(ctx *generate.GenerateContext, prune *generate.CommandStepBuilder) {
 	ctx.Logger.LogInfo("Pruning node dependencies")
-	prune.Variables["NPM_CONFIG_PRODUCTION"] = "true"
+	prune.Variables["NPM_CONFIG_OMIT"] = "dev,optional"
 	prune.Secrets = []string{}
 	p.packageManager.PruneDeps(ctx, prune)
 }

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -287,7 +287,6 @@ func (p *NodeProvider) shouldPrune(ctx *generate.GenerateContext) bool {
 
 func (p *NodeProvider) PruneNodeDeps(ctx *generate.GenerateContext, prune *generate.CommandStepBuilder) {
 	ctx.Logger.LogInfo("Pruning node dependencies")
-	prune.Variables["NPM_CONFIG_OMIT"] = "dev,optional"
 	prune.Secrets = []string{}
 	p.packageManager.PruneDeps(ctx, prune)
 }
@@ -413,7 +412,6 @@ func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 func (p *NodeProvider) GetNodeEnvVars(ctx *generate.GenerateContext) map[string]string {
 	envVars := map[string]string{
 		"NODE_ENV":                   "production",
-		"NPM_CONFIG_PRODUCTION":      "false",
 		"NPM_CONFIG_UPDATE_NOTIFIER": "false",
 		"NPM_CONFIG_FUND":            "false",
 		// https://docs.npmjs.com/cli/using-npm/config#fetch-retries

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/charmbracelet/log"
 	"github.com/railwayapp/railpack/core/app"
 	"github.com/railwayapp/railpack/core/generate"
@@ -86,8 +87,6 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 		return fmt.Errorf("package.json not found")
 	}
 
-	p.SetNodeMetadata(ctx)
-
 	ctx.Logger.LogInfo("Using %s package manager", p.packageManager)
 
 	if p.workspace != nil && len(p.workspace.Packages) > 0 {
@@ -98,6 +97,7 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 
 	miseStep := ctx.GetMiseStepBuilder()
 	p.InstallMisePackages(ctx, miseStep)
+	p.SetNodeMetadata(ctx)
 
 	install := ctx.NewCommandStep("install")
 	install.AddInput(plan.NewStepLayer(miseStep.Name()))
@@ -168,6 +168,25 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 	})
 
 	return nil
+}
+
+func warnIfNodeVersionUnsupported(ctx *generate.GenerateContext, packages map[string]*resolver.ResolvedPackage) {
+	nodePackage, ok := packages["node"]
+	if !ok || nodePackage.ResolvedVersion == nil {
+		return
+	}
+
+	nodeVersion, err := semver.NewVersion(*nodePackage.ResolvedVersion)
+	// NOTE: Update this check and log message when the oldest supported Node.js
+	// LTS release changes.
+	if err != nil || nodeVersion.Major() >= 22 {
+		return
+	}
+
+	ctx.Logger.LogDeprecation(
+		"Node.js %s is no longer officially supported. Node.js 22 is the oldest supported LTS release.",
+		nodeVersion.Original(),
+	)
 }
 
 func (p *NodeProvider) StartCommandHelp() string {
@@ -533,10 +552,30 @@ func (p *NodeProvider) getScripts(packageJson *PackageJson, name string) string 
 }
 
 func (p *NodeProvider) SetNodeMetadata(ctx *generate.GenerateContext) {
-	ctx.Metadata.Set("nodeRuntime", p.getRuntime(ctx))
+	runtime := p.getRuntime(ctx)
+	ctx.Metadata.Set("nodeRuntime", runtime)
 	ctx.Metadata.Set("nodePackageManager", string(p.packageManager))
 	ctx.Metadata.SetBool("nodeIsSPA", p.isSPA(ctx))
 	ctx.Metadata.SetBool("nodeUsesCorepack", p.usesCorepack())
+
+	packages, err := ctx.Resolver.ResolvePackages()
+	if err != nil {
+		return
+	}
+	warnIfNodeVersionUnsupported(ctx, packages)
+
+	runtimePackage := "node"
+	if runtime == "bun" {
+		runtimePackage = "bun"
+	}
+	if pkg, ok := packages[runtimePackage]; ok && pkg.ResolvedVersion != nil {
+		ctx.Metadata.Set("nodeRuntimeVersion", *pkg.ResolvedVersion)
+	}
+
+	packageManagerPackage := p.packageManager.misePackageName()
+	if pkg, ok := packages[packageManagerPackage]; ok && pkg.ResolvedVersion != nil {
+		ctx.Metadata.Set("nodePackageManagerVersion", *pkg.ResolvedVersion)
+	}
 }
 
 func (p *NodeProvider) getPackagesWithFramework(ctx *generate.GenerateContext, frameworkCheck func(*WorkspacePackage, *generate.GenerateContext) bool) ([]*WorkspacePackage, error) {

--- a/core/providers/node/node_test.go
+++ b/core/providers/node/node_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/railwayapp/railpack/core/app"
 	"github.com/railwayapp/railpack/core/generate"
+	"github.com/railwayapp/railpack/core/logger"
 	testingUtils "github.com/railwayapp/railpack/core/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +20,7 @@ func TestNode(t *testing.T) {
 		nodeVersion    string
 		pnpmVersion    string
 		envVars        map[string]string
+		deprecated     bool
 	}{
 		{
 			name:           "npm",
@@ -40,6 +42,7 @@ func TestNode(t *testing.T) {
 			packageManager: PackageManagerPnpm,
 			nodeVersion:    "20",
 			pnpmVersion:    "10.4.1",
+			deprecated:     true,
 		},
 		{
 			name:           "pnpm",
@@ -117,6 +120,25 @@ func TestNode(t *testing.T) {
 						require.Equal(t, tt.pnpmVersion, pnpmVersion.Version)
 					}
 				}
+
+				if ctx.Resolver.Get("node") != nil {
+					require.NotEmpty(t, ctx.Metadata.Get("nodeRuntimeVersion"))
+				}
+
+				if packageManagerPackage := tt.packageManager.misePackageName(); packageManagerPackage != "" {
+					require.NotEmpty(t, ctx.Metadata.Get("nodePackageManagerVersion"))
+				} else {
+					require.Empty(t, ctx.Metadata.Get("nodePackageManagerVersion"))
+				}
+
+				hasDeprecation := false
+				for _, log := range ctx.Logger.Logs {
+					if log.Level == logger.Deprecation {
+						hasDeprecation = true
+						break
+					}
+				}
+				require.Equal(t, tt.deprecated, hasDeprecation)
 			}
 		})
 	}

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -230,7 +230,7 @@ func (p PackageManager) PruneDeps(ctx *generate.GenerateContext, prune *generate
 
 	switch p {
 	case PackageManagerNpm:
-		prune.AddCommand(plan.NewExecCommand("npm prune --omit=dev --ignore-scripts"))
+		prune.AddCommand(plan.NewExecCommand("npm prune --ignore-scripts"))
 	case PackageManagerPnpm:
 		p.prunePnpm(ctx, prune)
 	case PackageManagerBun:

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -130,9 +130,9 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 	case PackageManagerNpm:
 		hasLockfile := ctx.App.HasFile("package-lock.json")
 		if hasLockfile {
-			install.AddCommand(plan.NewExecCommand("npm ci"))
+			install.AddCommand(plan.NewExecCommand("npm ci --include=dev"))
 		} else {
-			install.AddCommand(plan.NewExecCommand("npm install"))
+			install.AddCommand(plan.NewExecCommand("npm install --include=dev"))
 		}
 	case PackageManagerPnpm:
 		install.AddEnvVars(map[string]string{
@@ -230,7 +230,7 @@ func (p PackageManager) PruneDeps(ctx *generate.GenerateContext, prune *generate
 
 	switch p {
 	case PackageManagerNpm:
-		prune.AddCommand(plan.NewExecCommand("npm prune --ignore-scripts"))
+		prune.AddCommand(plan.NewExecCommand("npm prune --omit=dev --ignore-scripts"))
 	case PackageManagerPnpm:
 		p.prunePnpm(ctx, prune)
 	case PackageManagerBun:

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -456,3 +456,6 @@ There are some manual maintenance tasks that need to be done periodically:
 * PNPM lockfile versions are manually mapped to minimum pnpm versions
 * Pnpm default version needs to be updated as LTS versions are released.
 * Node default version needs to be updated as LTS versions are released.
+* The minimum supported Node.js version check and deprecation log in
+  `core/providers/node/node.go` need to be updated when the oldest supported
+  LTS release changes.

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -59,7 +59,6 @@ These variables are available at runtime:
 
 ```sh
 NODE_ENV=production
-NPM_CONFIG_PRODUCTION=false
 NPM_CONFIG_UPDATE_NOTIFIER=false
 NPM_CONFIG_FUND=false
 NPM_CONFIG_FETCH_RETRIES=5

--- a/examples/node-latest-npm-native-deps/test.json
+++ b/examples/node-latest-npm-native-deps/test.json
@@ -4,9 +4,6 @@
       "Database test successful!",
       "Bcrypt compare result: true",
       "better-sqlite3 and bcrypt native modules working correctly with npm"
-    ],
-    // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
-    // Currently causes: npm warn config production Use `--omit=dev` instead.
-    "stderrAllowed": true
+    ]
   }
 ]

--- a/examples/node-lts-npm-native-deps/test.json
+++ b/examples/node-lts-npm-native-deps/test.json
@@ -4,9 +4,6 @@
       "Database test successful!",
       "Bcrypt compare result: true",
       "better-sqlite3 and bcrypt native modules working correctly with npm"
-    ],
-    // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
-    // Currently causes: npm warn config production Use `--omit=dev` instead.
-    "stderrAllowed": true
+    ]
   }
 ]

--- a/examples/node-npm-install-in-build/test.json
+++ b/examples/node-npm-install-in-build/test.json
@@ -1,8 +1,5 @@
 [
   {
-    "expectedOutput": "hello from Node v23.5.0",
-    // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
-    // Currently causes: npm warn config production Use `--omit=dev` instead.
-    "stderrAllowed": true
+    "expectedOutput": "hello from Node v23.5.0"
   }
 ]

--- a/examples/node-npm/test.json
+++ b/examples/node-npm/test.json
@@ -1,9 +1,6 @@
 [
   {
     "expectedOutput": "hello from Node v23.5.0",
-    // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
-    // Currently causes: npm warn config production Use `--omit=dev` instead.
-    "stderrAllowed": true,
     "envs": {
       "RAILPACK_PRUNE_DEPS": "true"
     }

--- a/examples/node-prisma/test.json
+++ b/examples/node-prisma/test.json
@@ -1,8 +1,5 @@
 [
   {
-    "expectedOutput": "Prisma client created",
-    // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
-    // Currently causes: npm warn config production Use `--omit=dev` instead.
-    "stderrAllowed": true
+    "expectedOutput": "Prisma client created"
   }
 ]

--- a/examples/node-remix/test.json
+++ b/examples/node-remix/test.json
@@ -1,9 +1,6 @@
 [
   {
-    "expectedOutput": "[remix-serve]",
-    // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
-    // Currently causes: npm warn config production Use `--omit=dev` instead.
-    "stderrAllowed": true
+    "expectedOutput": "[remix-serve]"
   },
   {
     "httpCheck": {
@@ -11,9 +8,6 @@
       "expected": 200,
       "internalPort": 3000,
       "expectedOutput": "New Remix App"
-    },
-    // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
-    // Currently causes: npm warn config production Use `--omit=dev` instead.
-    "stderrAllowed": true
+    }
   }
 ]


### PR DESCRIPTION
Replace the deprecated `NPM_CONFIG_PRODUCTION` environment variable with
explicit npm dependency-group flags:

- `npm install` and `npm ci` use `--include=dev` so build dependencies remain
  available while `NODE_ENV=production`.
- `npm prune` uses `--omit=dev`, matching the previous production-pruning
  behavior while retaining optional dependencies.
- The deprecated variable is no longer included in the runtime image.

## Breaking Changes

- Runtime npm commands now follow `NODE_ENV=production`. An `npm install` run
  inside a deployed image will omit dev dependencies instead of inheriting
  `NPM_CONFIG_PRODUCTION=false`. Applications or scripts that inspect that
  variable will no longer see it.
- The generated npm install command explicitly uses `--include=dev`. npm gives
  `include` precedence over `omit`, so an existing `.npmrc` containing
  `omit=dev` will no longer suppress dev dependencies during Railpack's install
  step. Users who intentionally need that behavior can replace the install
  command, for example with
  `RAILPACK_INSTALL_CMD="npm ci --omit=dev"`.
- `--include=dev` is supported by npm 7 and newer. Projects pinned to npm 6 or
  earlier may not install dev dependencies correctly while
  `NODE_ENV=production` and should override the install command or upgrade npm.
- Install lifecycle scripts and custom prune commands that explicitly depend
  on `NPM_CONFIG_PRODUCTION` may behave differently. `NODE_ENV` remains set to
  `production`.
- Generated build plans now contain `npm ci --include=dev` or
  `npm install --include=dev`. Tooling that matches exact command strings may
  require an update, and existing build caches will be invalidated once.

Optional dependencies continue to be installed, matching the behavior before
this migration.
