### PR TITLE
fix: preserve --env secrets when config defines secrets

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -158,8 +158,16 @@ func GetConfig(app *app.App, env *app.Environment, options *GenerateBuildPlanOpt
 	}
 
 	mergedConfig := c.Merge(optionsConfig, envConfig, fileConfig)
+	// c.Merge only includes the latest value for slices
+	// so we re append the env secrets to the config
+	mergedConfig.Secrets = mergeSecrets(envConfig.Secrets, mergedConfig.Secrets)
 
 	return mergedConfig, nil
+}
+
+// Merge secrets from env without losing values
+func mergeSecrets(envSecrets []string, mergedConfigSecrets []string) []string {
+	return utils.RemoveDuplicates(append(slices.Clone(envSecrets), mergedConfigSecrets...))
 }
 
 func GenerateConfigFromFile(app *app.App, env *app.Environment, options *GenerateBuildPlanOptions, logger *logger.Logger) (*c.Config, error) {

--- a/core/core.go
+++ b/core/core.go
@@ -158,16 +158,14 @@ func GetConfig(app *app.App, env *app.Environment, options *GenerateBuildPlanOpt
 	}
 
 	mergedConfig := c.Merge(optionsConfig, envConfig, fileConfig)
-	// c.Merge only includes the latest value for slices
-	// so we re append the env secrets to the config
+	// Environment-provided secrets must remain available when file configuration replaces slice values.
 	mergedConfig.Secrets = mergeSecrets(envConfig.Secrets, mergedConfig.Secrets)
 
 	return mergedConfig, nil
 }
 
-// Merge secrets from env without losing values
 func mergeSecrets(envSecrets []string, mergedConfigSecrets []string) []string {
-	return utils.RemoveDuplicates(append(slices.Clone(envSecrets), mergedConfigSecrets...))
+	return utils.RemoveDuplicates(slices.Concat(envSecrets, mergedConfigSecrets))
 }
 
 func GenerateConfigFromFile(app *app.App, env *app.Environment, options *GenerateBuildPlanOptions, logger *logger.Logger) (*c.Config, error) {

--- a/core/core.go
+++ b/core/core.go
@@ -159,13 +159,9 @@ func GetConfig(app *app.App, env *app.Environment, options *GenerateBuildPlanOpt
 
 	mergedConfig := c.Merge(optionsConfig, envConfig, fileConfig)
 	// Environment-provided secrets must remain available when file configuration replaces slice values.
-	mergedConfig.Secrets = mergeSecrets(envConfig.Secrets, mergedConfig.Secrets)
+	mergedConfig.Secrets = utils.RemoveDuplicates(slices.Concat(envConfig.Secrets, mergedConfig.Secrets))
 
 	return mergedConfig, nil
-}
-
-func mergeSecrets(envSecrets []string, mergedConfigSecrets []string) []string {
-	return utils.RemoveDuplicates(slices.Concat(envSecrets, mergedConfigSecrets))
 }
 
 func GenerateConfigFromFile(app *app.App, env *app.Environment, options *GenerateBuildPlanOptions, logger *logger.Logger) (*c.Config, error) {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -93,10 +93,10 @@ func TestGenerateConfigFromFile_Malformed(t *testing.T) {
 	require.Nil(t, cfg, "config should be nil on error")
 }
 
-func TestGetConfig_SecretsAlwaysIncludeEnvVars(t *testing.T) {
+func TestGetConfig_MergesEnvironmentAndFileSecrets(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, defaultConfigFileName)
-	err := os.WriteFile(configPath, []byte(`{"secrets":["VITE_APP_TITLE"]}`), 0644)
+	err := os.WriteFile(configPath, []byte(`{"secrets":["VITE_APP_TITLE","FILE_ONLY_SECRET"]}`), 0644)
 	require.NoError(t, err)
 
 	userApp, err := app.NewApp(tempDir)
@@ -118,6 +118,7 @@ func TestGetConfig_SecretsAlwaysIncludeEnvVars(t *testing.T) {
 		"SENTRY_AUTH_TOKEN",
 		"VITE_APP_TITLE",
 		"MY_SECRET",
+		"FILE_ONLY_SECRET",
 	}, config.Secrets)
 }
 


### PR DESCRIPTION
## Summary
- Preserve CLI `--env` secrets when config file also defines secrets by merging both sources instead of replacing one with the other.
- Add coverage for secret merge behavior in `core/core_test.go` to prevent regressions.

## Context
- Issue #455