### PR TITLE
refactor(node): consolidate SPA framework detection

### DIFF
--- a/core/providers/node/astro.go
+++ b/core/providers/node/astro.go
@@ -60,6 +60,7 @@ func (p *NodeProvider) getAstroConfigFileContents(ctx *generate.GenerateContext)
 	return contents
 }
 
+// TODO feels like we should be able to specify this in the start command and avoid injecting additional vars into the container?
 func (p *NodeProvider) getAstroEnvVars() map[string]string {
 	envVars := map[string]string{
 		"HOST": "0.0.0.0",

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -411,6 +411,7 @@ func (p *NodeProvider) GetNodeEnvVars(ctx *generate.GenerateContext) map[string]
 		envVars["YARN_PRODUCTION"] = "false"
 	}
 
+	// TODO why are we special-casing astro here? Smells like a misunderstanding of how astro works...
 	if p.isAstro(ctx) && !p.isAstroSPA(ctx) {
 		maps.Copy(envVars, p.getAstroEnvVars())
 	}
@@ -518,11 +519,7 @@ func (p *NodeProvider) getScripts(packageJson *PackageJson, name string) string 
 }
 
 func (p *NodeProvider) SetNodeMetadata(ctx *generate.GenerateContext) {
-	runtime := p.getRuntime(ctx)
-	spaFramework := p.getSPAFramework(ctx)
-
-	ctx.Metadata.Set("nodeRuntime", runtime)
-	ctx.Metadata.Set("nodeSPAFramework", spaFramework)
+	ctx.Metadata.Set("nodeRuntime", p.getRuntime(ctx))
 	ctx.Metadata.Set("nodePackageManager", string(p.packageManager))
 	ctx.Metadata.SetBool("nodeIsSPA", p.isSPA(ctx))
 	ctx.Metadata.SetBool("nodeUsesCorepack", p.usesCorepack())
@@ -599,18 +596,9 @@ func (p *NodeProvider) requiresBun(ctx *generate.GenerateContext) bool {
 
 func (p *NodeProvider) getRuntime(ctx *generate.GenerateContext) string {
 	if p.isSPA(ctx) {
-		if p.isAstro(ctx) {
-			return "astro"
-		} else if p.isVite(ctx) {
-			return "vite"
-		} else if p.isCRA(ctx) {
-			return "cra"
-		} else if p.isAngular(ctx) {
-			return "angular"
-		} else if p.isReactRouter(ctx) {
-			return "react-router"
-		} else if p.isExpoSPA(ctx) {
-			return "expo"
+		// note that some of the frameworks can be both SPA and traditional node, and they are checked in the same way
+		if name := p.getSPAName(ctx); name != "" {
+			return name
 		}
 
 		// this can occur if a user forces SPA mode via config
@@ -627,6 +615,8 @@ func (p *NodeProvider) getRuntime(ctx *generate.GenerateContext) string {
 		return "vite"
 	} else if p.isReactRouter(ctx) {
 		return "react-router"
+	} else if p.isAstro(ctx) {
+		return "astro"
 	} else if p.packageManager == PackageManagerBun {
 		return "bun"
 	}

--- a/core/providers/node/spa.go
+++ b/core/providers/node/spa.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/charmbracelet/log"
 	"github.com/railwayapp/railpack/core/generate"
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/providers/staticfile"
@@ -47,11 +48,9 @@ func (p *NodeProvider) isSPA(ctx *generate.GenerateContext) bool {
 	return (isVite || isAstro || isNext || isCRA || isAngular || isReactRouter || isExpoSPA) && p.getOutputDirectory(ctx) != ""
 }
 
-func (p *NodeProvider) getSPAFramework(ctx *generate.GenerateContext) string {
-	if !p.isSPA(ctx) {
-		return ""
-	}
-
+// returns the canonical lowercase SPA framework name, or "" when none is detected.
+func (p *NodeProvider) getSPAName(ctx *generate.GenerateContext) string {
+	// TODO react router is not always SPA!
 	if p.isReactRouter(ctx) {
 		return "react-router"
 	} else if p.isVite(ctx) {
@@ -61,11 +60,14 @@ func (p *NodeProvider) getSPAFramework(ctx *generate.GenerateContext) string {
 	} else if p.isNextSPA(ctx) {
 		return "next"
 	} else if p.isCRA(ctx) {
-		return "CRA"
+		return "cra"
 	} else if p.isAngular(ctx) {
-		return "Angular"
+		return "angular"
 	} else if p.isExpoSPA(ctx) {
-		return "Expo"
+		return "expo"
+	} else {
+		// this could happen if the user forces SPA with env
+		log.Infof("No SPA framework detected")
 	}
 
 	return ""
@@ -73,7 +75,7 @@ func (p *NodeProvider) getSPAFramework(ctx *generate.GenerateContext) string {
 
 func (p *NodeProvider) DeploySPA(ctx *generate.GenerateContext, build *generate.CommandStepBuilder) error {
 	outputDir := p.getOutputDirectory(ctx)
-	spaFramework := p.getSPAFramework(ctx)
+	spaFramework := p.getSPAName(ctx)
 
 	ctx.Logger.LogInfo("Deploying as %s static site", spaFramework)
 	ctx.Logger.LogInfo("Output directory: %s", outputDir)
@@ -89,6 +91,8 @@ func (p *NodeProvider) DeploySPA(ctx *generate.GenerateContext, build *generate.
 		"IndexFallback": indexFallback,
 	}
 
+	// TODO this template stuff is a bit odd: I don't see the use case for passing these specific variables to the template.
+	//      if the user is customizing the Caddyfile, they can just hardcode what they want into the Caddyfile?
 	caddyfileTemplate, err := ctx.TemplateFiles([]string{"Caddyfile.template", "Caddyfile"}, caddyfileTemplate, data)
 	if err != nil {
 		return err
@@ -122,19 +126,6 @@ func (p *NodeProvider) DeploySPA(ctx *generate.GenerateContext, build *generate.
 			Include: []string{outputDir},
 		}),
 	})
-
-	// ctx.Deploy.Inputs = []plan.Layer{
-	// 	ctx.DefaultRuntimeInput(),
-	// 	plan.NewStepLayer(installCaddyStep.Name(), plan.InputOptions{
-	// 		Include: installCaddyStep.GetOutputPaths(),
-	// 	}),
-	// 	plan.NewStepLayer(caddy.Name(), plan.InputOptions{
-	// 		Include: []string{DefaultCaddyfilePath},
-	// 	}),
-	// 	plan.NewStepLayer(build.Name(), plan.InputOptions{
-	// 		Include: []string{outputDir},
-	// 	}),
-	// }
 
 	return nil
 }

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -196,6 +196,9 @@ static exports). Next.js reads `distDir` from your config when set. Set the
 directory. Railpack uses your app's `build` script to produce the static
 output.
 
+Note that is an SPA framework is *not* detected automatically, can you force SPA mode
+by specifying a `RAILPACK_SPA_OUTPUT_DIR` environment variable. This will enable SPA mode and serve the specified directory as a static site.
+
 Static sites are served using the [Caddy](https://caddyserver.com/) web server
 and a [default
 Caddyfile](https://github.com/railwayapp/railpack/blob/main/core/providers/node/Caddyfile.template).


### PR DESCRIPTION
## Motivation

SPA framework identification was duplicated across `getRuntime`, `getSPAFramework`, and metadata setup, with inconsistent naming (e.g. `CRA` vs `cra`). This made the detection logic harder to maintain and extend.

## Description

Introduces `getSPAName` as the single source of truth for SPA framework detection. `getRuntime` and `DeploySPA` now delegate to it instead of re-implementing the same checks. Framework names are normalized to lowercase, and the redundant `nodeSPAFramework` metadata entry is removed. When SPA mode is forced via `RAILPACK_SPA_OUTPUT_DIR` without a detectable framework, a log message is emitted. Docs note how to force SPA mode when auto-detection does not apply.

## Test

Existing SPA detection tests in `core/providers/node/spa_test.go` cover the affected behavior; no new tests were added.