### PR TITLE
Update installation command to use GitHub source

### DIFF
--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -14,7 +14,7 @@ GHCR](https://github.com/railwayapp/railpack/pkgs/container/railpack-frontend).
 We love mise, and you can install railpack using mise:
 
 ```sh
-mise use ubi:railwayapp/railpack@latest
+mise use github:railwayapp/railpack@latest
 ```
 
 ## Curl


### PR DESCRIPTION
According to mise documentation:
```md
The ubi backend is deprecated. Use the github backend instead.
```