### PR TITLE
refactor(mise): remove minimum release age constraint

### DIFF
--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -28,7 +28,7 @@
  "steps": [
   {
    "assets": {
-    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\"]\n  minimum_release_age = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
+    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\"]\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
    },
    "commands": [
     {

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -292,9 +292,6 @@ func (b *MiseStepBuilder) Build(p *plan.BuildPlan, options *BuildStepOptions) er
 		b.AddMiseSetting("trusted_config_paths", []string{"/app"})
 		// Enable mise to automatically read idiomatic version files
 		b.AddMiseSetting("idiomatic_version_file_enable_tools", strings.Split(mise.IdiomaticVersionFileTools, ","))
-		// Only resolve tool versions released more than 14 days ago to avoid broken newly-released versions
-		b.AddMiseSetting("minimum_release_age", "14d")
-
 		// pass through the MISE_VERBOSE variable for detailed logging
 		if verbose := b.env.GetVariable("MISE_VERBOSE"); verbose != "" {
 			step.Variables["MISE_VERBOSE"] = verbose

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -172,8 +172,6 @@ func (m *Mise) runCmdWithEnv(extraEnv []string, args ...string) (string, error) 
 		fmt.Sprintf("MISE_DATA_DIR=%s", dataDir),
 		fmt.Sprintf("MISE_STATE_DIR=%s", stateDir),
 		fmt.Sprintf("MISE_SYSTEM_CONFIG_DIR=%s", systemDir),
-		// match the same mise_step_builder default
-		"MISE_MINIMUM_RELEASE_AGE=14d",
 		// TODO doesn't HTTP timeout apply to fetch remote versions too?
 		"MISE_HTTP_TIMEOUT=60s",
 		"MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=60s",

--- a/core/providers/node/node_test.go
+++ b/core/providers/node/node_test.go
@@ -52,7 +52,7 @@ func TestNode(t *testing.T) {
 			path:           "../../../examples/node-latest-pnpm-mise-native-deps",
 			detected:       true,
 			packageManager: PackageManagerPnpm,
-			nodeVersion:    "26.1.0",
+			nodeVersion:    "26.2.0",
 			pnpmVersion:    "latest",
 		},
 		{

--- a/docs/src/content/docs/architecture/package-resolution.md
+++ b/docs/src/content/docs/architecture/package-resolution.md
@@ -49,5 +49,4 @@ Manifest constraints (for example `engines.pnpm`) are not resolved with
 npm-style semver. Caret (`^`) and range (`>=`, `<`) notation are simplified to
 the major version only (`^10.34.0` → `10`) before Mise picks a release. This
 is done because Mise does not support compound version constraints right now.
-Use an exact version or `mise.toml` to pin. See also
-[`minimum_release_age`](/config/mise#minimum_release_age).
+Use an exact version or `mise.toml` to pin.

--- a/docs/src/content/docs/config/mise.md
+++ b/docs/src/content/docs/config/mise.md
@@ -28,7 +28,6 @@ Railpack sets the following mise settings by default in the generated
 | `paranoid` | `true` | Enforces HTTPS and stricter security validation |
 | `trusted_config_paths` | `["/app"]` | Trusts app config files to avoid warnings during build |
 | `idiomatic_version_file_enable_tools` | *(language list)* | Auto-reads version files like `.node-version`, `.python-version`, etc. |
-| `minimum_release_age` | `"14d"` | Mise will omit language, package manager, etc versions released in the last two weeks. You can override this settings in your application's mise configuration. |
 | `node.verify` | `false` | Skips asset signature verification for Node, since recently released versions may not yet have a public key |
 
 ## Customization


### PR DESCRIPTION
## Motivation

Railpack forced a 14-day minimum release age when resolving mise tool versions, which blocked newly published runtimes from being selected. Users who want that guard can set it in their own `mise.toml` instead of inheriting a Railpack default.

Relates to #571

## Description

- Drop `minimum_release_age` from generated build `mise.toml` and `MISE_MINIMUM_RELEASE_AGE` from host-side mise resolution so `latest` and related lookups follow mise defaults.
- Remove docs that described Railpack as owning this setting.

## Test

- Updated generate context snapshots and node provider test expectations after version resolution no longer applies the 14-day filter.