### PR TITLE
build: add syntax `parser` directive to Dockerfile

### DIFF
--- a/Dockerfiles/frontend.Dockerfile
+++ b/Dockerfiles/frontend.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1
 FROM golang:1.23-alpine AS builder
 
 WORKDIR /src

--- a/Dockerfiles/frontend.goreleaser.Dockerfile
+++ b/Dockerfiles/frontend.goreleaser.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1
 FROM alpine
 
 COPY railpack /

--- a/examples/node-vite-react-router-ssr/Dockerfile
+++ b/examples/node-vite-react-router-ssr/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1
 FROM node:20-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app

--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1
 FROM buildpack-deps:bookworm-scm
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/images/debian/mise/Dockerfile
+++ b/images/debian/mise/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1
 FROM rust:1-slim-bookworm AS builder
 
 # Compile mise from source with size optimizations

--- a/images/debian/runtime/Dockerfile
+++ b/images/debian/runtime/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1
 FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary

Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).

## Why?

To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend.