### PR TITLE
docs: do not mark procfile as deprecated

### DIFF
--- a/docs/src/content/docs/config/procfile.mdx
+++ b/docs/src/content/docs/config/procfile.mdx
@@ -10,15 +10,10 @@ determine how your application should start. This is compatible with
 Heroku-style Procfiles and provides a simple way to specify different process
 types for your application.
 
-<Aside>
-  Procfiles are deprecated and natively setting the start command with
-  `RAILPACK_START_CMD` or in the `railpack.json` config file is recommended.
-</Aside>
-
 ## Detection
 
 Railpack will automatically detect a `Procfile` in your project root directory.
-No additional configuration is required - if a `Procfile` exists, Railpack will
+No additional configuration is required: if a `Procfile` exists, Railpack will
 use it to set the container start command.
 
 ## Format


### PR DESCRIPTION
This is definitely a personal preference, but I really like Procfiles.

* They are not vendor specific
* They self-document what the production start commands are in-code
* They can be run locally using foreman, honcho, etc to make it easy to run systems *exactly* as they are in production

I don't think we should mark them as deprecated.
