### PR TITLE
feat: run containers as non-root user by default

### DIFF
--- a/buildkit/convert.go
+++ b/buildkit/convert.go
@@ -79,6 +79,7 @@ func ConvertPlanToLLB(plan *p.BuildPlan, opts ConvertPlanOptions) (*llb.State, *
 			WorkingDir: WorkingDir,
 			Entrypoint: []string{"/bin/bash", "-c"},
 			Cmd:        []string{startCommand},
+			User:       plan.Deploy.User,
 		},
 	}
 

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "pnpm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -173,6 +174,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "python --version \u0026\u0026 neofetch $HELLO",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -193,6 +194,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-cmake_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-cmake_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -11,7 +11,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "/build/cpp-cmake"
+  "startCommand": "/build/cpp-cmake",
+  "user": "1001"
  },
  "steps": [
   {
@@ -73,6 +74,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-meson_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-meson_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -11,7 +11,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "/build/cpp-meson"
+  "startCommand": "/build/cpp-meson",
+  "user": "1001"
  },
  "steps": [
   {
@@ -73,6 +74,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -22,7 +22,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "deno run --allow-all main.ts"
+  "startCommand": "deno run --allow-all main.ts",
+  "user": "1001"
  },
  "steps": [
   {
@@ -78,6 +79,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_dockerignore_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_dockerignore_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -11,7 +11,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "sh start.sh"
+  "startCommand": "sh start.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -60,6 +61,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-api_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-api_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -28,6 +28,7 @@
    }
   ],
   "startCommand": "ASPNETCORE_URLS=http://0.0.0.0:${PORT:-3000} ./out/csharp-api",
+  "user": "1001",
   "variables": {
    "ASPNETCORE_CONTENTROOT": "/app/out",
    "ASPNETCORE_ENVIRONMENT": "Production",
@@ -157,6 +158,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-cli_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-cli_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -28,6 +28,7 @@
    }
   ],
   "startCommand": "ASPNETCORE_URLS=http://0.0.0.0:${PORT:-3000} ./out/csharp-cli",
+  "user": "1001",
   "variables": {
    "ASPNETCORE_CONTENTROOT": "/app/out",
    "ASPNETCORE_ENVIRONMENT": "Production",
@@ -157,6 +158,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -12,6 +12,7 @@
    }
   ],
   "startCommand": "/app/_build/prod/rel/friends/bin/friends start",
+  "user": "1001",
   "variables": {
    "ELIXIR_ERL_OPTIONS": "+fnu",
    "LANG": "en_US.UTF-8",
@@ -163,6 +164,20 @@
     "MIX_ENV": "prod",
     "MIX_HOME": "/root/.mix"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-latest_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -12,6 +12,7 @@
    }
   ],
   "startCommand": "/app/_build/prod/rel/friends/bin/friends start",
+  "user": "1001",
   "variables": {
    "ELIXIR_ERL_OPTIONS": "+fnu",
    "LANG": "en_US.UTF-8",
@@ -167,6 +168,20 @@
     "MIX_ENV": "prod",
     "MIX_HOME": "/root/.mix"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -12,6 +12,7 @@
    }
   ],
   "startCommand": "/app/_build/prod/rel/hello/bin/hello start",
