### PR TITLE
fix: eliminate additional logs when using --dump-llb

### DIFF
--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -112,9 +112,7 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 		return fmt.Errorf("error marshaling LLB state: %w", err)
 	}
 
-	// TODO consider removing, hard to imagine a case where this is useful
 	if opts.DumpLLB {
-		log.Info("Dumping LLB to stdout")
 		err = llb.WriteTo(def, os.Stdout)
 		if err != nil {
 			return fmt.Errorf("error writing LLB definition: %w", err)

--- a/cli/build.go
+++ b/cli/build.go
@@ -62,14 +62,16 @@ var BuildCommand = &cli.Command{
 			return cli.Exit(err, 1)
 		}
 
-		core.PrettyPrintBuildResult(buildResult, core.PrintOptions{Version: Version})
+		if !cmd.Bool("dump-llb") {
+			core.PrettyPrintBuildResult(buildResult, core.PrintOptions{Version: Version})
+		}
 
 		if !buildResult.Success {
 			os.Exit(1)
 			return nil
 		}
 
-		if cmd.Bool("show-plan") {
+		if cmd.Bool("show-plan") && !cmd.Bool("dump-llb") {
 			planMap, err := addSchemaToPlanMap(buildResult.Plan)
 			if err != nil {
 				return cli.Exit(err, 1)

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -245,6 +245,39 @@ Here's some helpful debugging tricks:
 * `docker exec buildkit buildctl prune` to clean the builder cache
 * `NO_COLOR=1`
 
+### Inspecting LLB Output
+
+The `--dump-llb` flag outputs the raw BuildKit LLB (Low-Level Builder)
+definition, which can be piped to various tools for inspection:
+
+#### Visualize LLB as a graph
+
+```bash
+mise run cli build $(pwd) --dump-llb | \
+  buildctl debug dump-llb --dot | \
+  dot -Tpng > graph.png
+```
+
+#### Inspect LLB as JSON
+
+```bash
+mise run cli build $(pwd) --dump-llb | \
+  buildctl debug dump-llb | \
+  fx
+```
+
+_Note: Any JSON visualization tool can be used (jq, fx, jless, etc.)_
+
+#### Build directly with buildctl
+
+```bash
+mise run cli build $(pwd) --dump-llb | \
+  buildctl build \
+    --progress=plain \
+    --trace=build.log \
+    --local context=.
+```
+
 ### Interactive Debugging with Delve
 
 ```sh


### PR DESCRIPTION
The stdout must be clean to use the llb with other tooling. This is for railpack developers only, but enables some helpful debug tooling.
