### PR TITLE
fix: remove duplicate bun version file read

### DIFF
--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -330,10 +330,6 @@ func (p *NodeProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 			miseStep.Version(bun, string(bunVersionFile), ".bun-version")
 		}
 
-		if bunVersionFile, err := ctx.App.ReadFile(".bun-version"); err == nil {
-			miseStep.Version(bun, string(bunVersionFile), ".bun-version")
-		}
-
 		// If we don't need node in the final image, we still want to include it for the install steps
 		// since many packages need node-gyp to install native modules
 		// TODO: use the same version detection logic as when bun is not in place (NODE_VERSION, package.json engines, .nvmrc, .node-version)


### PR DESCRIPTION
Fixes #413 
## Summary
- Remove duplicate `.bun-version` file read in Node provider
- The file was being read twice with identical logic

## Test plan
- Existing integration tests cover this code path