### PR TITLE
docs: add architecture pages and update contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,5 @@
 # Contributing to Railpack
 
-## Project Status
-
-This is an early-stage project that is expected to undergo frequent changes.
-While we welcome contributions, please note that the API and functionality may
-change significantly as we evolve.
-
 ## Pull Requests
 
 We welcome pull requests that push the project forward in meaningful ways.
@@ -18,16 +12,12 @@ Please ensure your PRs:
 Note: We prefer focused, well-thought-out contributions over "drive-by" PRs that
 make superficial changes.
 
-## Setup
+DO NOT submit completely AI-generated PRs. If we suspect PRs are completely generated,
+we will close them with a note indicating this (feel free to reopen if we got it wrong!).
 
-We use [Mise](https://mise.jdx.dev/) for managing language dependencies and
-tasks for building and testing Railpack.
+## Development Workflow
 
-To set up your local environment, follow these steps:
-
-```bash
-mise run setup
-```
+[Checkout this guide for more information.](https://railpack.com/guides/developing-locally/)
 
 ## Testing
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -183,6 +183,7 @@ export default defineConfig({
         {
           label: "Architecture",
           items: [
+            { label: "Design Goals", link: "/architecture/design-goals" },
             { label: "High Level Overview", link: "/architecture/overview" },
             {
               label: "Package Resolution",
@@ -195,6 +196,10 @@ export default defineConfig({
             { label: "BuildKit Generation", link: "/architecture/buildkit" },
             { label: "Caching", link: "/architecture/caching" },
             { label: "User Config", link: "/architecture/user-config" },
+            {
+              label: "Recommendations",
+              link: "/architecture/recommendations",
+            },
           ],
         },
         {

--- a/docs/src/content/docs/architecture/design-goals.md
+++ b/docs/src/content/docs/architecture/design-goals.md
@@ -3,13 +3,10 @@ title: Design Goals
 description: The principles that guide Railpack's architecture and behavior
 ---
 
-1. **Zero-config by default.** Analyze source code and build with minimal setup.
-2. **No Dockerfiles.** Build images directly with BuildKit LLB.
-3. **Single builder for all languages.** One tool for Node, Python, Go, PHP, and more.
-4. **Backend-agnostic build plans.** Core generates JSON independent of BuildKit.
-5. **Built on BuildKit.** Parallel steps, layer cache, and mount caches.
-6. **Built on Mise.** Align dev, CI, and production tool versions.
-7. **Unopinionated runtime defaults.** No timezone, locale, or app-specific env vars.
-8. **Configurable when needed.** CLI flags, env vars, or `railpack.json`.
-9. **Stable defaults for platforms.** `--previous` pins versions across builds.
-10. **Tested against real projects.** Hundreds of example apps built and run in CI.
+Design principles that guide our development of Railpack:
+
+3. **Zero config for all popular languages and frameworks.** One tool for Node, Python, Go, PHP, etc and any popular frameworks within those ecosystems. Building a container for a project should require no railpack-specific customization. 
+7. **Unopinionated runtime defaults.** No timezone, locale, or other opinionated configuration is included by default. However, all common configuration paths should be easily supported and obvious universal configuration should be included by default.
+8. **Make Failures Obvious.** When a project contains custom configuration that will likely cause a build error, make this obvious to the user.
+9. **Allow Overrides.** Make it easy for a user to override any default configuration setting.
+10. **Integration Tests for Everything.** Hundreds of example apps built and run in CI. We prefer larger-scoped integration tests, especially when supporting new frameworks, than tightly scoped unit tests.

--- a/docs/src/content/docs/architecture/design-goals.md
+++ b/docs/src/content/docs/architecture/design-goals.md
@@ -5,8 +5,8 @@ description: The principles that guide Railpack's architecture and behavior
 
 Design principles that guide our development of Railpack:
 
-3. **Zero config for all popular languages and frameworks.** One tool for Node, Python, Go, PHP, etc and any popular frameworks within those ecosystems. Building a container for a project should require no railpack-specific customization. 
-7. **Unopinionated runtime defaults.** No timezone, locale, or other opinionated configuration is included by default. However, all common configuration paths should be easily supported and obvious universal configuration should be included by default.
-8. **Make Failures Obvious.** When a project contains custom configuration that will likely cause a build error, make this obvious to the user.
-9. **Allow Overrides.** Make it easy for a user to override any default configuration setting.
-10. **Integration Tests for Everything.** Hundreds of example apps built and run in CI. We prefer larger-scoped integration tests, especially when supporting new frameworks, than tightly scoped unit tests.
+1. **Zero config for all popular languages and frameworks.** One tool for Node, Python, Go, PHP, etc and any popular frameworks within those ecosystems. Building a container for a project should require no railpack-specific customization. 
+2. **Unopinionated runtime defaults.** No timezone, locale, or other opinionated configuration is included by default. However, all common configuration paths should be easily supported and obvious universal configuration should be included by default.
+3. **Make failures obvious.** When a project contains custom configuration that will likely cause a build error, make this obvious to the user.
+4. **Allow overrides.** Make it easy for a user to override any default configuration setting.
+5. **Integration tests for everything.** Hundreds of example apps built and run in CI. We prefer larger-scoped integration tests, especially when supporting new frameworks, than tightly scoped unit tests.

--- a/docs/src/content/docs/architecture/design-goals.md
+++ b/docs/src/content/docs/architecture/design-goals.md
@@ -1,0 +1,15 @@
+---
+title: Design Goals
+description: The principles that guide Railpack's architecture and behavior
+---
+
+1. **Zero-config by default.** Analyze source code and build with minimal setup.
+2. **No Dockerfiles.** Build images directly with BuildKit LLB.
+3. **Single builder for all languages.** One tool for Node, Python, Go, PHP, and more.
+4. **Backend-agnostic build plans.** Core generates JSON independent of BuildKit.
+5. **Built on BuildKit.** Parallel steps, layer cache, and mount caches.
+6. **Built on Mise.** Align dev, CI, and production tool versions.
+7. **Unopinionated runtime defaults.** No timezone, locale, or app-specific env vars.
+8. **Configurable when needed.** CLI flags, env vars, or `railpack.json`.
+9. **Stable defaults for platforms.** `--previous` pins versions across builds.
+10. **Tested against real projects.** Hundreds of example apps built and run in CI.

--- a/docs/src/content/docs/architecture/recommendations.md
+++ b/docs/src/content/docs/architecture/recommendations.md
@@ -1,0 +1,117 @@
+---
+title: Recommendations
+description: Environment and tooling recommendations for Railpack-built images
+---
+
+## Timezone
+
+Railpack does not set a timezone. Set `TZ` explicitly for your application.
+`TZ=UTC` is a good default.
+
+```json
+{
+  "deploy": {
+    "variables": {
+      "TZ": "UTC"
+    }
+  }
+}
+```
+
+## Python with pipx
+
+If you install `pipx` without also installing Python via mise, pipx will use
+the system Python and pip from the Debian runtime image. That Python is old and
+can cause compatibility issues with mise and other tooling.
+
+Install Python via mise whenever you use pipx:
+
+```json
+{
+  "packages": {
+    "python": "latest",
+    "pipx:httpie": "3.2.4"
+  }
+}
+```
+
+Or, even better, configure this in a `mise.toml` instead of a `railpack.json`
+
+## Locale
+
+Set `LANG=en_US.UTF-8` so applications and shell tools handle Unicode
+correctly. Railpack does not bundle additional locales — only `en_US.UTF-8`
+is available in the runtime image. If your application requires a different
+locale, install the corresponding locale packages via
+[`deploy.aptPackages`](/config/file).
+
+```json
+{
+  "deploy": {
+    "variables": {
+      "LANG": "en_US.UTF-8"
+    }
+  }
+}
+```
+
+## Use Mise for Language and Package Manager Versioning
+
+Although mise supports extracting versions from language-specific configuration
+files (`.node-version`, `.python-version`, `runtime.txt`, etc.), mise offers a
+much more unified and streamlined way of managing these versions. We highly
+recommend moving development configuration as much as you can to mise.
+
+Specify versions of languages, package managers, tools, and other dependencies
+in your mise config rather than relying on defaults or `latest`. Pinning
+versions keeps local development, CI, and production aligned.
+
+A `mise.toml` in your project keeps tool versions in one place:
+
+```toml
+[tools]
+node = "22.14.0"
+python = "3.13.2"
+poetry = "2.1.1"
+jq = "1.7.1"
+```
+
+See [Mise Configuration](/config/mise) for how Railpack detects and applies
+mise config during builds.
+
+## Prefer Mise Over Apt, pipx, and Other Installers
+
+When you need a CLI tool or utility, prefer installing it with mise over Apt,
+pipx, npm, or other package managers. Mise does not support every tool, but it
+supports most external tools you are likely to need.
+
+Using mise keeps tool versions consistent with the rest of your config and
+avoids coupling your build to distro packages or a separate install path.
+
+```toml
+[tools]
+jq = "1.7.1"
+ripgrep = "14.1.1"
+```
+
+Reach for Apt when you need system libraries or packages that mise does not
+provide (for example `libpq-dev` or `ffmpeg`). See [Installing Additional
+Packages](/guides/installing-packages) for how to add mise and Apt packages to
+a build.
+
+## Use Mise Lockfiles
+
+Add `locked = true` to your mise config. This ensures that the exact same
+version is used for dev, CI, and production.
+
+```toml
+[tools]
+node = "22.14.0"
+python = "3.13.2"
+
+[settings]
+locked = true
+```
+
+Commit the generated `mise.lock` file alongside your `mise.toml`. Railpack
+automatically includes `mise.lock` files in the build when present.

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -119,6 +119,8 @@ install the specified package manager version. When a package manager is
 detected via the `engines` field, the specified version constraint will be
 used.
 
+Railpack supports building native modules and automatically configures `node-gyp`.
+
 ### Monorepo Support
 
 Railpack automatically supports monorepo (workspaces) configurations with all major


### PR DESCRIPTION
## Motivation

Document Railpack's architectural principles and deployment best practices, and refresh contribution guidance.

## Description

- Adds Design Goals and Recommendations pages to the architecture docs
- Updates CONTRIBUTING.md: removes stale status section, adds AI-generated PR policy, links to dev workflow guide
- Notes native module support in the Node language docs