### PR TITLE
feat(providers): Allow injection of external providers.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -31,6 +31,9 @@ type GenerateBuildPlanOptions struct {
 	PreviousVersions         map[string]string
 	ConfigFilePath           string
 	ErrorMissingStartCommand bool // enabled on railway
+
+	// replaces the built-in providers; empty uses GetLanguageProviders()
+	Providers []providers.Provider
 }
 
 type BuildResult struct {
@@ -85,8 +88,13 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 		}
 	}
 
-	// Figure out what providers to use
-	providerToUse, detectedProviderName := getProviders(ctx, config)
+	// Figure out what providers to use, defaulting to the built-ins
+	availableProviders := options.Providers
+	if len(availableProviders) == 0 {
+		availableProviders = providers.GetLanguageProviders()
+	}
+
+	providerToUse, detectedProviderName := getProviders(ctx, config, availableProviders)
 	ctx.Metadata.Set("providers", detectedProviderName)
 
 	// TODO: We should indicate if we have packages specified in the config
@@ -122,6 +130,7 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 	if !ValidatePlan(buildPlan, app, logger, &ValidatePlanOptions{
 		ErrorMissingStartCommand: options.ErrorMissingStartCommand,
 		ProviderToUse:            providerToUse,
+		AvailableProviders:       availableProviders,
 	}) {
 		return &BuildResult{Success: false, Logs: logger.Logs}
 	}
@@ -259,9 +268,7 @@ func GenerateConfigFromOptions(options *GenerateBuildPlanOptions) *c.Config {
 	return config
 }
 
