### PR TITLE
fix: propagate host environment variables to sub-folder contexts

### DIFF
--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -80,6 +81,22 @@ func NewGenerateContext(app *a.App, env *a.Environment, config *config.Config, l
 
 		log.Debugf("Dockerignore exclude patterns: %v", dockerignoreCtx.Excludes)
 		log.Debugf("Dockerignore include patterns: %v", dockerignoreCtx.Includes)
+	}
+
+	// Init env map to avoid nil panics in mocked tests.
+	if env == nil {
+		env = a.NewEnvironment(nil)
+	} else if env.Variables == nil {
+		env.Variables = make(map[string]string)
+	}
+
+	// Preserve host RAILPACK_* overrides when resolving sub-folder configs.
+	if hostEnv, err := a.FromEnvs(os.Environ()); err == nil && hostEnv != nil {
+		for k, v := range hostEnv.Variables {
+			if strings.HasPrefix(k, "RAILPACK_") {
+				env.SetVariable(k, v)
+			}
+		}
 	}
 
 	ctx := &GenerateContext{

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -312,12 +312,14 @@ func (p *NodeProvider) InstallNodeDeps(ctx *generate.GenerateContext, install *g
 // resolve node version selection which is used both for node runtime *and* when bun is used but node is required for
 // build or runtime.
 func (p *NodeProvider) applyNodeVersionResolution(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder, nodeToolRef resolver.PackageRef) {
-	if envVersion, varName := ctx.Env.GetConfigVariable("NODE_VERSION"); envVersion != "" {
-		miseStep.Version(nodeToolRef, envVersion, varName)
-	}
-
+	// Check package.json first.
 	if p.packageJson != nil && p.packageJson.Engines != nil && p.packageJson.Engines["node"] != "" {
 		miseStep.Version(nodeToolRef, p.packageJson.Engines["node"], "package.json > engines > node")
+	}
+
+	// Env override.
+	if envVersion, varName := ctx.Env.GetConfigVariable("NODE_VERSION"); envVersion != "" {
+		miseStep.Version(nodeToolRef, envVersion, varName)
 	}
 }
 


### PR DESCRIPTION
### Overview

Fixes #591.

Sub-folder deployments were ignoring `RAILPACK_NODE_VERSION` because the generated context did not inherit host `RAILPACK_*` variables.

### Root Cause

`GenerateContext` creates an isolated environment for sub-folder evaluation. That environment did not include host configuration variables, causing `GetConfigVariable("NODE_VERSION")` to return an empty value.

As a result, version resolution always fell back to `package.json` engines or provider defaults.

Additionally, Node version resolution allowed `package.json` values to override environment-defined values.

### Changes

- Propagate `RAILPACK_*` variables into sub-folder `GenerateContext` instances.
- Ensure environment-defined Node versions take precedence over `package.json` engine constraints.
- Add defensive environment initialization to avoid nil map access in tests.

### Verification

- Verified `RAILPACK_NODE_VERSION=24` is respected in sub-folder deployments.
- Verified existing test suites pass without regressions.