### PR TITLE
fix: set aspnet content root to properly find configuration files

### DIFF
--- a/core/providers/dotnet/dotnet.go
+++ b/core/providers/dotnet/dotnet.go
@@ -108,8 +108,9 @@ func (p *DotnetProvider) Build(ctx *generate.GenerateContext, build *generate.Co
 func (p *DotnetProvider) GetEnvVars(ctx *generate.GenerateContext) map[string]string {
 	version := p.getDotnetVersion(ctx)
 	return map[string]string{
-		"ASPNETCORE_ENVIRONMENT":      "production",
+		"ASPNETCORE_ENVIRONMENT":      "Production",
 		"ASPNETCORE_URLS":             "http://0.0.0.0:3000",
+		"ASPNETCORE_CONTENTROOT":      "/app/out",
 		"DOTNET_CLI_TELEMETRY_OPTOUT": "1",
 		"DOTNET_ROOT":                 path.Join(DOTNET_ROOT, version),
 	}


### PR DESCRIPTION
the dotnet provider copies the built project to /app/out and starts the app from /app with ./out/<app-name> and this makes aspnet set it's ContentRootPath to /app and expects to find appsettings configuration files (like appsettings.json, appsettings.Development.json, etc) , the default static files folder wwwroot/ and other user code relying on reading files from the proper content root to fail.

setting the ASPNETCORE_CONTENTROOT env var to '/app/out' fixes this.

and i capitalized the default run environement ASPNETCORE_ENVIRONMENT to 'Production' instead of 'production'
to follow the idiomatic values because it also wouldn't load the production settings file: appsettings.Production.json with the lowercase letter 

from [aspnet docs](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/environments?view=aspnetcore-10.0#environments)
> 
> Environments
> 
> Although the environment can be any string value, the following environment values are provided by the framework:
> 
>     Development
>     Staging
>     Production