### PR TITLE
feat(node): support pnpm binaries in monorepo workspaces

### DIFF
--- a/core/providers/node/package_json.go
+++ b/core/providers/node/package_json.go
@@ -19,6 +19,7 @@ type PackageJson struct {
 	DevDependencies map[string]string `json:"devDependencies"`
 	Engines         map[string]string `json:"engines"`
 	Main            string            `json:"main"`
+	Bin             json.RawMessage   `json:"bin"`
 	Workspaces      []string          `json:"-"`
 }
 
@@ -32,6 +33,10 @@ func NewPackageJson() *PackageJson {
 
 func (p *PackageJson) HasScript(name string) bool {
 	return p.Scripts != nil && p.Scripts[name] != ""
+}
+
+func (p *PackageJson) HasBin() bool {
+	return len(p.Bin) > 0 && string(p.Bin) != "null"
 }
 
 func (p *PackageJson) GetScript(name string) string {

--- a/core/providers/node/package_json_test.go
+++ b/core/providers/node/package_json_test.go
@@ -13,6 +13,23 @@ func TestPackageJson(t *testing.T) {
 		assert.Equal(t, packageJson.HasScript("start"), false)
 		assert.Equal(t, packageJson.GetScript("build"), "")
 		assert.Equal(t, packageJson.hasDependency("react"), false)
+		assert.False(t, packageJson.HasBin())
+	})
+
+	t.Run("bin field", func(t *testing.T) {
+		t.Run("string bin", func(t *testing.T) {
+			var packageJson PackageJson
+			err := json.Unmarshal([]byte(`{"bin": "./cli.js"}`), &packageJson)
+			assert.NoError(t, err)
+			assert.True(t, packageJson.HasBin())
+		})
+
+		t.Run("object bin", func(t *testing.T) {
+			var packageJson PackageJson
+			err := json.Unmarshal([]byte(`{"bin": {"hello-cli": "./bin/hello.js"}}`), &packageJson)
+			assert.NoError(t, err)
+			assert.True(t, packageJson.HasBin())
+		})
 	})
 
 	t.Run("full package.json", func(t *testing.T) {

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -85,14 +85,17 @@ func (p PackageManager) installDependencies(ctx *generate.GenerateContext, works
 	}
 
 	usesLocalFile := p.usesLocalFile(ctx)
+	hasWorkspaceBins := p == PackageManagerPnpm && workspace != nil && workspace.HasPackageBins()
 
 	// If there are any pre/post install scripts, we need the entire app to be copied
 	// This is to handle things like patch-package
-	if hasPreInstall || hasPostInstall || hasPrepare || usesLocalFile {
+	if hasPreInstall || hasPostInstall || hasPrepare || usesLocalFile || hasWorkspaceBins {
 		install.AddInput(ctx.NewLocalLayer())
 
 		// Use all secrets for the install step if there are any pre/post install scripts
-		install.UseSecrets([]string{"*"})
+		if hasPreInstall || hasPostInstall || hasPrepare {
+			install.UseSecrets([]string{"*"})
+		}
 	} else {
 		files := p.SupportingInstallFiles(ctx)
 		for _, file := range files {

--- a/core/providers/node/workspace.go
+++ b/core/providers/node/workspace.go
@@ -149,3 +149,13 @@ func (w *Workspace) AllPackageJson() []*PackageJson {
 
 	return packageJsons
 }
+
+func (w *Workspace) HasPackageBins() bool {
+	for _, pkg := range w.Packages {
+		if pkg.PackageJson.HasBin() {
+			return true
+		}
+	}
+
+	return false
+}

--- a/core/providers/node/workspace_test.go
+++ b/core/providers/node/workspace_test.go
@@ -124,6 +124,34 @@ func TestConvertWorkspacePattern(t *testing.T) {
 	}
 }
 
+func TestWorkspaceHasPackageBins(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantBin bool
+	}{
+		{
+			name:    "pnpm workspace with package bins",
+			path:    "../../../examples/node-pnpm-monorepo-binaries",
+			wantBin: true,
+		},
+		{
+			name:    "pnpm workspace without package bins",
+			path:    "../../../examples/node-pnpm-workspaces",
+			wantBin: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testingUtils.CreateGenerateContext(t, tt.path)
+			workspace, err := NewWorkspace(ctx.App)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBin, workspace.HasPackageBins())
+		})
+	}
+}
+
 func TestWorkspaceAllPackageJson(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/examples/node-pnpm-monorepo-binaries/package.json
+++ b/examples/node-pnpm-monorepo-binaries/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-pnpm-monorepo-binaries",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Reproduces railpack#584: pnpm workspace bin scripts are not relinked after source files are copied",
+  "type": "module",
+  "scripts": {
+    "build": "pnpm --filter package-b build",
+    "start": "hello-cli"
+  },
+  "dependencies": {
+    "package-a": "workspace:*",
+    "package-b": "workspace:*"
+  }
+}

--- a/examples/node-pnpm-monorepo-binaries/packages/package-a/package.json
+++ b/examples/node-pnpm-monorepo-binaries/packages/package-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-a",
+  "version": "1.0.0",
+  "type": "module",
+  "bin": {
+    "hello-cli": "./bin/hello.js"
+  }
+}

--- a/examples/node-pnpm-monorepo-binaries/packages/package-b/index.js
+++ b/examples/node-pnpm-monorepo-binaries/packages/package-b/index.js
@@ -1,0 +1,1 @@
+export const message = "package-b built with package-a bin";

--- a/examples/node-pnpm-monorepo-binaries/packages/package-b/package.json
+++ b/examples/node-pnpm-monorepo-binaries/packages/package-b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "package-b",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "package-a": "workspace:*"
+  },
+  "scripts": {
+    "build": "hello-cli"
+  }
+}

--- a/examples/node-pnpm-monorepo-binaries/pnpm-lock.yaml
+++ b/examples/node-pnpm-monorepo-binaries/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      package-a:
+        specifier: workspace:*
+        version: link:packages/package-a
+      package-b:
+        specifier: workspace:*
+        version: link:packages/package-b
+
+  packages/package-a: {}
+
+  packages/package-b:
+    dependencies:
+      package-a:
+        specifier: workspace:*
+        version: link:../package-a

--- a/examples/node-pnpm-monorepo-binaries/pnpm-workspace.yaml
+++ b/examples/node-pnpm-monorepo-binaries/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/examples/node-pnpm-monorepo-binaries/test.json
+++ b/examples/node-pnpm-monorepo-binaries/test.json
@@ -1,0 +1,10 @@
+[
+  {
+    // Reproduces railpack#584: pnpm install runs before workspace source files are
+    // copied, so package-a's bin is not linked for package-b's build script.
+    "expectedOutput": [
+      "Hello from package-a"
+    ],
+    "stderrAllowed": true
+  }
+]


### PR DESCRIPTION
## Motivation

In pnpm monorepos, builds fail when one workspace package exposes a `bin` and another depends on it via `workspace:*`. Railpack runs `pnpm install` before workspace source files are copied, so pnpm cannot link the binary and downstream build scripts cannot find it.

Fixes #584

## Description

Detect workspace packages with `bin` entries and copy the full workspace layer before install, matching the approach already used for lifecycle scripts and local file dependencies. Secret exposure during install is limited to workspaces that define lifecycle scripts, so binary-only workspaces do not receive secrets unnecessarily.

## Test

- Add `examples/node-pnpm-monorepo-binaries` integration test where `package-b` runs `package-a`'s `hello-cli` bin during build
- Unit tests for `PackageJson.HasBin()` and `Workspace.HasPackageBins()`