-func getProviders(ctx *generate.GenerateContext, config *c.Config) (providers.Provider, string) {
-	allProviders := providers.GetLanguageProviders()
-
+func getProviders(ctx *generate.GenerateContext, config *c.Config, allProviders []providers.Provider) (providers.Provider, string) {
 	var providerToUse providers.Provider
 	var detectedProvider string
 
@@ -293,7 +300,7 @@ func getProviders(ctx *generate.GenerateContext, config *c.Config) (providers.Pr
 	}
 
 	if config.Provider != nil {
-		provider := providers.GetProvider(*config.Provider)
+		provider := providers.GetProviderFrom(*config.Provider, allProviders)
 
 		if provider == nil {
 			ctx.Logger.LogWarn("Provider `%s` not found", *config.Provider)

--- a/core/providers/provider.go
+++ b/core/providers/provider.go
@@ -50,8 +50,10 @@ func GetLanguageProviders() []Provider {
 	}
 }
 
-func GetProvider(name string) Provider {
-	for _, provider := range GetLanguageProviders() {
+// GetProviderFrom looks up a provider by name (case-insensitive) within the
+// given list, returning nil if none match.
+func GetProviderFrom(name string, list []Provider) Provider {
+	for _, provider := range list {
 		if strings.EqualFold(provider.Name(), name) {
 			return provider
 		}

--- a/core/providers/provider_test.go
+++ b/core/providers/provider_test.go
@@ -3,12 +3,29 @@ package providers
 import (
 	"testing"
 
+	"github.com/railwayapp/railpack/core/generate"
+	"github.com/railwayapp/railpack/core/plan"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetProviderIsCaseInsensitive(t *testing.T) {
-	require.NotNil(t, GetProvider("elixir"))
-	require.NotNil(t, GetProvider("Elixir"))
-	require.NotNil(t, GetProvider("dotnet"))
-	require.NotNil(t, GetProvider("Dotnet"))
+// stubProvider is a minimal Provider used to verify custom provider injection.
+type stubProvider struct{ name string }
+
+func (p *stubProvider) Name() string                                   { return p.name }
+func (p *stubProvider) Detect(*generate.GenerateContext) (bool, error) { return false, nil }
+func (p *stubProvider) Initialize(*generate.GenerateContext) error     { return nil }
+func (p *stubProvider) Plan(*generate.GenerateContext) error           { return nil }
+func (p *stubProvider) CleansePlan(*plan.BuildPlan)                    {}
+func (p *stubProvider) StartCommandHelp() string                       { return "" }
+
+func TestGetProviderFrom(t *testing.T) {
+	custom := []Provider{&stubProvider{name: "custom"}}
+	require.NotNil(t, GetProviderFrom("custom", custom))
+	require.NotNil(t, GetProviderFrom("Custom", custom))
+	require.Nil(t, GetProviderFrom("node", custom))
+
+	builtin := GetLanguageProviders()
+	require.NotNil(t, GetProviderFrom("elixir", builtin))
+	require.NotNil(t, GetProviderFrom("Elixir", builtin))
+	require.NotNil(t, GetProviderFrom("dotnet", builtin))
 }

--- a/core/validate.go
+++ b/core/validate.go
@@ -14,10 +14,11 @@ import (
 type ValidatePlanOptions struct {
 	ErrorMissingStartCommand bool
 	ProviderToUse            providers.Provider
+	AvailableProviders       []providers.Provider
 }
 
 func ValidatePlan(plan *plan.BuildPlan, app *app.App, logger *logger.Logger, options *ValidatePlanOptions) bool {
-	if !validateCommands(plan, app, logger) {
+	if !validateCommands(plan, app, logger, options) {
 		return false
 	}
 
@@ -35,7 +36,7 @@ func ValidatePlan(plan *plan.BuildPlan, app *app.App, logger *logger.Logger, opt
 }
 
 // validateCommands checks if the plan has at least one command
-func validateCommands(plan *plan.BuildPlan, app *app.App, logger *logger.Logger) bool {
+func validateCommands(plan *plan.BuildPlan, app *app.App, logger *logger.Logger, options *ValidatePlanOptions) bool {
 	var atLeastOneCommand = false
 	for _, step := range plan.Steps {
 		if len(step.Commands) > 0 {
@@ -44,7 +45,7 @@ func validateCommands(plan *plan.BuildPlan, app *app.App, logger *logger.Logger)
 	}
 
 	if !atLeastOneCommand {
-		logger.LogError("%s", getNoProviderError(app))
+		logger.LogError("%s", getNoProviderError(app, options.AvailableProviders))
 		return false
 	}
 
@@ -107,9 +108,9 @@ func validateDeployLayers(plan *plan.BuildPlan, logger *logger.Logger) bool {
 	return true
 }
 
-func getNoProviderError(app *app.App) string {
+func getNoProviderError(app *app.App, availableProviders []providers.Provider) string {
 	providerNames := []string{}
-	for _, provider := range providers.GetLanguageProviders() {
+	for _, provider := range availableProviders {
 		providerNames = append(providerNames, utils.CapitalizeFirst(provider.Name()))
 	}
 

--- a/core/validate_test.go
+++ b/core/validate_test.go
@@ -53,14 +53,14 @@ func TestValidateCommands(t *testing.T) {
 		buildStep := plan.NewStep("build")
 		buildStep.Commands = []plan.Command{plan.NewExecShellCommand("npm build")}
 		buildPlan.Steps = append(buildPlan.Steps, *buildStep)
-		require.True(t, validateCommands(buildPlan, testApp, logger))
+		require.True(t, validateCommands(buildPlan, testApp, logger, &ValidatePlanOptions{}))
 	})
 
 	t.Run("plan without commands", func(t *testing.T) {
 		buildPlan := plan.NewBuildPlan()
 		buildStep := plan.NewStep("build")
 		buildPlan.Steps = append(buildPlan.Steps, *buildStep)
-		require.False(t, validateCommands(buildPlan, testApp, logger))
+		require.False(t, validateCommands(buildPlan, testApp, logger, &ValidatePlanOptions{}))
 	})
 }
 


### PR DESCRIPTION
# Motivation

I maintain a custom buildkit frontend that consumes railpack as a go library and I've hit a point where I would like to augment the current set of providers and iterate on them quickly.

Happy to maintain something like this as a full fork as well if that is more appropriate and changes like this are out of scope for railpack, but thought I would raise this as a PR as provider dependency injection felt like the simpler path.