### PR TITLE
feat: add --cache-ref flag for registry-based BuildKit layer cache

### DIFF
--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/containerd/platforms"
+	"github.com/docker/cli/cli/config"
 	"github.com/moby/buildkit/client"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
 	_ "github.com/moby/buildkit/client/connhelper/nerdctlcontainer"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/util/appcontext"
 	_ "github.com/moby/buildkit/util/grpcutil/encoding/proto"
@@ -185,11 +187,16 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 	}
 	secrets := secretsprovider.FromMap(secretsMap)
 
+	// Attach Docker auth provider so BuildKit can authenticate to private
+	// registries for cache import/export (--cache-ref).
+	dockerCfg := config.LoadDefaultConfigFile(os.Stderr)
+	dockerAuth := authprovider.NewDockerAuthProvider(dockerCfg, nil)
+
 	solveOpts := client.SolveOpt{
 		LocalMounts: map[string]fsutil.FS{
 			"context": appFS,
 		},
-		Session: []session.Attachable{secrets},
+		Session: []session.Attachable{secrets, dockerAuth},
 		Exports: []client.ExportEntry{
 			{
 				Type: client.ExporterDocker,

--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -53,6 +53,7 @@ type BuildWithBuildkitClientOptions struct {
 	Platform     string
 	ImportCache  string
 	ExportCache  string
+	CacheRef     string
 	CacheKey     string
 	GitHubToken  string
 }
@@ -216,6 +217,23 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 		solveOpts.CacheExports = append(solveOpts.CacheExports, client.CacheOptionsEntry{
 			Type:  "gha",
 			Attrs: parseKeyValue(opts.ExportCache),
+		})
+	}
+
+	// Add registry cache import/export if specified
+	if opts.CacheRef != "" {
+		solveOpts.CacheImports = append(solveOpts.CacheImports, client.CacheOptionsEntry{
+			Type: "registry",
+			Attrs: map[string]string{
+				"ref": opts.CacheRef,
+			},
+		})
+		solveOpts.CacheExports = append(solveOpts.CacheExports, client.CacheOptionsEntry{
+			Type: "registry",
+			Attrs: map[string]string{
+				"ref":  opts.CacheRef,
+				"mode": "max",
+			},
 		})
 	}
 

--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/buildkit/util/appcontext"
 	_ "github.com/moby/buildkit/util/grpcutil/encoding/proto"
 	"github.com/moby/buildkit/util/progress/progressui"
+	"github.com/railwayapp/railpack/buildkit/cplnauth"
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/tonistiigi/fsutil"
 )
@@ -46,18 +47,19 @@ Use 'railpack --verbose' to view more error details.
 )
 
 type BuildWithBuildkitClientOptions struct {
-	ImageName    string
-	DumpLLB      bool
-	OutputDir    string
-	ProgressMode string
-	SecretsHash  string
-	Secrets      map[string]string
-	Platform     string
-	ImportCache  string
-	ExportCache  string
-	CacheRef     string
-	CacheKey     string
-	GitHubToken  string
+	ImageName      string
+	DumpLLB        bool
+	OutputDir      string
+	ProgressMode   string
+	SecretsHash    string
+	Secrets        map[string]string
+	Platform       string
+	ImportCache    string
+	ExportCache    string
+	CacheRef       string
+	CacheKey       string
+	GitHubToken    string
+	CacheAuthBasic bool
 }
 
 func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWithBuildkitClientOptions) error {
@@ -190,13 +192,27 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 	// Attach Docker auth provider so BuildKit can authenticate to private
 	// registries for cache import/export (--cache-ref).
 	dockerCfg := config.LoadDefaultConfigFile(os.Stderr)
-	dockerAuth := authprovider.NewDockerAuthProvider(dockerCfg, nil)
+	var authAttachable session.Attachable
+	authAttachable = authprovider.NewDockerAuthProvider(dockerCfg, nil)
+
+	// When --cache-auth-basic is set and --cache-ref targets a registry,
+	// wrap the auth provider to force client-side token fetching via Basic
+	// auth GET. This works around registries (like Control Plane) that
+	// don't support the OAuth2 POST token exchange that BuildKit's daemon
+	// uses by default.
+	if opts.CacheAuthBasic && opts.CacheRef != "" {
+		host := cplnauth.RegistryHost(opts.CacheRef)
+		if host != "" {
+			log.Debugf("Using basic auth token provider for cache registry %s", host)
+			authAttachable = cplnauth.New(authAttachable, dockerCfg, []string{host})
+		}
+	}
 
 	solveOpts := client.SolveOpt{
 		LocalMounts: map[string]fsutil.FS{
 			"context": appFS,
 		},
-		Session: []session.Attachable{secrets, dockerAuth},
+		Session: []session.Attachable{secrets, authAttachable},
 		Exports: []client.ExportEntry{
 			{
 				Type: client.ExporterDocker,

--- a/buildkit/cplnauth/cplnauth.go
+++ b/buildkit/cplnauth/cplnauth.go
@@ -1,0 +1,226 @@
+// Package cplnauth provides a custom BuildKit session auth provider that
+// delegates token fetching to the client for registries that don't support
+// the standard Docker OAuth2 token exchange (POST with grant_type=password).
+//
+// When --cache-auth-basic is set and --cache-ref targets a matching registry,
+// this provider wraps the default Docker auth provider. It returns a real
+// ed25519 public key from GetTokenAuthority, which causes the BuildKit daemon
+// to call the client's FetchToken RPC instead of performing its own HTTP token
+// exchange. The client's FetchToken then calls the registry's token endpoint
+// using HTTP GET with Basic auth, which is the V2 token auth spec's
+// "direct authentication" flow and works with registries (like Control Plane)
+// that reject the OAuth2 POST flow.
+package cplnauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth"
+	"golang.org/x/crypto/nacl/sign"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AuthProvider wraps the default Docker auth provider and overrides
+// FetchToken for registries in the basicAuthHosts set. For those hosts,
+// it performs a V2 token auth GET with Basic credentials instead of
+// relying on the daemon's OAuth2 POST flow.
+type AuthProvider struct {
+	inner          session.Attachable
+	config         *configfile.ConfigFile
+	basicAuthHosts map[string]bool
+	seed           []byte
+}
+
+// New creates a new AuthProvider. basicAuthHosts is the set of registry
+// hosts (e.g. "myorg.registry.cpln.io") that should use client-side
+// token fetching with Basic auth.
+func New(inner session.Attachable, cfg *configfile.ConfigFile, basicAuthHosts []string) *AuthProvider {
+	hosts := make(map[string]bool, len(basicAuthHosts))
+	for _, h := range basicAuthHosts {
+		hosts[h] = true
+	}
+
+	// Deterministic seed derived from the hosts — stable across calls
+	// but unique enough for ed25519 key derivation.
+	mac := hmac.New(sha256.New, []byte("cpln-auth-provider"))
+	for _, h := range basicAuthHosts {
+		mac.Write([]byte(h))
+	}
+
+	return &AuthProvider{
+		inner:          inner,
+		config:         cfg,
+		basicAuthHosts: hosts,
+		seed:           mac.Sum(nil),
+	}
+}
+
+func (ap *AuthProvider) Register(server *grpc.Server) {
+	auth.RegisterAuthServer(server, ap)
+}
+
+// Credentials delegates to the inner provider.
+func (ap *AuthProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
+	if inner, ok := ap.inner.(auth.AuthServer); ok {
+		return inner.Credentials(ctx, req)
+	}
+	return &auth.CredentialsResponse{}, nil
+}
+
+// FetchToken handles token fetching. For basic-auth hosts, it calls the
+// registry's token endpoint directly using HTTP GET with Basic auth (the V2
+// "direct authentication" flow). For other hosts, it delegates to the inner
+// provider.
+func (ap *AuthProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequest) (*auth.FetchTokenResponse, error) {
+	if !ap.basicAuthHosts[req.Host] {
+		if inner, ok := ap.inner.(auth.AuthServer); ok {
+			return inner.FetchToken(ctx, req)
+		}
+		return &auth.FetchTokenResponse{}, nil
+	}
+
+	log.Debugf("[cpln-auth] fetching token for %s via Basic auth GET", req.Host)
+
+	// Get credentials from docker config.
+	ac, err := ap.config.GetAuthConfig(req.Host)
+	if err != nil {
+		return nil, fmt.Errorf("cpln-auth: get auth config for %s: %w", req.Host, err)
+	}
+
+	if ac.Username == "" || ac.Password == "" {
+		return nil, fmt.Errorf("cpln-auth: no credentials found for %s in docker config", req.Host)
+	}
+
+	// Build the V2 token auth GET request.
+	tokenURL, err := url.Parse(req.Realm)
+	if err != nil {
+		return nil, fmt.Errorf("cpln-auth: parse realm %q: %w", req.Realm, err)
+	}
+
+	params := tokenURL.Query()
+	if req.Service != "" {
+		params.Set("service", req.Service)
+	}
+	for _, scope := range req.Scopes {
+		params.Add("scope", scope)
+	}
+	tokenURL.RawQuery = params.Encode()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("cpln-auth: create token request: %w", err)
+	}
+	httpReq.SetBasicAuth(ac.Username, ac.Password)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("cpln-auth: token request to %s failed: %w", req.Realm, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("cpln-auth: token endpoint %s returned %d", req.Realm, resp.StatusCode)
+	}
+
+	var tokenResp struct {
+		Token       string    `json:"token"`
+		AccessToken string    `json:"access_token"`
+		ExpiresIn   int64     `json:"expires_in"`
+		IssuedAt    time.Time `json:"issued_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("cpln-auth: decode token response: %w", err)
+	}
+
+	token := tokenResp.Token
+	if token == "" {
+		token = tokenResp.AccessToken
+	}
+	if token == "" {
+		return nil, fmt.Errorf("cpln-auth: empty token from %s", req.Realm)
+	}
+
+	log.Debugf("[cpln-auth] successfully obtained token for %s (expires_in=%d)", req.Host, tokenResp.ExpiresIn)
+
+	expiresIn := tokenResp.ExpiresIn
+	if expiresIn == 0 {
+		expiresIn = 60
+	}
+
+	fetchResp := &auth.FetchTokenResponse{
+		Token:     token,
+		ExpiresIn: expiresIn,
+	}
+	if !tokenResp.IssuedAt.IsZero() {
+		fetchResp.IssuedAt = tokenResp.IssuedAt.Unix()
+	}
+	return fetchResp, nil
+}
+
+// GetTokenAuthority returns an ed25519 public key for basic-auth hosts.
+// This signals to the BuildKit daemon that it should delegate token fetching
+// to the client (via FetchToken RPC) instead of doing its own HTTP token
+// exchange.
+func (ap *AuthProvider) GetTokenAuthority(ctx context.Context, req *auth.GetTokenAuthorityRequest) (*auth.GetTokenAuthorityResponse, error) {
+	if !ap.basicAuthHosts[req.Host] {
+		if inner, ok := ap.inner.(auth.AuthServer); ok {
+			return inner.GetTokenAuthority(ctx, req)
+		}
+		return nil, status.Errorf(codes.Unavailable, "no token authority for %s", req.Host)
+	}
+
+	key := ap.deriveKey(req.Host, req.Salt)
+	return &auth.GetTokenAuthorityResponse{PublicKey: key[32:]}, nil
+}
+
+// VerifyTokenAuthority verifies the token authority for basic-auth hosts.
+func (ap *AuthProvider) VerifyTokenAuthority(ctx context.Context, req *auth.VerifyTokenAuthorityRequest) (*auth.VerifyTokenAuthorityResponse, error) {
+	if !ap.basicAuthHosts[req.Host] {
+		if inner, ok := ap.inner.(auth.AuthServer); ok {
+			return inner.VerifyTokenAuthority(ctx, req)
+		}
+		return nil, status.Errorf(codes.Unavailable, "no token authority for %s", req.Host)
+	}
+
+	key := ap.deriveKey(req.Host, req.Salt)
+	priv := new([64]byte)
+	copy((*priv)[:], key)
+	return &auth.VerifyTokenAuthorityResponse{Signed: sign.Sign(nil, req.Payload, priv)}, nil
+}
+
+// deriveKey derives a deterministic ed25519 key from host + salt + seed.
+func (ap *AuthProvider) deriveKey(host string, salt []byte) ed25519.PrivateKey {
+	mac := hmac.New(sha256.New, salt)
+	mac.Write(ap.seed)
+	mac.Write([]byte(host))
+	sum := mac.Sum(nil)
+	return ed25519.NewKeyFromSeed(sum[:ed25519.SeedSize])
+}
+
+// RegistryHost extracts the host portion from a registry ref
+// (e.g. "myorg.registry.cpln.io/gvc/workload:buildcache" → "myorg.registry.cpln.io").
+func RegistryHost(ref string) string {
+	// Remove tag/digest
+	ref = strings.SplitN(ref, "@", 2)[0]
+	ref = strings.SplitN(ref, ":", 2)[0]
+	// First segment is the host
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}

--- a/buildkit/cplnauth/cplnauth_test.go
+++ b/buildkit/cplnauth/cplnauth_test.go
@@ -1,0 +1,37 @@
+package cplnauth
+
+import (
+	"testing"
+)
+
+func TestRegistryHost(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{"myorg.registry.cpln.io/gvc/workload:buildcache", "myorg.registry.cpln.io"},
+		{"myorg.registry.cpln.io/gvc/workload", "myorg.registry.cpln.io"},
+		{"registry.example.com/repo:tag", "registry.example.com"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := RegistryHost(tt.ref)
+		if got != tt.want {
+			t.Errorf("RegistryHost(%q) = %q, want %q", tt.ref, got, tt.want)
+		}
+	}
+}
+
+func TestNew(t *testing.T) {
+	hosts := []string{"a.registry.cpln.io", "b.registry.cpln.io"}
+	ap := New(nil, nil, hosts)
+	if !ap.basicAuthHosts["a.registry.cpln.io"] {
+		t.Error("expected a.registry.cpln.io in basicAuthHosts")
+	}
+	if !ap.basicAuthHosts["b.registry.cpln.io"] {
+		t.Error("expected b.registry.cpln.io in basicAuthHosts")
+	}
+	if ap.basicAuthHosts["other.registry.io"] {
+		t.Error("unexpected other.registry.io in basicAuthHosts")
+	}
+}

--- a/cli/build.go
+++ b/cli/build.go
@@ -50,6 +50,10 @@ var BuildCommand = &cli.Command{
 			Name:  "cache-key",
 			Usage: "Unique id to prefix to cache keys",
 		},
+		&cli.StringFlag{
+			Name:  "cache-ref",
+			Usage: "Registry ref for remote BuildKit layer cache (e.g. registry.example.com/cache:latest)",
+		},
 		&cli.BoolFlag{
 			Name:   "dump-llb",
 			Hidden: true,
@@ -98,6 +102,7 @@ var BuildCommand = &cli.Command{
 			OutputDir:    cmd.String("output"),
 			ProgressMode: cmd.String("progress"),
 			CacheKey:     cmd.String("cache-key"),
+			CacheRef:     cmd.String("cache-ref"),
 			SecretsHash:  secretsHash,
 			Secrets:      env.Variables,
 			Platform:     platformStr,

--- a/cli/build.go
+++ b/cli/build.go
@@ -55,6 +55,11 @@ var BuildCommand = &cli.Command{
 			Usage: "Registry ref for remote BuildKit layer cache (e.g. registry.example.com/cache:latest)",
 		},
 		&cli.BoolFlag{
+			Name:  "cache-auth-basic",
+			Usage: "Force client-side Basic auth for registry cache (for registries that don't support OAuth2 token exchange)",
+			Value: false,
+		},
+		&cli.BoolFlag{
 			Name:   "dump-llb",
 			Hidden: true,
 			Value:  false,
@@ -97,16 +102,17 @@ var BuildCommand = &cli.Command{
 
 		platformStr := cmd.String("platform")
 		err = buildkit.BuildWithBuildkitClient(app.Source, buildResult.Plan, buildkit.BuildWithBuildkitClientOptions{
-			ImageName:    cmd.String("name"),
-			DumpLLB:      cmd.Bool("dump-llb"),
-			OutputDir:    cmd.String("output"),
-			ProgressMode: cmd.String("progress"),
-			CacheKey:     cmd.String("cache-key"),
-			CacheRef:     cmd.String("cache-ref"),
-			SecretsHash:  secretsHash,
-			Secrets:      env.Variables,
-			Platform:     platformStr,
-			GitHubToken:  os.Getenv("GITHUB_TOKEN"),
+			ImageName:      cmd.String("name"),
+			DumpLLB:        cmd.Bool("dump-llb"),
+			OutputDir:      cmd.String("output"),
+			ProgressMode:   cmd.String("progress"),
+			CacheKey:       cmd.String("cache-key"),
+			CacheRef:       cmd.String("cache-ref"),
+			CacheAuthBasic: cmd.Bool("cache-auth-basic"),
+			SecretsHash:    secretsHash,
+			Secrets:        env.Variables,
+			Platform:       platformStr,
+			GitHubToken:    os.Getenv("GITHUB_TOKEN"),
 		})
 		if err != nil {
 			return cli.Exit(err, 1)

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v27.5.0+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gkampitakis/ciinfo v0.3.1 // indirect
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
@@ -60,6 +61,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/in-toto/in-toto-golang v0.5.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/docker/cli v27.5.0+incompatible h1:aMphQkcGtpHixwwhAXJT1rrK/detk2JIvD
 github.com/docker/cli v27.5.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v27.5.0+incompatible h1:um++2NcQtGRTz5eEgO6aJimo6/JxrTXC941hd05JO6U=
 github.com/docker/docker v27.5.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
+github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -113,6 +115,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0/go.mod h1:ggCgvZ2r7uOoQjOyu2Y1
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/in-toto/in-toto-golang v0.5.0 h1:hb8bgwr0M2hGdDsLjkJ3ZqJ8JFLL/tgYdAxF/XEFBbY=


### PR DESCRIPTION
## Summary
Adds a `--cache-ref` CLI flag that configures BuildKit to use a remote container registry for layer cache import/export (`type=registry`).

This enables stateless CI/CD workers to share build cache across deploys by storing layers in a container registry, rather than relying on local disk cache that is lost on pod restart.

## Usage
```bash
railpack build . --cache-ref registry.example.com/cache:latest
```

## Changes
- `cli/build.go`: Add `--cache-ref` string flag, pass to `BuildWithBuildkitClientOptions`
- `buildkit/build.go`: Add `CacheRef` field, configure `CacheImports`/`CacheExports` with `type=registry` and `mode=max`

## Context
BuildKit natively supports registry-based cache via `CacheImports`/`CacheExports` with `type=registry`. Railpack already supports GHA cache (`ImportCache`/`ExportCache` fields with `type=gha`) but doesn't expose registry cache. This is a small addition that unlocks stateless build workers for multi-tenant platforms where each customer has their own registry.