### PR TITLE
feat: 14d delay on new mise packages

### DIFF
--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -28,7 +28,7 @@
  "steps": [
   {
    "assets": {
-    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\"]\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
+    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\"]\n  install_before = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
    },
    "commands": [
     {

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -290,6 +290,8 @@ func (b *MiseStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) er
 		b.AddMiseSetting("trusted_config_paths", []string{"/app"})
 		// Enable mise to automatically read idiomatic version files
 		b.AddMiseSetting("idiomatic_version_file_enable_tools", strings.Split(mise.IdiomaticVersionFileTools, ","))
+		// Only resolve tool versions released more than 14 days ago to avoid broken newly-released versions
+		b.AddMiseSetting("install_before", "14d")
 
 		// pass through the MISE_VERBOSE variable for detailed logging
 		if verbose := b.env.GetVariable("MISE_VERBOSE"); verbose != "" {

--- a/docs/src/content/docs/config/mise.md
+++ b/docs/src/content/docs/config/mise.md
@@ -18,6 +18,19 @@ ruby versions, and add additional utilities like `jq` to your image all through 
   source code. However, this global configuration is set in `/etc/mise/config.toml`
   so it can easily be overwritten in your application.
 
+## Default Settings
+
+Railpack sets the following mise settings by default in the generated
+`/etc/mise/config.toml`. These can be overridden in your own `mise.toml`.
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `paranoid` | `true` | Enforces HTTPS and stricter security validation |
+| `trusted_config_paths` | `["/app"]` | Trusts app config files to avoid warnings during build |
+| `idiomatic_version_file_enable_tools` | *(language list)* | Auto-reads version files like `.node-version`, `.python-version`, etc. |
+| `install_before` | `"14d"` | Only resolves tool versions released more than 14 days ago, avoiding newly-released versions that may be broken |
+| `node.verify` | `false` | Skips asset signature verification for Node, since recently released versions may not yet have a public key |
+
 ## Customization
 
 Use a mise configuration file or environment variables to customize mise in the Railpack-generated container.


### PR DESCRIPTION
## Motivation

Avoid broken or incomplete tool versions by ensuring only versions released at least 14 days ago are resolved by default. This should help with the python & ruby compilation issues and the node version verification stuff (I'd like to to remove the node verification skip in the future).

## Description

- Set the mise `install_before` setting to `14d` in the default configuration.
- Add a table to the documentation explaining all default mise settings and the reason for each setting.

## Screenshots / Test

Verified by updating the mise configuration snapshot in `core/generate/__snapshots__/context_test.snap`.

## Links

- Relates to #207