### PR TITLE
Remove --no-scripts from PHP composer install command

### DIFF
--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -173,7 +173,7 @@ func (p *PhpProvider) InstallCompose(ctx *generate.GenerateContext, composer *ge
 		}
 
 		composer.AddCommands([]plan.Command{
-			plan.NewExecCommand("composer install --optimize-autoloader --no-scripts --no-interaction"),
+			plan.NewExecCommand("composer install --optimize-autoloader --no-interaction"),
 		})
 	}
 }

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -173,7 +173,7 @@ func (p *PhpProvider) InstallCompose(ctx *generate.GenerateContext, composer *ge
 		}
 
 		composer.AddCommands([]plan.Command{
-			plan.NewExecCommand("composer install --optimize-autoloader --no-interaction"),
+			plan.NewExecCommand("composer install --no-dev --optimize-autoloader --no-interaction"),
 		})
 	}
 }


### PR DESCRIPTION
`--no-scripts` prevents `pre-install-cmd` and `post-install-cmd` events from running.

I see no reason to prevent this and I had to add a workaround to my own applications, due to this.

It was added as part of this commit: https://github.com/railwayapp/railpack/commit/1547fa7a82293bb0a075973d4b873ccf02642c1f