### PR TITLE
feat: include tzdata by default in build and runtime images

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "go-build": {
    "directory": "/root/.cache/go-build",
    "type": "shared"
@@ -15,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.6.0"
   },
   "inputs": [
    {
@@ -123,24 +115,6 @@
    "secrets": [
     "*"
    ]
-  },
-  {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y tzdata'",
-     "customName": "install apt packages: tzdata"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.6.0"
-    }
-   ],
-   "name": "packages:apt:runtime"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "go-build": {
    "directory": "/root/.cache/go-build",
    "type": "shared"
@@ -15,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.6.0"
   },
   "inputs": [
    {
@@ -123,24 +115,6 @@
    "secrets": [
     "*"
    ]
-  },
-  {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y tzdata'",
-     "customName": "install apt packages: tzdata"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.6.0"
-    }
-   ],
-   "name": "packages:apt:runtime"
   }
  ]
 }

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
@@ -1,13 +1,5 @@
 {
  "caches": {
-  "apt": {
-   "directory": "/var/cache/apt",
-   "type": "locked"
-  },
-  "apt-lists": {
-   "directory": "/var/lib/apt/lists",
-   "type": "locked"
-  },
   "go-build": {
    "directory": "/root/.cache/go-build",
    "type": "shared"
@@ -15,7 +7,7 @@
  },
  "deploy": {
   "base": {
-   "step": "packages:apt:runtime"
+   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.6.0"
   },
   "inputs": [
    {
@@ -123,24 +115,6 @@
    "secrets": [
     "*"
    ]
-  },
-  {
-   "caches": [
-    "apt",
-    "apt-lists"
-   ],
-   "commands": [
-    {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y tzdata'",
-     "customName": "install apt packages: tzdata"
-    }
-   ],
-   "inputs": [
-    {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.6.0"
-    }
-   ],
-   "name": "packages:apt:runtime"
   }
  ]
 }

--- a/core/providers/golang/golang.go
+++ b/core/providers/golang/golang.go
@@ -44,13 +44,10 @@ func (p *GoProvider) Plan(ctx *generate.GenerateContext) error {
 
 	ctx.Deploy.StartCmd = fmt.Sprintf("./%s", GO_BINARY_NAME)
 
-	runtimePkgs := []string{"tzdata"}
 	if p.hasCGOEnabled(ctx) {
 		ctx.Logger.LogInfo("CGO is enabled")
-		runtimePkgs = append(runtimePkgs, "libc6")
+		ctx.Deploy.AddAptPackages([]string{"libc6"})
 	}
-
-	ctx.Deploy.AddAptPackages(runtimePkgs)
 	ctx.Deploy.AddInputs([]plan.Layer{
 		plan.NewStepLayer(build.Name(), plan.Filter{
 			Include: []string{"."},

--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     ssh \
     rsync \
+    tzdata \
     locales && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/debian/runtime/Dockerfile
+++ b/images/debian/runtime/Dockerfile
@@ -7,4 +7,5 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     pkg-config \
     openssl \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Motivation

Railpack runtime images did not include timezone data by default. Go apps relied on the Golang provider to add `tzdata` as a runtime apt package, while other stacks had no consistent way to resolve named timezones (for example via `TZ` or libraries that read the zoneinfo database).

## Description

Install `tzdata` in the shared Debian build and runtime base images so every Railpack build and deploy image has zoneinfo available without per-language apt steps.

Remove the Golang provider's dedicated `tzdata` runtime apt package; CGO builds still add `libc6` when needed. Go example build-plan snapshots are updated to drop the redundant runtime apt layer.

## Test

- Updated Go example build-plan snapshots (`go-mod`, `go-cmd-dirs`, `go-workspaces`)
- `mise run check`
- Rebuild Debian base images so integration tests pick up the new packages