### PR TITLE
docs: Railpack provider values in schema enum

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -27,7 +27,7 @@ type StepConfig struct {
 }
 
 type Config struct {
-	Provider         *string                `json:"provider,omitempty" jsonschema:"description=The provider to use"`
+	Provider         *string                `json:"provider,omitempty" jsonschema:"enum=php,enum=golang,enum=java,enum=rust,enum=ruby,enum=elixir,enum=python,enum=deno,enum=dotnet,enum=node,enum=gleam,enum=cpp,enum=staticfile,enum=shell,description=The provider to use"`
 	BuildAptPackages []string               `json:"buildAptPackages,omitempty" jsonschema:"description=List of apt packages to install during the build step"`
 	Steps            map[string]*StepConfig `json:"steps,omitempty" jsonschema:"description=Map of step names to step definitions"`
 	Deploy           *DeployConfig          `json:"deploy,omitempty" jsonschema:"description=Deploy configuration"`

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -309,6 +309,24 @@ func TestGetJsonSchema(t *testing.T) {
 	require.NotEmpty(t, schema)
 
 	require.NotContains(t, schema.Required, "provider")
+	providerSchema, ok := schema.Properties.Get("provider")
+	require.True(t, ok)
+	require.ElementsMatch(t, []any{
+		"php",
+		"golang",
+		"java",
+		"rust",
+		"ruby",
+		"elixir",
+		"python",
+		"deno",
+		"dotnet",
+		"node",
+		"gleam",
+		"cpp",
+		"staticfile",
+		"shell",
+	}, providerSchema.Enum)
 
 	schemaJson, err := json.MarshalIndent(schema, "", "  ")
 	require.NoError(t, err)

--- a/core/providers/provider.go
+++ b/core/providers/provider.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"strings"
+
 	"github.com/railwayapp/railpack/core/generate"
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/providers/cpp"
@@ -50,7 +52,7 @@ func GetLanguageProviders() []Provider {
 
 func GetProvider(name string) Provider {
 	for _, provider := range GetLanguageProviders() {
-		if provider.Name() == name {
+		if strings.EqualFold(provider.Name(), name) {
 			return provider
 		}
 	}

--- a/core/providers/provider_test.go
+++ b/core/providers/provider_test.go
@@ -1,0 +1,14 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProviderIsCaseInsensitive(t *testing.T) {
+	require.NotNil(t, GetProvider("elixir"))
+	require.NotNil(t, GetProvider("Elixir"))
+	require.NotNil(t, GetProvider("dotnet"))
+	require.NotNil(t, GetProvider("Dotnet"))
+}

--- a/docs/src/content/docs/config/file.mdx
+++ b/docs/src/content/docs/config/file.mdx
@@ -163,6 +163,32 @@ For example:
 }
 ```
 
+### Provider Values
+
+Railpack autodetects the provider by default. If you need to force a provider,
+set the root `provider` field to one of these values:
+
+| Provider     | Use case                         |
+| :----------- | :------------------------------- |
+| `php`        | PHP and Laravel applications     |
+| `golang`     | Go applications                  |
+| `java`       | Java applications                |
+| `rust`       | Rust applications                |
+| `ruby`       | Ruby and Rails applications      |
+| `elixir`     | Elixir and Phoenix applications  |
+| `python`     | Python applications              |
+| `deno`       | Deno applications                |
+| `dotnet`     | .NET applications                |
+| `node`       | Node.js, Bun, and frontend apps  |
+| `gleam`      | Gleam applications               |
+| `cpp`        | C/C++ applications               |
+| `staticfile` | Static sites with a `Staticfile` |
+| `shell`      | Shell-script based applications  |
+
+Provider names are matched case-insensitively. Package managers are handled
+inside each provider, so `uv` support is part of the `python` provider rather
+than a separate provider value.
+
 ## Caches
 
 Caches are used to speed up builds by storing and reusing files between builds.


### PR DESCRIPTION
## Summary
- add provider enum values to the generated `railpack schema` output
- document the available `provider` values in the config file guide
- make configured provider lookup case-insensitive so the documented lowercase values work for `elixir` and `dotnet`

This also clarifies that `uv` support is handled by the `python` provider, not a separate provider.

Related Central Station question: https://station.railway.com/questions/what-are-the-available-providers-in-rail-bae3a690

## Verification
- `git diff --check`
- `go test ./core/config ./core/providers`
- `go run ./cmd/cli schema` shows the provider enum
- `bun run build` in `docs`

I also tried `go test ./...`; it did not complete cleanly in this environment because existing example snapshots resolve newer Caddy/FrankenPHP patch versions and integration tests require `BUILDKIT_HOST`. Those failures appear unrelated to this change.