### PR TITLE
feat(pnpm): standardize store path and configuration

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -112,7 +112,7 @@
      "src": "pnpm-lock.yaml"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -133,7 +133,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
@@ -17,7 +17,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -117,7 +117,7 @@
      "src": "pnpm-lock.yaml"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -139,7 +139,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -138,7 +138,9 @@
     "NODE_ENV": "production",
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
-    "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+    "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -120,7 +120,7 @@
      "src": "pnpm-workspace.yaml"
     },
     {
-     "path": "/pnpm/bin"
+     "path": "/opt/pnpm/bin"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -141,7 +141,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -108,7 +108,7 @@
      "src": "package.json"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -129,7 +129,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -112,7 +112,7 @@
      "src": "pnpm-lock.yaml"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -133,7 +133,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -132,7 +132,7 @@
      "src": "pnpm-workspace.yaml"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -153,7 +153,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -103,7 +103,7 @@
      "cmd": "mkdir -p /app/node_modules/.cache"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -130,7 +130,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   },
   "react-router": {
@@ -111,7 +111,7 @@
      "src": "pnpm-lock.yaml"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -132,7 +132,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   },
   "react-router": {
@@ -120,7 +120,7 @@
      "src": "pnpm-lock.yaml"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -141,7 +141,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   },
   "vite": {
@@ -107,7 +107,7 @@
      "src": "pnpm-lock.yaml"
     },
     {
-     "path": "/pnpm"
+     "path": "/opt/pnpm"
     },
     {
      "cmd": "pnpm add -g node-gyp"
@@ -128,7 +128,8 @@
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-    "PNPM_HOME": "/pnpm"
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
@@ -13,7 +13,7 @@
    "type": "shared"
   },
   "pnpm-install": {
-   "directory": "/root/.local/share/pnpm/store/v3",
+   "directory": "/opt/pnpm/store",
    "type": "shared"
   }
  },
@@ -119,6 +119,10 @@
      "src": "package.json"
     },
     {
+     "dest": "pnpm-workspace.yaml",
+     "src": "pnpm-workspace.yaml"
+    },
+    {
      "cmd": "pnpm install"
     }
    ],
@@ -134,7 +138,9 @@
     "NODE_ENV": "production",
     "NPM_CONFIG_FUND": "false",
     "NPM_CONFIG_PRODUCTION": "false",
-    "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+    "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
    }
   },
   {

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -20,7 +20,8 @@ const (
 	PackageManagerYarnBerry PackageManager = "yarnberry"
 
 	DEFAULT_PNPM_VERSION = "9"
-	PNPM_HOME            = "/pnpm"
+	PNPM_HOME            = "/opt/pnpm"
+	PNPM_STORE_DIR       = PNPM_HOME + "/store"
 )
 
 func (p PackageManager) Name() string {
@@ -110,7 +111,7 @@ func (p PackageManager) GetInstallCache(ctx *generate.GenerateContext) string {
 	case PackageManagerNpm:
 		return ctx.Caches.AddCache("npm-install", "/root/.npm")
 	case PackageManagerPnpm:
-		return ctx.Caches.AddCache("pnpm-install", "/root/.local/share/pnpm/store/v3")
+		return ctx.Caches.AddCache("pnpm-install", PNPM_STORE_DIR)
 	case PackageManagerBun:
 		return ctx.Caches.AddCache("bun-install", "/root/.bun/install/cache")
 	case PackageManagerYarn1:
@@ -134,6 +135,11 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 			install.AddCommand(plan.NewExecCommand("npm install"))
 		}
 	case PackageManagerPnpm:
+		install.AddEnvVars(map[string]string{
+			"PNPM_HOME":      PNPM_HOME,
+			"PNPM_STORE_DIR": PNPM_STORE_DIR,
+		})
+
 		// pnpm (standalone) does not bundle node-gyp like npm does, so we must install it globally
 		// to support packages with native dependencies (e.g., better-sqlite3, bcrypt, etc.)
 		// Only needed when using mise to install pnpm (not corepack, which includes node-gyp)
@@ -145,10 +151,6 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 				pnpmBinPath = PNPM_HOME + "/bin"
 			}
 
-			// Set PNPM_HOME so pnpm can create a global bin directory for node-gyp
-			install.AddEnvVars(map[string]string{
-				"PNPM_HOME": PNPM_HOME,
-			})
 			// binaries are installed in the /bin subpath. If this is not added to PATH `pnpm add -g` will fail
 			install.AddPaths([]string{pnpmBinPath})
 			install.AddCommand(plan.NewExecCommand("pnpm add -g node-gyp"))

--- a/examples/pnpm-corepack-runtime-usage/README.md
+++ b/examples/pnpm-corepack-runtime-usage/README.md
@@ -1,0 +1,1 @@
+lockfile is intentionally omitted to test the pnpm detection without lockfile + mise config

--- a/examples/pnpm-corepack-runtime-usage/package.json
+++ b/examples/pnpm-corepack-runtime-usage/package.json
@@ -7,6 +7,9 @@
     "start": "node main.js"
   },
   "packageManager": "pnpm@11.1.2",
+  "dependencies": {
+    "better-sqlite3": ">=12"
+  },
   "engines": {
     "node": "^26.0.0"
   }

--- a/examples/pnpm-corepack-runtime-usage/pnpm-workspace.yaml
+++ b/examples/pnpm-corepack-runtime-usage/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  better-sqlite3: true

--- a/mise.toml
+++ b/mise.toml
@@ -40,6 +40,7 @@ run = "go build -o bin/railpack cmd/cli/main.go"
 [tasks.clean]
 run = [
   "rm -rf bin dist docs/dist",
+  "find . -type d -name node_modules -prune -exec rm -rf {} +",
   # clean up buildkit cache, avoids cached layers from being used
   "docker exec buildkit buildctl prune",
   "rm -f *.test",


### PR DESCRIPTION
## Motivation

Railpack cached a hardcoded pnpm store path (`/root/.local/share/pnpm/store/v3`), but newer pnpm versions write to a different location. BuildKit was caching the wrong directory, so pnpm install cache hits never materialized.

## Description

- Set `PNPM_HOME` and `PNPM_STORE_DIR` explicitly during every pnpm install so the store path is known and consistent regardless of pnpm version or install method.
- Point the BuildKit install cache at `PNPM_STORE_DIR` (`/opt/pnpm/store`) instead of the old hardcoded path, so cached layers match where pnpm actually stores packages.

## Test

- Extended `pnpm-corepack-runtime-usage` with a `better-sqlite3` native dependency and workspace config.
- Updated build plan snapshots to reflect the new pnpm store and home paths.