### PR TITLE
fix: run mise latest twice to fix indeterminate erlang version detection

### DIFF
--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -57,9 +57,14 @@ func (m *Mise) GetLatestVersion(pkg, version string) (string, error) {
 	}
 	defer unlock()
 
-	// Try with extracted semver version first
 	semverVersion := utils.ExtractSemverVersion(version)
 	query := fmt.Sprintf("%s@%s", pkg, semverVersion)
+
+	// TODO remove this once mise is fixed
+	// running this command twice to work around this issue: https://github.com/jdx/mise/pull/7467/changes
+	_, _ = m.runCmdWithEnv([]string{"MISE_NO_CONFIG=1", "MISE_PARANOID=1"}, "latest", query)
+
+	// Try with extracted semver version first
 	output, err := m.runCmdWithEnv([]string{"MISE_NO_CONFIG=1", "MISE_PARANOID=1"}, "latest", query)
 
 	// If semver extraction fails, try with original version


### PR DESCRIPTION
https://github.com/jdx/mise/pull/7467

This is a terrible hack, but given how quickly mise moves, I think we can remove it quickly.