+  "user": "1001",
   "variables": {
    "ELIXIR_ERL_OPTIONS": "+fnu",
    "LANG": "en_US.UTF-8",
@@ -173,6 +174,20 @@
     "MIX_ENV": "prod",
     "MIX_HOME": "/root/.mix"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-custom-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-custom-version_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -21,7 +21,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "./build/erlang-shipment/entrypoint.sh run"
+  "startCommand": "./build/erlang-shipment/entrypoint.sh run",
+  "user": "1001"
  },
  "steps": [
   {
@@ -117,6 +118,20 @@
     "MISE_INSTALLS_DIR": "/mise/installs",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-include-source_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-include-source_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -21,7 +21,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "./build/erlang-shipment/entrypoint.sh run"
+  "startCommand": "./build/erlang-shipment/entrypoint.sh run",
+  "user": "1001"
  },
  "steps": [
   {
@@ -109,6 +110,20 @@
     "MISE_INSTALLS_DIR": "/mise/installs",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -21,7 +21,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "./build/erlang-shipment/entrypoint.sh run"
+  "startCommand": "./build/erlang-shipment/entrypoint.sh run",
+  "user": "1001"
  },
  "steps": [
   {
@@ -109,6 +110,20 @@
     "MISE_INSTALLS_DIR": "/mise/installs",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -25,7 +25,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "./out"
+  "startCommand": "./out",
+  "user": "1001"
  },
  "steps": [
   {
@@ -141,6 +142,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -25,7 +25,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "./out"
+  "startCommand": "./out",
+  "user": "1001"
  },
  "steps": [
   {
@@ -141,6 +142,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -25,7 +25,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "./out"
+  "startCommand": "./out",
+  "user": "1001"
  },
  "steps": [
   {
@@ -141,6 +142,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -27,7 +27,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "java $JAVA_OPTS -jar  $(ls -1 */build/libs/*jar | grep -v plain)"
+  "startCommand": "java $JAVA_OPTS -jar  $(ls -1 */build/libs/*jar | grep -v plain)",
+  "user": "1001"
  },
  "steps": [
   {
@@ -118,6 +119,20 @@
     "MISE_INSTALLS_DIR": "/mise/installs",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -27,7 +27,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "java  $JAVA_OPTS -jar target/*jar"
+  "startCommand": "java  $JAVA_OPTS -jar target/*jar",
+  "user": "1001"
  },
  "steps": [
   {
@@ -118,6 +119,20 @@
     "MISE_INSTALLS_DIR": "/mise/installs",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -27,7 +27,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "java  $JAVA_OPTS -jar target/*jar"
+  "startCommand": "java  $JAVA_OPTS -jar target/*jar",
+  "user": "1001"
  },
  "steps": [
   {
@@ -118,6 +119,20 @@
     "MISE_INSTALLS_DIR": "/mise/installs",
     "MISE_SHIMS_DIR": "/mise/shims"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -166,6 +167,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -42,6 +42,7 @@
    }
   ],
   "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -207,6 +208,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -55,6 +55,7 @@
    }
   ],
   "startCommand": "pnpm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "HOST": "0.0.0.0",
@@ -185,6 +186,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -46,6 +46,7 @@
    }
   ],
   "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -212,6 +213,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "bun index.ts",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -170,6 +171,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "bun run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -162,6 +163,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "bun index.ts",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -174,6 +175,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "bun index.ts",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -171,6 +172,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -52,6 +52,7 @@
    }
   ],
   "startCommand": "pnpm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -181,6 +182,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -42,6 +42,7 @@
    }
   ],
   "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -207,6 +208,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -52,6 +52,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -176,6 +177,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "pnpm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -181,6 +182,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -55,6 +55,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -179,6 +180,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -169,6 +170,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -52,6 +52,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -188,6 +189,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -166,6 +167,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "node .output/server/index.mjs",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -169,6 +170,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -166,6 +167,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "pnpm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -169,6 +170,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "pnpm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -193,6 +194,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -175,6 +176,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -51,6 +51,7 @@
    }
   ],
   "startCommand": "node index.js",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -166,6 +167,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
@@ -27,7 +27,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -59,6 +59,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -181,6 +182,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -50,6 +50,7 @@
     "step": "build"
    }
   ],
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -175,6 +176,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -55,6 +55,7 @@
    }
   ],
   "startCommand": "bun run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -176,6 +177,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -56,6 +56,7 @@
    }
   ],
   "startCommand": "npm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -210,6 +211,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
@@ -27,7 +27,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -50,6 +50,7 @@
    }
   ],
   "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -230,6 +231,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
@@ -27,7 +27,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -59,6 +59,7 @@
    }
   ],
   "startCommand": "pnpm run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -194,6 +195,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -46,6 +46,7 @@
    }
   ],
   "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -212,6 +213,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -46,6 +46,7 @@
    }
   ],
   "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -219,6 +220,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -23,7 +23,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -46,6 +46,7 @@
    }
   ],
   "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -212,6 +213,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -52,6 +52,7 @@
    }
   ],
   "startCommand": "yarn run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -201,6 +202,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -53,6 +53,7 @@
    }
   ],
   "startCommand": "yarn run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -172,6 +173,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -52,6 +52,7 @@
    }
   ],
   "startCommand": "yarn run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -183,6 +184,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -53,6 +53,7 @@
    }
   ],
   "startCommand": "yarn run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -190,6 +191,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -53,6 +53,7 @@
    }
   ],
   "startCommand": "yarn run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -182,6 +183,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -53,6 +53,7 @@
    }
   ],
   "startCommand": "yarn run start",
