### PR TITLE
fix(elixir): add support for Elixir 1.20 erlang mapping

### DIFF
--- a/core/providers/elixir/elixir.go
+++ b/core/providers/elixir/elixir.go
@@ -308,6 +308,8 @@ func getCompatibleErlangVersion(elixirVersion string) string {
 		return "27"
 	case "1.19":
 		return "28"
+	case "1.20":
+		return "29"
 	default:
 		return DEFAULT_ERLANG_VERSION
 	}


### PR DESCRIPTION
- update compatible Erlang version mapping to use Erlang 29 for Elixir 1.20

Generated-by: aiautocommit
