### PR TITLE
fix: .dockerignore negations causing BuildKit lstat failures

### DIFF
--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -154,9 +154,8 @@ func TestGenerateContextDockerignore(t *testing.T) {
 		require.NotNil(t, ctx.dockerignoreCtx)
 
 		// Verify parsing works with no file present
-		excludes, includes, _ := ctx.dockerignoreCtx.Parse()
-		require.Nil(t, excludes)
-		require.Nil(t, includes)
+		patterns, _ := ctx.dockerignoreCtx.Parse()
+		require.Nil(t, patterns)
 	})
 
 	t.Run("context creation fails with invalid dockerignore", func(t *testing.T) {

--- a/core/plan/dockerignore.go
+++ b/core/plan/dockerignore.go
@@ -8,45 +8,28 @@ import (
 )
 
 // checks if a .dockerignore file exists in the app directory and parses it
-func CheckAndParseDockerignore(app *app.App) ([]string, []string, error) {
+func CheckAndParseDockerignore(app *app.App) ([]string, error) {
 	if !app.HasFile(".dockerignore") {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	content, err := app.ReadFile(".dockerignore")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	reader := strings.NewReader(content)
 	patterns, err := ignorefile.ReadAll(reader)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	excludePatterns, includePatterns := separatePatterns(patterns)
-
-	return excludePatterns, includePatterns, nil
-}
-
-// separatePatterns separates patterns into exclude and include lists
-// Include patterns are those starting with '!' (negation)
-func separatePatterns(patterns []string) (excludes []string, includes []string) {
-	for _, pattern := range patterns {
-		if len(pattern) > 0 && pattern[0] == '!' {
-			// Remove the '!' prefix for include patterns
-			includes = append(includes, pattern[1:])
-		} else {
-			excludes = append(excludes, pattern)
-		}
-	}
-	return excludes, includes
+	return patterns, nil
 }
 
 type DockerignoreContext struct {
 	parsed   bool
-	excludes []string
-	includes []string
+	patterns []string
 	app      *app.App
 }
 
@@ -57,30 +40,29 @@ func NewDockerignoreContext(app *app.App) *DockerignoreContext {
 }
 
 // Parse parses the .dockerignore file and caches the results
-func (d *DockerignoreContext) Parse() ([]string, []string, error) {
+func (d *DockerignoreContext) Parse() ([]string, error) {
 	if !d.parsed {
-		excludes, includes, err := CheckAndParseDockerignore(d.app)
+		patterns, err := CheckAndParseDockerignore(d.app)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
-		d.excludes = excludes
-		d.includes = includes
+		d.patterns = patterns
 		d.parsed = true
 	}
 
-	return d.excludes, d.includes, nil
+	return d.patterns, nil
 }
 
-func (d *DockerignoreContext) ParseWithLogging(logger interface{ LogInfo(string, ...interface{}) }) ([]string, []string, error) {
-	excludes, includes, err := d.Parse()
+func (d *DockerignoreContext) ParseWithLogging(logger interface{ LogInfo(string, ...interface{}) }) ([]string, error) {
+	patterns, err := d.Parse()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if excludes != nil || includes != nil {
+	if patterns != nil {
 		logger.LogInfo("Found .dockerignore file, applying filters")
 	}
 
-	return excludes, includes, nil
+	return patterns, nil
 }


### PR DESCRIPTION
I was trying to use Railpack on some obscure side project, and writing my own Dockerfile seemed so uncivilised compared to using Railpack.
I kept running into `ERROR: failed to build: failed to solve: lstat /.vscode/tasks.json: no such file or directory` during the build phase. I had neither created nor pushed any file named `tasks.json` to the project’s repository, so why would it be looking for it?
Some quick investigation led to the discovery that the pattern `!.vscode/tasks.json` in my `.dockerignore` was being wrongly interpreted by Railpack. 
I unleashed Codex at it and here we are. 

## Problem
Negated `.dockerignore` entries (e.g. `!/.vscode/tasks.json`) were being converted into explicit include paths in the generated plan. That could cause BuildKit to try to `lstat` absolute host paths like `/.vscode/tasks.json`, failing when those files don’t exist in the build context.

## Changes
- Preserve parsed `.dockerignore` patterns as-is (including `!` negations) in `DockerignoreContext`.
- Apply `.dockerignore` patterns only as local-layer exclude patterns while keeping local includes as `["."]` to avoid emitting explicit include copies.
- Add/update tests to cover negated dockerignore entries.
## Testing

- `mise run check`
- `mise run test`
- `mise run test-integration-cwd` (from `examples/dockerignore/`) ✅