+  "user": "1001",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -185,6 +186,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -27,7 +27,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -46,7 +46,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -321,6 +322,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -27,7 +27,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -46,7 +46,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -321,6 +322,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
@@ -7,9 +7,10 @@
  },
  "deploy": {
   "base": {
-   "step": "build"
+   "step": "setup:user"
   },
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -125,6 +126,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "build"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
@@ -1,9 +1,10 @@
 {
  "deploy": {
   "base": {
-   "step": "build"
+   "step": "setup:user"
   },
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -102,6 +103,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "build"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -28,6 +28,7 @@
    }
   ],
   "startCommand": "python bot.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -94,6 +95,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -139,6 +140,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -45,6 +45,7 @@
    }
   ],
   "startCommand": "python manage.py migrate \u0026\u0026 gunicorn --bind 0.0.0.0:${PORT:-8000} mysite.wsgi:application",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -191,6 +192,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -143,6 +144,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -131,6 +132,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "gunicorn --bind 0.0.0.0:${PORT:-8000} main:app",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -131,6 +132,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -28,6 +28,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -98,6 +99,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -45,6 +45,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -191,6 +192,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -28,6 +28,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -98,6 +99,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -28,6 +28,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -98,6 +99,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -31,6 +31,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -125,6 +126,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "python app.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -135,6 +136,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -31,6 +31,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -127,6 +128,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -31,6 +31,7 @@
    }
   ],
   "startCommand": "poetry run python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -127,6 +128,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -147,6 +148,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -45,6 +45,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -179,6 +180,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "python-uv-packaged",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -147,6 +148,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -147,6 +148,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -45,6 +45,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -185,6 +186,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "python main.py",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -145,6 +146,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -7,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -37,6 +37,7 @@
    }
   ],
   "startCommand": "gunicorn --bind 0.0.0.0:${PORT:-8000} main:app",
+  "user": "1001",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -147,6 +148,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_railpack-env-configuration_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_railpack-env-configuration_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -11,7 +11,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "bash start.sh"
+  "startCommand": "bash start.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -43,6 +44,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "ruby app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -177,6 +178,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3-precompiled_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3-precompiled_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "ruby --yjit app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -185,6 +186,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "ruby --enable-yjit app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -177,6 +178,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-execjs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-execjs_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "ruby app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -173,6 +174,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-jemalloc_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-jemalloc_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "ruby app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -173,6 +174,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-latest_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "ruby app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -177,6 +178,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "bundle exec ruby app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -177,6 +178,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "bundle exec rackup config.ru -o 0.0.0.0 -p ${PORT:-3000}",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -173,6 +174,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -39,6 +39,7 @@
    }
   ],
   "startCommand": "rake db:migrate \u0026\u0026 bundle exec bin/rails server -b 0.0.0.0 -p ${PORT:-3000}",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -186,6 +187,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -39,6 +39,7 @@
    }
   ],
   "startCommand": "rake db:migrate \u0026\u0026 bundle exec bin/rails server -b 0.0.0.0 -p ${PORT:-3000}",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -189,6 +190,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "RACK_ENV=production bundle exec puma",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -173,6 +174,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -38,6 +38,7 @@
    }
   ],
   "startCommand": "ruby app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -177,6 +178,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
@@ -19,7 +19,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -62,6 +62,7 @@
    }
   ],
   "startCommand": "ruby app.rb",
+  "user": "1001",
   "variables": {
    "BUNDLE_GEMFILE": "/app/Gemfile",
    "GEM_HOME": "/usr/local/bundle",
@@ -284,6 +285,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces-glob_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces-glob_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -25,6 +25,7 @@
    }
   ],
   "startCommand": "./bin/binary",
