### PR TITLE
fix(build): respect configured deploy input filters

### DIFF
--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -8,12 +8,6 @@
   "inputs": [
    {
     "step": "build"
-   },
-   {
-    "include": [
-     "."
-    ],
-    "step": "build"
    }
   ],
   "startCommand": "echo hello",

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -249,6 +249,8 @@ func (c *GenerateContext) applyConfig() {
 		outputFilters := []plan.Filter{plan.NewIncludeFilter([]string{"."})}
 		if configStep.DeployOutputs != nil {
 			outputFilters = configStep.DeployOutputs
+		} else if c.Deploy.HasInputForStep(name) {
+			continue
 		}
 		for _, filter := range outputFilters {
 			alreadyCovered := false

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -264,6 +264,8 @@ func (c *GenerateContext) applyConfig() {
 		outputFilters := []plan.Filter{plan.NewIncludeFilter([]string{"."})}
 		if configStep.DeployOutputs != nil {
 			outputFilters = configStep.DeployOutputs
+		} else if c.Deploy.HasInputForStep(name) {
+			continue
 		}
 		for _, filter := range outputFilters {
 			alreadyCovered := false

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -231,6 +231,11 @@ func (c *GenerateContext) applyConfig() {
 		maps.Copy(c.Deploy.Variables, c.Config.Deploy.Variables)
 	}
 
+	// A spread retains generated deploy composition; any explicit list without one takes full control.
+	replacesGeneratedDeployInputs := c.Config.Deploy != nil &&
+		c.Config.Deploy.Inputs != nil &&
+		!slices.ContainsFunc(c.Config.Deploy.Inputs, plan.Layer.IsSpread)
+
 	// Apply step config to the context
 	for _, name := range slices.Sorted(maps.Keys(c.Config.Steps)) {
 		configStep := c.Config.Steps[name]
@@ -263,21 +268,20 @@ func (c *GenerateContext) applyConfig() {
 		// (e.g. provider already added "." so we don't duplicate it from --build-cmd).
 		outputFilters := []plan.Filter{plan.NewIncludeFilter([]string{"."})}
 		if configStep.DeployOutputs != nil {
+			// if deploy outputs are explicitly set on a step, then always use them, regardless of deploy configuration
+			// TODO I don't like this and find it confusing: deploy.inputs should be able to override step-level deploy outputs
 			outputFilters = configStep.DeployOutputs
-		} else if c.Deploy.HasInputForStep(name) {
+		} else if replacesGeneratedDeployInputs || c.Deploy.HasInputForStep(name) {
+			// if no deployOutput is specified on a step, the user has not specified a "..." in deploy.inputs, and
 			continue
 		}
 		for _, filter := range outputFilters {
-			alreadyCovered := false
-			for _, inc := range filter.Include {
-				if c.Deploy.HasIncludeForStep(name, inc) {
-					alreadyCovered = true
-					break
-				}
+			if slices.ContainsFunc(filter.Include, func(inc string) bool {
+				return c.Deploy.HasIncludeForStep(name, inc)
+			}) {
+				continue
 			}
-			if !alreadyCovered {
-				c.Deploy.AddInputs([]plan.Layer{plan.NewStepLayer(name, filter)})
-			}
+			c.Deploy.AddInputs([]plan.Layer{plan.NewStepLayer(name, filter)})
 		}
 	}
 }

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -101,6 +101,36 @@ func TestGenerateContext(t *testing.T) {
 	snaps.MatchJSON(t, serializedPlan)
 }
 
+func TestGenerateContextKeepsConfiguredDeployInputFilters(t *testing.T) {
+	ctx := CreateTestContext(t, "../../examples/node-npm")
+	configJSON := `{
+		"steps": {
+			"build": {
+				"commands": ["npm run build"]
+			}
+		},
+		"deploy": {
+			"inputs": [
+				{
+					"step": "build",
+					"include": ["apps/landing/.next/standalone"]
+				}
+			]
+		}
+	}`
+
+	var config config.Config
+	require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
+	ctx.Config = &config
+
+	buildPlan, _, err := ctx.Generate()
+	require.NoError(t, err)
+
+	require.Equal(t, []plan.Layer{
+		plan.NewStepLayer("build", plan.NewIncludeFilter([]string{"apps/landing/.next/standalone"})),
+	}, buildPlan.Deploy.Inputs)
+}
+
 func TestGenerateContextDockerignore(t *testing.T) {
 	t.Run("context with dockerignore", func(t *testing.T) {
 		ctx := CreateTestContext(t, "../../examples/dockerignore")

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -204,6 +204,36 @@ func TestGenerateContextAppliesConfiguredDeployBase(t *testing.T) {
 	})
 }
 
+func TestGenerateContextKeepsConfiguredDeployInputFilters(t *testing.T) {
+	ctx := CreateTestContext(t, "../../examples/node-npm")
+	configJSON := `{
+		"steps": {
+			"build": {
+				"commands": ["npm run build"]
+			}
+		},
+		"deploy": {
+			"inputs": [
+				{
+					"step": "build",
+					"include": ["apps/landing/.next/standalone"]
+				}
+			]
+		}
+	}`
+
+	var config config.Config
+	require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
+	ctx.Config = &config
+
+	buildPlan, _, err := ctx.Generate()
+	require.NoError(t, err)
+
+	require.Equal(t, []plan.Layer{
+		plan.NewStepLayer("build", plan.NewIncludeFilter([]string{"apps/landing/.next/standalone"})),
+	}, buildPlan.Deploy.Inputs)
+}
+
 func TestGenerateContextDockerignore(t *testing.T) {
 	t.Run("dockerignore patterns precede config patterns", func(t *testing.T) {
 		ctx := CreateTestContext(t, "../../examples/dockerignore")

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -204,34 +204,156 @@ func TestGenerateContextAppliesConfiguredDeployBase(t *testing.T) {
 	})
 }
 
-func TestGenerateContextKeepsConfiguredDeployInputFilters(t *testing.T) {
-	ctx := CreateTestContext(t, "../../examples/node-npm")
-	configJSON := `{
-		"steps": {
-			"build": {
-				"commands": ["npm run build"]
-			}
-		},
-		"deploy": {
-			"inputs": [
-				{
-					"step": "build",
-					"include": ["apps/landing/.next/standalone"]
+func TestGenerateContextDeployInputs(t *testing.T) {
+	t.Run("explicit inputs suppress implicit outputs from every configured step", func(t *testing.T) {
+		ctx := CreateTestContext(t, "../../examples/node-npm")
+		provider := &TestProvider{}
+		require.NoError(t, provider.Plan(ctx))
+
+		configJSON := `{
+			"steps": {
+				"install": {
+					"commands": ["echo installing"]
+				},
+				"build": {
+					"commands": ["echo building"]
 				}
-			]
-		}
-	}`
+			},
+			"deploy": {
+				"inputs": [
+					{
+						"step": "build",
+						"include": ["apps/landing/.next/standalone"]
+					}
+				]
+			}
+		}`
 
-	var config config.Config
-	require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
-	ctx.Config = &config
+		var config config.Config
+		require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
+		ctx.Config = &config
 
-	buildPlan, _, err := ctx.Generate()
-	require.NoError(t, err)
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
 
-	require.Equal(t, []plan.Layer{
-		plan.NewStepLayer("build", plan.NewIncludeFilter([]string{"apps/landing/.next/standalone"})),
-	}, buildPlan.Deploy.Inputs)
+		require.Equal(t, []plan.Layer{
+			plan.NewStepLayer("build", plan.NewIncludeFilter([]string{"apps/landing/.next/standalone"})),
+		}, buildPlan.Deploy.Inputs)
+	})
+
+	t.Run("omitted inputs preserve implicit outputs", func(t *testing.T) {
+		ctx := CreateTestContext(t, "../../examples/node-npm")
+		configJSON := `{
+			"steps": {
+				"custom": {
+					"commands": ["echo custom"]
+				}
+			},
+			"deploy": {
+				"startCommand": "echo hello"
+			}
+		}`
+
+		var config config.Config
+		require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
+		ctx.Config = &config
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+
+		require.Equal(t, []plan.Layer{
+			plan.NewStepLayer("custom", plan.NewIncludeFilter([]string{"."})),
+		}, buildPlan.Deploy.Inputs)
+	})
+
+	t.Run("explicit deploy outputs remain additive", func(t *testing.T) {
+		ctx := CreateTestContext(t, "../../examples/node-npm")
+		configJSON := `{
+			"steps": {
+				"build": {
+					"commands": ["echo building"],
+					"deployOutputs": [
+						{"include": ["dist"]}
+					]
+				}
+			},
+			"deploy": {
+				"inputs": [
+					{"step": "build", "include": ["other"]}
+				]
+			}
+		}`
+
+		var config config.Config
+		require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
+		ctx.Config = &config
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+
+		require.Equal(t, []plan.Layer{
+			plan.NewStepLayer("build", plan.NewIncludeFilter([]string{"other"})),
+			plan.NewStepLayer("build", plan.NewIncludeFilter([]string{"dist"})),
+		}, buildPlan.Deploy.Inputs)
+	})
+
+	t.Run("empty inputs suppress implicit outputs", func(t *testing.T) {
+		ctx := CreateTestContext(t, "../../examples/node-npm")
+		provider := &TestProvider{}
+		require.NoError(t, provider.Plan(ctx))
+
+		configJSON := `{
+			"steps": {
+				"install": {
+					"commands": ["echo installing"]
+				},
+				"build": {
+					"commands": ["echo building"]
+				}
+			},
+			"deploy": {
+				"inputs": []
+			}
+		}`
+
+		var config config.Config
+		require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
+		ctx.Config = &config
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+
+		require.Empty(t, buildPlan.Deploy.Inputs)
+	})
+
+	t.Run("spread inputs preserve generated and implicit outputs", func(t *testing.T) {
+		ctx := CreateTestContext(t, "../../examples/node-npm")
+		provider := &TestProvider{}
+		require.NoError(t, provider.Plan(ctx))
+
+		configJSON := `{
+			"steps": {
+				"custom": {
+					"commands": ["echo custom"]
+				}
+			},
+			"deploy": {
+				"inputs": ["..."]
+			}
+		}`
+
+		var config config.Config
+		require.NoError(t, json.Unmarshal([]byte(configJSON), &config))
+		ctx.Config = &config
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+
+		require.Equal(t, []plan.Layer{
+			plan.NewStepLayer("build"),
+			plan.NewStepLayer("custom", plan.NewIncludeFilter([]string{"."})),
+		}, buildPlan.Deploy.Inputs)
+	})
 }
 
 func TestGenerateContextDockerignore(t *testing.T) {

--- a/core/generate/deploy_builder.go
+++ b/core/generate/deploy_builder.go
@@ -47,6 +47,15 @@ func (b *DeployBuilder) HasIncludeForStep(stepName string, path string) bool {
 	return false
 }
 
+func (b *DeployBuilder) HasInputForStep(stepName string) bool {
+	for _, layer := range b.DeployInputs {
+		if layer.Step == stepName {
+			return true
+		}
+	}
+	return false
+}
+
 func (b *DeployBuilder) AddAptPackages(packages []string) {
 	b.AptPackages = append(b.AptPackages, packages...)
 }

--- a/core/generate/deploy_builder.go
+++ b/core/generate/deploy_builder.go
@@ -47,6 +47,7 @@ func (b *DeployBuilder) HasIncludeForStep(stepName string, path string) bool {
 	return false
 }
 
+// checks if any of the deploy inputs contain a given step name
 func (b *DeployBuilder) HasInputForStep(stepName string) bool {
 	for _, layer := range b.DeployInputs {
 		if layer.Step == stepName {

--- a/core/generate/deploy_builder_test.go
+++ b/core/generate/deploy_builder_test.go
@@ -96,3 +96,13 @@ func TestHasIncludeForStep(t *testing.T) {
 		})
 	}
 }
+
+func TestHasInputForStep(t *testing.T) {
+	builder := NewDeployBuilder()
+	builder.DeployInputs = []plan.Layer{
+		{Step: "build", Filter: plan.Filter{Include: []string{"apps/landing/.next/standalone"}}},
+	}
+
+	assert.True(t, builder.HasInputForStep("build"))
+	assert.False(t, builder.HasInputForStep("install"))
+}

--- a/examples/config-file/custom-start.sh
+++ b/examples/config-file/custom-start.sh
@@ -5,4 +5,10 @@ if [ "$(cat /hello)" != "world" ]; then
   exit 1
 fi
 
+# /boop comes from an unrelated step and must not leak through implicit deploy outputs.
+if [ -e /boop ]; then
+  echo "Error: implicit deploy output copied /boop"
+  exit 1
+fi
+
 echo "custom start!"

--- a/examples/config-file/railpack.other.json
+++ b/examples/config-file/railpack.other.json
@@ -19,6 +19,8 @@
       { "local": true, "include": ["custom-start.sh"] }
     ],
     "aptPackages": ["cowsay"],
+    // Debian installs cowsay in /usr/games, which is not on the runtime PATH.
+    "paths": ["/usr/games"],
     "startCommand": "neofetch && cowsay hello && ./custom-start.sh"
   }
 }


### PR DESCRIPTION
Fixes #448.

When a `railpack.json` defines a step and also explicitly lists that step in `deploy.inputs`, Railpack was still appending the implicit deploy output for the whole step. That meant a filtered input like:

```json
{ "step": "build", "include": ["apps/landing/.next/standalone"] }
```

could be followed by another `$build`/`.` deploy input, copying the full build output into the final image.

This skips the implicit default deploy output for config-defined steps when that step already has an explicit deploy input. Config steps without explicit deploy inputs keep the existing default behavior.

Verification:
- `go test ./core/generate -run 'TestHasInputForStep|TestGenerateContextKeepsConfiguredDeployInputFilters'`\n- `go test ./core/generate -run TestHasIncludeForStep`\n- `go test ./core/generate`\n- `git diff --check`