### PR TITLE
chore: update missed snapshots

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
@@ -83,7 +83,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.5.16"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.5.18"
     }
    ],
    "name": "packages:mise",
@@ -170,7 +170,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.5.16"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.5.18"
     }
    ],
    "name": "packages:apt:runtime"


### PR DESCRIPTION
not sure how this was missed in the automated update. If it happens again I'll have to revisit.