+  "user": "1001",
   "variables": {
    "ROCKET_ADDRESS": "0.0.0.0"
   }
@@ -124,6 +125,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -25,6 +25,7 @@
    }
   ],
   "startCommand": "./bin/binary",
+  "user": "1001",
   "variables": {
    "ROCKET_ADDRESS": "0.0.0.0"
   }
@@ -120,6 +121,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -29,6 +29,7 @@
    }
   ],
   "startCommand": "./bin/rust-custom-toolchain",
+  "user": "1001",
   "variables": {
    "ROCKET_ADDRESS": "0.0.0.0"
   }
@@ -144,6 +145,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-version_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -29,6 +29,7 @@
    }
   ],
   "startCommand": "./bin/rust-custom-version",
+  "user": "1001",
   "variables": {
    "ROCKET_ADDRESS": "0.0.0.0"
   }
@@ -144,6 +145,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-multiple-bins_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-multiple-bins_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -29,6 +29,7 @@
    }
   ],
   "startCommand": "./bin/bin1",
+  "user": "1001",
   "variables": {
    "ROCKET_ADDRESS": "0.0.0.0"
   }
@@ -150,6 +151,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-rocket_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-rocket_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -29,6 +29,7 @@
    }
   ],
   "startCommand": "./bin/rocket",
+  "user": "1001",
   "variables": {
    "ROCKET_ADDRESS": "0.0.0.0"
   }
@@ -148,6 +149,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-system-deps_1.snap.json
@@ -15,7 +15,7 @@
  },
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -29,6 +29,7 @@
    }
   ],
   "startCommand": "./bin/rust-open-ssl",
+  "user": "1001",
   "variables": {
    "ROCKET_ADDRESS": "0.0.0.0"
   }
@@ -144,6 +145,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -17,7 +17,8 @@
     "step": "usesSecrets"
    }
   ],
-  "startCommand": "./run.sh"
+  "startCommand": "./run.sh",
+  "user": "1001"
  },
  "secrets": [
   "MY_SECRET",
@@ -81,6 +82,20 @@
    "variables": {
     "NOT_SECRET": "not secret"
    }
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-bash-arrays_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-bash-arrays_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -11,7 +11,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "bash start.sh"
+  "startCommand": "bash start.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -43,6 +44,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-platform-arch_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-platform-arch_1.snap.json
@@ -11,7 +11,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -21,7 +21,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "zsh start.sh"
+  "startCommand": "zsh start.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -71,6 +72,20 @@
     }
    ],
    "name": "packages:apt:runtime"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:apt:runtime"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-script_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-script_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -11,7 +11,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "sh start.sh"
