### PR TITLE
docs: correct GHCR image for Railpack frontend

### DIFF
--- a/docs/src/content/docs/reference/frontend.md
+++ b/docs/src/content/docs/reference/frontend.md
@@ -30,7 +30,7 @@ buildctl build \
   --local context=/path/to/app/to/build \
   --local dockerfile=/path/to/dir/containing/railpack-plan.json \
   --frontend=gateway.v0 \
-  --opt source=ghcr.io/railwayapp/railpack:railpack-frontend \
+  --opt source=ghcr.io/railwayapp/railpack-frontend:latest \
   --output type=docker,name=test
 ```
 
@@ -104,7 +104,7 @@ buildctl build \
   --local context=/path/to/app/to/build \
   --local dockerfile=/path/to/dir/containing/railpack-plan.json \
   --frontend=gateway.v0 \
-  --opt source=ghcr.io/railwayapp/railpack:railpack-frontend \
+  --opt source=ghcr.io/railwayapp/railpack-frontend:latest \
   --secret id=STRIPE_LIVE_KEY,env=STRIPE_LIVE_KEY \
   --output type=docker,name=test
 ```


### PR DESCRIPTION

## Summary

Updates the BuildKit/Railpack frontend image reference in the docs from:

```bash
ghcr.io/railwayapp/railpack:railpack-frontend
````

to the currently exposed GHCR frontend image:

```bash
ghcr.io/railwayapp/railpack-frontend:latest
```

## Why

The previous image reference appears to point to a tag on the `railwayapp/railpack` image, while the Railpack frontend is available in GHCR as the separate `railwayapp/railpack-frontend` package.

This change makes the documented `buildctl` example match the image users can pull directly from the registry.

## Testing

Verified the replacement image can be pulled from GHCR:

```bash
docker pull ghcr.io/railwayapp/railpack-frontend:latest
```