### PR TITLE
feat: configure en_US.UTF-8 locale in Debian images

### DIFF
--- a/docs/src/content/docs/architecture/overview.md
+++ b/docs/src/content/docs/architecture/overview.md
@@ -123,6 +123,11 @@ compile time, derived from a single pinned mise version in
 - **Runtime image** (`ghcr.io/railwayapp/railpack-runtime:mise-<version>`):
   a minimal Debian image used as the base for the final output image.
 
+Both images include the `en_US.UTF-8` locale (generated at image build time).
+Railpack does not set `LANG` or `LC_ALL` by default; set them yourself if your
+application needs a UTF-8 locale (for example Python or Ruby apps that call
+`locale.setlocale`).
+
 Because the image tags are pinned to the mise version, upgrading Railpack
 automatically uses the corresponding builder and runtime images. There is no
 `latest` tag ambiguity — a given binary always references the same images.

--- a/docs/src/content/docs/config/file.mdx
+++ b/docs/src/content/docs/config/file.mdx
@@ -328,6 +328,24 @@ The deploy section configures how the container runs:
 | `inputs`       | List of layers for the deploy step (from steps, images, or local files) |
 | `aptPackages`  | List of Apt packages to install in the final image                      |
 
+### Locale
+
+Both the builder and runtime images include `en_US.UTF-8`, but do not set
+`LANG` or `LC_ALL` by default. To enable it at runtime, set them in
+`deploy.variables`:
+
+```json
+"deploy": {
+  "variables": {
+    "LANG": "en_US.UTF-8",
+    "LC_ALL": "en_US.UTF-8"
+  }
+}
+```
+
+You can also set `LANG` and `LC_ALL` in your hosting platform's environment
+configuration.
+
 ## Schema
 
 The schema for the config file is available at https://schema.railpack.com. Add

--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -79,5 +79,7 @@ RUN apt-get update && apt-get install -y \
     locales && \
     rm -rf /var/lib/apt/lists/*
 
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
 # Make sure the cache directory exists
 RUN mkdir -p /root/.cache

--- a/images/debian/runtime/Dockerfile
+++ b/images/debian/runtime/Dockerfile
@@ -8,4 +8,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     openssl \
     tzdata \
+    locales \
+    && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+    && locale-gen \
     && rm -rf /var/lib/apt/lists/*

--- a/mise.toml
+++ b/mise.toml
@@ -144,8 +144,17 @@ run = ["bun install", "bun run dev"]
 run = "docker build --build-arg MISE_VERSION=$RAILPACK_MISE_VERSION -f images/debian/build/Dockerfile -t railpack-builder:local ."
 
 [tasks.mise-builder-shell]
-description = "Shell into the published railpack-builder image"
-run = "docker run -it --rm ghcr.io/railwayapp/railpack-builder:mise-$RAILPACK_MISE_VERSION bash"
+description = "Shell into the railpack-builder image"
+usage = 'flag "--local" help="Build and use railpack-builder:local instead of the ghcr image"'
+run = '''
+if [ "${usage_local:-false}" = "true" ]; then
+  mise run image-builder-build
+  image="railpack-builder:local"
+else
+  image="ghcr.io/railwayapp/railpack-builder:mise-$RAILPACK_MISE_VERSION"
+fi
+exec docker run -it --rm "$image" bash
+'''
 
 [tasks.image-runtime-build]
 run = "docker build -f images/debian/runtime/Dockerfile -t railpack-runtime:local ."


### PR DESCRIPTION
## Motivation

Build and runtime containers lacked a generated UTF-8 locale, which breaks or warns for apps that depend on locale-aware behavior (for example Python or Ruby). This aligns our default build containers with Heroku, which provides `LANG=en_US.UTF-8` in their images by default.

## Description

Generate `en_US.UTF-8` in the Debian builder and runtime images at image build time so the locale is available without changing default process environment. Railpack still does not set `LANG` or `LC_ALL`; users opt in via `deploy.variables` or their platform's env config, as documented in the architecture overview and config reference.

## Test

- `mise run check`
- Snapshot tests (updated `pnpm-corepack-runtime-usage` plan for current mise image tags)
- Rebuild builder/runtime images and run integration tests that exercise locale-sensitive builds (for example Ruby or Elixir examples) if validating the image change end-to-end