### PR TITLE
feat: surface extra mise.toml packages in build output

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -79,7 +79,7 @@
     },
     {
      "cmd": "mise install",
-     "customName": "install mise packages: bun, node"
+     "customName": "install mise packages: bun, node, go, python"
     }
    ],
    "inputs": [

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	a "github.com/railwayapp/railpack/core/app"
 	"github.com/railwayapp/railpack/core/mise"
 	"github.com/railwayapp/railpack/core/plan"
@@ -327,7 +328,32 @@ func (b *MiseStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) er
 		for k := range packagesToInstall {
 			pkgNames = append(pkgNames, k)
 		}
+
+		// Surface extra packages from user mise config files in build output (issue #419)
+		userPkgNames := []string{}
+		for _, file := range supportingMiseConfigFiles {
+			if !strings.HasSuffix(file, ".toml") {
+				continue
+			}
+			content, err := b.app.ReadFile(file)
+			if err != nil {
+				continue
+			}
+			var userConfig struct {
+				Tools map[string]any `toml:"tools"`
+			}
+			if _, err := toml.Decode(content, &userConfig); err != nil {
+				continue
+			}
+			for toolName := range userConfig.Tools {
+				if _, exists := packagesToInstall[toolName]; !exists {
+					userPkgNames = append(userPkgNames, toolName)
+				}
+			}
+		}
+		sort.Strings(userPkgNames)
 		sort.Strings(pkgNames)
+		pkgNames = append(pkgNames, userPkgNames...)
 
 		step.AddCommands([]plan.Command{
 			plan.NewFileCommand("/etc/mise/config.toml", "generated-mise-toml", plan.FileOptions{


### PR DESCRIPTION
Closes #419

## Problem

When users define additional packages in their `mise.toml` (e.g. `redis`, `terraform`), those packages are installed during the build but never shown in the output. The install step only lists packages that Railpack's providers auto-detected, leaving users with no visibility into what else is being installed.

## Solution

After collecting provider-detected packages, the build step now reads the user's mise config files, parses the `[tools]` section, and appends any extra package names (not already tracked by providers) to the install step's display name.

**Before:** `install mise packages: bun, node`  
**After:** `install mise packages: bun, node, go, python`

## Changes

- `core/generate/mise_step_builder.go`: Parse user mise.toml files for extra tool names and include them in build output
- Updated `mise-config` snapshot to reflect the new output

## Testing

- All 110 snapshot tests pass
- Tested with a sample project containing extra mise.toml packages