### PR TITLE
fix(config): honor configured deploy base layers

### DIFF
--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -206,6 +206,10 @@ func (c *GenerateContext) applyConfig() {
 
 	// Update deploy from config
 	if c.Config.Deploy != nil {
+		if c.Config.Deploy.Base != nil && !c.Config.Deploy.Base.IsEmpty() {
+			c.Deploy.Base = *c.Config.Deploy.Base
+		}
+
 		if c.Config.Deploy.StartCmd != "" {
 			c.Deploy.StartCmd = c.Config.Deploy.StartCmd
 		}

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -101,6 +101,42 @@ func TestGenerateContext(t *testing.T) {
 	snaps.MatchJSON(t, serializedPlan)
 }
 
+func TestGenerateContextAppliesConfiguredDeployBase(t *testing.T) {
+	t.Run("direct deploy base", func(t *testing.T) {
+		ctx := CreateTestContext(t, "../../examples/node-npm")
+		cfg := config.EmptyConfig()
+		cfg.Deploy.Base = &plan.Layer{Image: "debian:bookworm-slim"}
+		ctx.Config = cfg
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Equal(t, plan.NewImageLayer("debian:bookworm-slim"), buildPlan.Deploy.Base)
+	})
+
+	t.Run("runtime apt step uses configured deploy base", func(t *testing.T) {
+		ctx := CreateTestContext(t, "../../examples/node-npm")
+		cfg := config.EmptyConfig()
+		cfg.Deploy.Base = &plan.Layer{Image: "debian:bookworm-slim"}
+		cfg.Deploy.AptPackages = []string{"curl"}
+		ctx.Config = cfg
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Equal(t, plan.NewStepLayer("packages:apt:runtime"), buildPlan.Deploy.Base)
+
+		var runtimeAptStep *plan.Step
+		for i := range buildPlan.Steps {
+			if buildPlan.Steps[i].Name == "packages:apt:runtime" {
+				runtimeAptStep = &buildPlan.Steps[i]
+				break
+			}
+		}
+
+		require.NotNil(t, runtimeAptStep)
+		require.Equal(t, []plan.Layer{plan.NewImageLayer("debian:bookworm-slim")}, runtimeAptStep.Inputs)
+	})
+}
+
 func TestGenerateContextDockerignore(t *testing.T) {
 	t.Run("context with dockerignore", func(t *testing.T) {
 		ctx := CreateTestContext(t, "../../examples/dockerignore")


### PR DESCRIPTION
Fixes #551.

`deploy.base` is already parsed from `railpack.json`, but it was not copied into the deploy builder during config application. This applies a non-empty configured deploy base so custom runtime images show up in the generated plan.

When runtime apt packages are configured, the generated `packages:apt:runtime` step now uses the configured deploy base as its first input, preserving the existing apt layering behavior.

Verification:
- `go test ./core/generate -run TestGenerateContextAppliesConfiguredDeployBase`
- `go test ./core/generate -run TestGenerateContext`
- `go test ./core/generate`
- `git diff --check`