### PR TITLE
fix: correct typos

### DIFF
--- a/docs/src/content/docs/architecture/buildkit.md
+++ b/docs/src/content/docs/architecture/buildkit.md
@@ -21,5 +21,5 @@ several advantages:
 
 1. **Secret Management**: LLB provides more secure and flexible secret mounting.
 
-1. **Type Safety and Compile-Time Validation**: The build defintion is checked
+1. **Type Safety and Compile-Time Validation**: The build definition is checked
    at compile-time using the first party Go library.

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -187,7 +187,7 @@ documentation](/config/environment-variables) for a complete list of available
 
 ### Services
 
-Integation tests can define services (postgres, redis, anything with a docker image) that
+Integration tests can define services (postgres, redis, anything with a docker image) that
 are required for the application to run. Create a `docker-compose.yml` in a test directory
 and it will automatically be picked up and run before the project container is run.
 

--- a/docs/src/content/docs/guides/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/guides/running-railpack-in-production.mdx
@@ -71,7 +71,7 @@ the Railpack CLI.
 
 ## Secrets
 
-The secrets that are availabe to commands in the build must be specified in the
+The secrets that are available to commands in the build must be specified in the
 build plan. You can pass secrets to the `prepare` command with the `--env` flag.
 
 ```sh
@@ -94,7 +94,7 @@ STRIPE_LIVE_KEY=asdfasdf docker build \
   /path/to/app/to/build
 ```
 
-_Note how the secret is availabe to docker build at the start and also passed
+_Note how the secret is available to docker build at the start and also passed
 through the `--secret` flag._
 
 ### Layer invalidation


### PR DESCRIPTION
Just a quick fix for some typos in the documentation. 