+  "startCommand": "sh start.sh",
+  "user": "1001"
  },
  "steps": [
   {
@@ -43,6 +44,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -17,7 +17,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261"
+  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001"
  },
  "steps": [
   {
@@ -70,6 +71,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index-fallback_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index-fallback_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -17,7 +17,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261"
+  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001"
  },
  "steps": [
   {
@@ -70,6 +71,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
@@ -1,7 +1,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -17,7 +17,8 @@
     "step": "build"
    }
   ],
-  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261"
+  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "user": "1001"
  },
  "steps": [
   {
@@ -70,6 +71,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -19,6 +19,7 @@ type DeployConfig struct {
 	StartCmd    string            `json:"startCommand,omitempty" jsonschema:"description=The command to run in the container"`
 	Variables   map[string]string `json:"variables,omitempty" jsonschema:"description=The variables available to this step. The key is the name of the variable that is referenced in a variable command"`
 	Paths       []string          `json:"paths,omitempty" jsonschema:"description=The paths to prepend to the $PATH environment variable"`
+	User        string            `json:"user,omitempty" jsonschema:"description=The user to run the container as. Set to root to disable non-root user. Defaults to 1001"`
 }
 
 type StepConfig struct {

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -3,7 +3,7 @@
 {
  "deploy": {
   "base": {
-   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+   "step": "setup:user"
   },
   "inputs": [
    {
@@ -17,6 +17,7 @@
    }
   ],
   "startCommand": "echo hello",
+  "user": "1001",
   "variables": {
    "HELLO": "world"
   }
@@ -94,6 +95,20 @@
    "secrets": [
     "*"
    ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "groupadd -g 1001 railpack \u0026\u0026 useradd -u 1001 -g railpack -m -s /bin/bash railpack \u0026\u0026 chown -R 1001:1001 /app",
+     "customName": "create non-root user"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.3.17"
+    }
+   ],
+   "name": "setup:user"
   }
  ]
 }

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -213,6 +213,9 @@ func (c *GenerateContext) applyConfig() {
 		c.Deploy.AptPackages = plan.SpreadStrings(c.Config.Deploy.AptPackages, c.Deploy.AptPackages)
 		c.Deploy.DeployInputs = plan.Spread(c.Config.Deploy.Inputs, c.Deploy.DeployInputs)
 		c.Deploy.Paths = plan.SpreadStrings(c.Config.Deploy.Paths, c.Deploy.Paths)
+		if c.Config.Deploy.User != "" {
+			c.Deploy.User = c.Config.Deploy.User
+		}
 		maps.Copy(c.Deploy.Variables, c.Config.Deploy.Variables)
 	}
 

--- a/core/generate/deploy_builder.go
+++ b/core/generate/deploy_builder.go
@@ -11,6 +11,7 @@ type DeployBuilder struct {
 	Variables    map[string]string
 	Paths        []string
 	AptPackages  []string
+	User         string
 }
 
 func NewDeployBuilder() *DeployBuilder {
@@ -21,6 +22,7 @@ func NewDeployBuilder() *DeployBuilder {
 		Variables:    map[string]string{},
 		Paths:        []string{},
 		AptPackages:  []string{},
+		User:         "1001",
 	}
 }
 
@@ -66,10 +68,26 @@ func (b *DeployBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) {
 		baseLayer = plan.NewStepLayer(runtimeAptStep.Name)
 	}
 
+	// Create non-root user unless explicitly set to "root"
+	if b.User != "" && b.User != "root" {
+		userStep := plan.NewStep("setup:user")
+		userStep.Inputs = []plan.Layer{baseLayer}
+		userStep.AddCommands([]plan.Command{
+			plan.NewExecCommand(
+				"groupadd -g 1001 railpack && useradd -u 1001 -g railpack -m -s /bin/bash railpack && chown -R 1001:1001 /app",
+				plan.ExecOptions{CustomName: "create non-root user"},
+			),
+		})
+		userStep.Secrets = []string{}
+		p.Steps = append(p.Steps, *userStep)
+		baseLayer = plan.NewStepLayer(userStep.Name)
+	}
+
 	p.Deploy.Base = baseLayer
 
 	p.Deploy.Inputs = append(p.Deploy.Inputs, b.DeployInputs...)
 	p.Deploy.StartCmd = b.StartCmd
 	p.Deploy.Variables = b.Variables
 	p.Deploy.Paths = b.Paths
+	p.Deploy.User = b.User
 }

--- a/core/plan/plan.go
+++ b/core/plan/plan.go
@@ -33,6 +33,9 @@ type Deploy struct {
 
 	// The paths to prepend to the $PATH environment variable
 	Paths []string `json:"paths,omitempty"`
+
+	// The user to run the container as. Defaults to non-root
+	User string `json:"user,omitempty"`
 }
 
 func NewBuildPlan() *BuildPlan {


### PR DESCRIPTION
Closes #286

## Problem

Containers built by Railpack run as root by default, which is a security concern and violates container best practices.

## Solution

Containers now run as UID 1001 (`railpack` user) by default. A new `setup:user` build step creates the user/group and sets ownership of `/app`.

**Changes across 5 files:**
- `core/plan/plan.go` — Added `User` field to `Deploy` struct
- `core/config/config.go` — Added `user` option to `DeployConfig` so users can override
- `core/generate/deploy_builder.go` — Defaults to UID `1001`, creates non-root user step with `groupadd`/`useradd`/`chown`
- `core/generate/context.go` — Wires config override to deploy builder
- `buildkit/convert.go` — Sets `User` in OCI image config

**Opt-out:** Users who need root can set their railpack config:
```json
{"deploy": {"user": "root"}}
```

## Testing

- All 110 snapshot tests updated and passing
- Compiles clean on macOS (Apple Silicon)