### PR TITLE
fix(providers): reorder version resolution to prioritize ENV for Python, Ruby, and Deno

### DIFF
--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -84,11 +84,20 @@ func (p *DenoProvider) Build(ctx *generate.GenerateContext, build *generate.Comm
 func (p *DenoProvider) InstallMisePackages(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder) {
 	deno := miseStep.Default("deno", DEFAULT_DENO_VERSION)
 
+	// NOTE: Version resolution precedence matters here.
+	// We evaluate manifest files (.deno-version) and mise configs first to establish the baseline.
+	// The environment variable (DENO_VERSION) must be checked last to act as the ultimate override,
+	// strictly guaranteeing the 'Last Write Wins' behavior as expected by the docs.
+
+	// UseMiseVersions internally executes a forced override based on mise config files (.tool-versions, mise.toml)
+	// and idiomatic files (.deno-version).
+	miseStep.UseMiseVersions(ctx, []string{"deno"})
+
+	// IMPORTANT: The ENV check MUST be placed AFTER UseMiseVersions to guarantee it retains ultimate precedence
+	// over all idiomatic and mise configurations, strictly adhering to the documentation.
 	if envVersion, varName := ctx.Env.GetConfigVariable("DENO_VERSION"); envVersion != "" {
 		miseStep.Version(deno, envVersion, varName)
 	}
-
-	miseStep.UseMiseVersions(ctx, []string{"deno"})
 }
 
 func (p *DenoProvider) findMainFile(ctx *generate.GenerateContext) string {

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -305,16 +305,14 @@ func (p *PythonProvider) GetBuilderDeps(ctx *generate.GenerateContext) *generate
 func (p *PythonProvider) InstallMisePackages(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder) {
 	python := miseStep.Default("python", DEFAULT_PYTHON_VERSION)
 
-	if envVersion, varName := ctx.Env.GetConfigVariable("PYTHON_VERSION"); envVersion != "" {
-		miseStep.Version(python, envVersion, varName)
+	// NOTE: Version resolution precedence matters here.
+	// We evaluate manifest files (Pipfile, runtime.txt) first to establish the baseline.
+	if pipfileVersion, pipfileVarName := parseVersionFromPipfile(ctx); pipfileVersion != "" {
+		miseStep.Version(python, pipfileVersion, fmt.Sprintf("Pipfile > %s", pipfileVarName))
 	}
 
 	if runtimeFile, err := ctx.App.ReadFile("runtime.txt"); err == nil {
 		miseStep.Version(python, utils.ExtractSemverVersion(string(runtimeFile)), "runtime.txt")
-	}
-
-	if pipfileVersion, pipfileVarName := parseVersionFromPipfile(ctx); pipfileVersion != "" {
-		miseStep.Version(python, pipfileVersion, fmt.Sprintf("Pipfile > %s", pipfileVarName))
 	}
 
 	// Collect all packages that will be used by the provider
@@ -355,7 +353,14 @@ func (p *PythonProvider) InstallMisePackages(ctx *generate.GenerateContext, mise
 		packages = append(packages, "pipx:pipenv")
 	}
 
+	// UseMiseVersions internally executes a forced override based on mise config files (.python-version, mise.toml)
 	miseStep.UseMiseVersions(ctx, packages)
+
+	// IMPORTANT: The ENV check MUST be placed AFTER UseMiseVersions to guarantee it retains ultimate precedence
+	// over all manifest and mise configurations, strictly adhering to the documentation.
+	if envVersion, varName := ctx.Env.GetConfigVariable("PYTHON_VERSION"); envVersion != "" {
+		miseStep.Version(python, envVersion, varName)
+	}
 
 	// Disable Python compilation to avoid incompatibility issues with some packages
 	// https://mise.jdx.dev/lang/python.html#python.compile

--- a/core/providers/ruby/ruby.go
+++ b/core/providers/ruby/ruby.go
@@ -251,15 +251,24 @@ func (p *RubyProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 	// rdoc (a) slows down builds (b) increases build size and (c) mostly importantly, will cause builds to fail if the locale is not properly set
 	miseStep.Variables["RUBY_CONFIGURE_OPTS"] = "--disable-install-doc"
 
-	if envVersion, varName := ctx.Env.GetConfigVariable("RUBY_VERSION"); envVersion != "" {
-		miseStep.Version(ruby, envVersion, varName)
-	}
+	// NOTE: Version resolution precedence matters here.
+	// We evaluate manifest files (Gemfile, .ruby-version) first to establish the baseline.
+	// The environment variable (RUBY_VERSION) must be checked last to act as the ultimate override,
+	// strictly guaranteeing the 'Last Write Wins' behavior as expected by the docs.
 
 	if gemfileVersion := parseVersionFromGemfile(ctx); gemfileVersion != "" {
 		miseStep.Version(ruby, gemfileVersion, "Gemfile")
 	}
 
+	// UseMiseVersions internally executes a forced override based on mise config files (mise.toml, .tool-versions)
+	// and idiomatic files (.ruby-version, Gemfile).
 	miseStep.UseMiseVersions(ctx, []string{"ruby"})
+
+	// IMPORTANT: The ENV check MUST be placed AFTER UseMiseVersions to guarantee it retains ultimate precedence
+	// over all idiomatic and mise configurations.
+	if envVersion, varName := ctx.Env.GetConfigVariable("RUBY_VERSION"); envVersion != "" {
+		miseStep.Version(ruby, envVersion, varName)
+	}
 
 	miseStep.AddSupportingAptPackage("libyaml-dev")
 	miseStep.AddSupportingAptPackage("libjemalloc-dev")


### PR DESCRIPTION
### Motivation & Context

As detailed in my architectural review in #609, the current build planning for Python, Ruby, and Deno evaluates the `RAILPACK_*_VERSION` environment variables before manifest files and `UseMiseVersions()`. 

Due to the internal "last write wins" architecture, local idiomatic files (like `.ruby-version`, `runtime.txt`, etc.) were silently overwriting the deployment-level configurations. This PR reorders the lifecycle to strictly enforce the documented precedence, ensuring the Environment Variable remains the highest-precedence version source, consistent with the documentation.

### Description of Changes

I have moved/reordered the `InstallMisePackages` logic in the following files to establish the baseline first, allowing the ENV variable to process last:
* **Python (`python.go`):** Moved the `PYTHON_VERSION` check to the absolute bottom (after `Pipfile`, `runtime.txt`, and `UseMiseVersions`).
* **Ruby (`ruby.go`):** Moved the `RUBY_VERSION` check to the absolute bottom (after `Gemfile` and `UseMiseVersions`).
* **Deno (`deno.go`):** Moved the `DENO_VERSION` check to the absolute bottom (after `UseMiseVersions`).

*Architectural comments have been added to these files to prevent future regressions regarding this precedence order.*

### What is intentionally left out?
As discussed in the linked issue, **Rust, Go, Dotnet, and Elixir** have deliberately been left untouched to respect your original design decisions, as their current code aligns with their specific documentation (which ranks ENV lower).

### Testing & Verification
* Inserted local trace logs inside `RequestedPackage.SetVersion` to verify the execution sequence.
* Confirmed that `RAILPACK_*_VERSION` now successfully acts as the final override and is no longer clobbered by mise or manifest configurations.
* Ran the relevant provider test suites locally to ensure no regressions:
```bash
go test ./core/providers/python
go test ./core/providers/ruby
go test ./core/providers/deno
```
Next Steps 💡
If the core team decides to unify the global architecture and elevate ENV to the top priority for all providers, please just let me know. I would be more than happy to do the work, update the remaining providers, and adjust the documentation in a follow-up commit to this branch.

Alternatively, the ball is in your court: if you want to move faster, apply additional refactoring, or have a different vision for the code, please feel free to pull this branch and merge/build upon it directly. I am completely open to whatever works best for the project!

Fixes #609