### PR TITLE
docs: improve contribution guidelines and developer workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- feel free to drop this template into your agent, but make sure you edit the resulting PR description to be concise and de-slopped -->
+
+## Motivation
+
+<!--
+- describe the problem that motivated this change
+- link to any relevant open source projects demonstrating the motivating problem
+-->
+
+## Description
+
+<!-- describe the change that was made and why you took this approach -->
+
+## Test
+
+<!-- how is this change tested? -->
+
+## Links
+
+<!-- link(s) to any relevant external documentation, github issues this fixes or is connected to , etc-->

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -134,7 +134,7 @@ jobs:
       
       # intermittent docker pull failures kept failing the entire pipeline, which is why we are retrying
       - name: Start BuildKit
-        run: retry --attempts 5 mise run run-buildkit-container
+        run: mise run retry --attempts 5 -- mise run run-buildkit-container
 
       # required for integration tests that use multiple platforms
       - name: Set up QEMU

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -131,9 +131,10 @@ jobs:
           registry: ${{ env.PRODUCTION_CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      
+      # intermittent docker pull failures kept failing the entire pipeline, which is why we are retrying
       - name: Start BuildKit
-        run: mise run run-buildkit-container
+        run: retry --attempts 5 mise run run-buildkit-container
 
       # required for integration tests that use multiple platforms
       - name: Set up QEMU

--- a/.mise/tasks/retry
+++ b/.mise/tasks/retry
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#MISE description="Retry a command with exponential backoff"
+#USAGE flag "--attempts <attempts>" help="Number of attempts" default="3"
+#USAGE arg "<command>" var=#true help="Command to run" double_dash="automatic"
+
+set -euo pipefail
+
+attempts="${usage_attempts?}"
+delay=1
+
+eval "cmd=($usage_command)"
+
+if [[ ${#cmd[@]} -eq 0 ]]; then
+  echo "Error: command required" >&2
+  exit 1
+fi
+
+for ((i = 1; i <= attempts; i++)); do
+  if "${cmd[@]}"; then
+    exit 0
+  fi
+
+  if [[ $i -lt $attempts ]]; then
+    echo "failed, retrying..." >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+  fi
+done
+
+echo "continued to fail after ${attempts} attempts" >&2
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,15 +37,16 @@ Follow these instructions carefully when writing code:
 
 # Workflow
 
-- If mise is not available in your environment, install it using the instructions at https://mise.jdx.dev/installing-mise.html.
+- If mise is not available in your environment, [install it](https://mise.jdx.dev/installing-mise.html)
 - Take a careful look at @mise.toml to understand what commands should be run at different points in the project lifecycle
-- Do not worry about docker cache, etc. Never run `docker system prune` or any other similar commands.
+- Do not worry about docker cache, etc. Never run `docker system prune` or other similar commands.
 - Do not run `go` directly. Instead, inspect @mise.toml and use `mise run <task>` to run various dev lifecycle commands. For instance, you should not run `go vet`, `go fmt`, `go test`, etc directly.
-- After making code changes, first run `mise run check`
-- Then, run unit tests and a couple of relevant integration tests to verify your changes
+- After making code changes, run `mise run check`
+- Then, run unit tests (`mise run test`) and a couple of relevant integration tests to verify your changes.
   - Don't run tests manually using `go test` unless instructed to do so
   - If tests are failing that are unrelated to your changes, let me know and stop working.
 - Use the `cli` mise task to test your changes on a specific example project, i.e. `mise run cli -- --verbose build --show-plan examples/node-vite-react-router-spa/`
+- Run before finishing your work `mise run test-update-snapshots` and review the (possibly) updated snapshot files to make sure there are no unexpected changes. 
 - Do not run any write operations with `git`
 - Do not use `bin/railpack` instead use `mise run cli` (which is the development build of `railpack`)
   - Therefore do not run `mise build`, we don't need a `railpack` binary for local testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,60 +2,29 @@
 
 ## Pull Requests
 
-We welcome pull requests that push the project forward in meaningful ways.
-Please ensure your PRs:
+We love contributions from the community! Please ensure your PRs:
 
 - Address a specific problem or add a well-defined feature
 - Include tests for new functionality
 - Follow the existing code style
+- Do not just make superficial changes (e.g., formatting, comments, version updated)
+- PR title and description should follow [the PR template](.github/PULL_REQUEST_TEMPLATE.md)
+- Be concise when writing your PR description. Fine to use AI, but make sure to review and deslop any writing.
 
-Note: We prefer focused, well-thought-out contributions over "drive-by" PRs that
-make superficial changes.
+## AI Policy
 
-DO NOT submit completely AI-generated PRs. If we suspect PRs are completely generated,
-we will close them with a note indicating this (feel free to reopen if we got it wrong!).
+We love AI and encourage its use. However, in order to maintain a high-quality codebase and optimize the time
+of maintainers of the project, we have some guidelines around the use of AI in contributions:
+
+- **DO NOT submit completely AI-generated PRs.** If we suspect PRs is AI generated without careful human review,
+  we will close them with a note indicating this (feel free to reopen if we got it wrong!). We use AI extensively in our
+  development process, and it's easier for us to generate a PR from a well-written issue than it is review an AI generated
+  PR with no human in the loop.
+
+- **The human-in-the-loop must fully understand all code.** A rule of thumb: if you
+  can't explain what your changes do and how they interact with the
+  greater system without the aid of AI tools, create a well-written GitHub issue instead so an engineer with a deeper understanding of the system can quickly generate a PR.
 
 ## Development Workflow
 
-[Checkout this guide for more information.](https://railpack.com/guides/developing-locally/)
-
-## Testing
-
-### Core Tests
-
-- All example plans are snapshot tested in `core_test.go`
-- Tests with a `test.json` file will be built and run automatically
-- The test output must contain the `expectedOutput` specified in the test file
-
-### Snapshot Tests
-
-Railpack uses [go-snaps](https://github.com/gkampitakis/go-snaps) for snapshot
-testing. This helps prevent regressions to generated build plans.
-
-If you see a test failure because of a snapshot change, please confirm that the
-change is intentional, and then update the snapshot by running:
-
-```bash
-mise run test-update-snapshots
-```
-
-### Integration Tests
-
-Example directories with a `test.json` file will be automatically built and run
-in CI. You can run them locally with:
-
-```bash
-mise run test-integration
-```
-
-The `test.json` file contains an array of build configurations and expected
-outputs. See [this
-file](https://github.com/railwayapp/railpack/blob/main/integration_tests/run_test.go#L26)
-for the schema.
-
-## Useful Commands
-
-- `mise check` - Run linting and type checking
-- `mise test` - Run unit tests
-- `mise test-integration` - Run integration tests
-- `mise run test-update-snapshots` - Update snapshot tests
+[Checkout this guide.](https://railpack.com/guides/developing-locally/)

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -199,7 +199,8 @@ func (b *MiseStepBuilder) GetMisePackageVersions(ctx *GenerateContext) (map[stri
 	return packages, nil
 }
 
-// Use mise-specified versions (including idiomatic version files) for all packages in the input list, this will overwrite any previously-specified package versions
+// Use mise-specified versions (including idiomatic version files) for all packages in the input list
+// this overwrites any previously-specified package versions, so ENV-soured versions must be applied after this is called.
 func (b *MiseStepBuilder) UseMiseVersions(ctx *GenerateContext, packageNamesToOverride []string) {
 	miseSpecifiedPackageVersions, err := b.GetMisePackageVersions(ctx)
 	if err != nil {

--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -81,17 +81,8 @@ func (p *DenoProvider) Build(ctx *generate.GenerateContext, build *generate.Comm
 func (p *DenoProvider) InstallMisePackages(ctx *generate.GenerateContext, miseStep *generate.MiseStepBuilder) {
 	deno := miseStep.Default("deno", DEFAULT_DENO_VERSION)
 
-	// NOTE: Version resolution precedence matters here.
-	// We evaluate manifest files (.deno-version) and mise configs first to establish the baseline.
-	// The environment variable (DENO_VERSION) must be checked last to act as the ultimate override,
-	// strictly guaranteeing the 'Last Write Wins' behavior as expected by the docs.
-
-	// UseMiseVersions internally executes a forced override based on mise config files (.tool-versions, mise.toml)
-	// and idiomatic files (.deno-version).
 	miseStep.UseMiseVersions(ctx, []string{"deno"})
 
-	// IMPORTANT: The ENV check MUST be placed AFTER UseMiseVersions to guarantee it retains ultimate precedence
-	// over all idiomatic and mise configurations, strictly adhering to the documentation.
 	if envVersion, varName := ctx.Env.GetConfigVariable("DENO_VERSION"); envVersion != "" {
 		miseStep.Version(deno, envVersion, varName)
 	}

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -353,11 +353,8 @@ func (p *PythonProvider) InstallMisePackages(ctx *generate.GenerateContext, mise
 		packages = append(packages, "pipx:pipenv")
 	}
 
-	// UseMiseVersions internally executes a forced override based on mise config files (.python-version, mise.toml)
 	miseStep.UseMiseVersions(ctx, packages)
 
-	// IMPORTANT: The ENV check MUST be placed AFTER UseMiseVersions to guarantee it retains ultimate precedence
-	// over all manifest and mise configurations, strictly adhering to the documentation.
 	if envVersion, varName := ctx.Env.GetConfigVariable("PYTHON_VERSION"); envVersion != "" {
 		miseStep.Version(python, envVersion, varName)
 	}

--- a/core/providers/ruby/ruby.go
+++ b/core/providers/ruby/ruby.go
@@ -251,32 +251,26 @@ func (p *RubyProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 	// rdoc (a) slows down builds (b) increases build size and (c) mostly importantly, will cause builds to fail if the locale is not properly set
 	miseStep.Variables["RUBY_CONFIGURE_OPTS"] = "--disable-install-doc"
 
-	// NOTE: Version resolution precedence matters here.
-	// We evaluate manifest files (Gemfile, .ruby-version) first to establish the baseline.
-	// The environment variable (RUBY_VERSION) must be checked last to act as the ultimate override,
-	// strictly guaranteeing the 'Last Write Wins' behavior as expected by the docs.
-
+	// TODO mise parses simple versions from the Gemfile now, maybe that's all we should do and eliminate our custom parser?
 	if gemfileVersion := parseVersionFromGemfile(ctx); gemfileVersion != "" {
 		miseStep.Version(ruby, gemfileVersion, "Gemfile")
 	}
 
-	// UseMiseVersions internally executes a forced override based on mise config files (mise.toml, .tool-versions)
-	// and idiomatic files (.ruby-version, Gemfile).
 	miseStep.UseMiseVersions(ctx, []string{"ruby"})
 
-	// IMPORTANT: The ENV check MUST be placed AFTER UseMiseVersions to guarantee it retains ultimate precedence
-	// over all idiomatic and mise configurations.
 	if envVersion, varName := ctx.Env.GetConfigVariable("RUBY_VERSION"); envVersion != "" {
 		miseStep.Version(ruby, envVersion, varName)
 	}
 
 	miseStep.AddSupportingAptPackage("libyaml-dev")
 	miseStep.AddSupportingAptPackage("libjemalloc-dev")
+
 	// TODO this does not take into account the mise-specified version of ruby, we should pull the resolved version via Mise
 	version := p.getRubyVersion(ctx)
 	version = utils.ExtractSemverVersion(version)
 	semver, err := utils.ParseSemver(version)
 
+	// TODO we should install these only if it's < v3 instead since the matching is not exact
 	// TODO we should install these via mise, not apt
 	// YJIT in Ruby 3.1+ requires rustc to install
 	if err == nil && semver != nil && semver.Major >= 3 && semver.Minor > 1 {

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -13,16 +13,18 @@ Some pre-requisites:
 ## Getting Setup
 
 [Mise](https://mise.jdx.dev/) is used to manage language dependencies and
-tasks for building and testing Railpack.
+tasks for building and testing Railpack. Checkout `mise.toml` in the root
+repo for more information on various lifecycle tasks.
 
 Install and use all versions of tools needed for Railpack
 
 ```bash
-# Assuming you are cd'd into the repo root
+cd ~/railpack
+mise install
 mise run setup
 ```
 
-This command will also start a BuildKit container (check out `mise.toml` in the root directory for more information).
+This command starts a BuildKit container (check out `mise.toml` in the root directory for more information).
 
 Use the `cli` task to run the Railpack CLI (this is like `railpack --help`)
 
@@ -38,6 +40,21 @@ mise run build
 # add the Railpack repo `bin/` directory to your path to use the newly-compiled Railpack on your machine
 export PATH="$PWD/bin:$PATH"
 ```
+
+## Lifecyle of a Change
+
+Most improvements to Railpack look like:
+
+1. There's a motivating problem: a new javascript framework that doesn't work without tinkering, a new language feature we want to support, etc.
+2. Reproduce the failure in a new `example/` project and make sure it fails with `mise run test-integration-cwd`.
+3. Point AI at the failing project and work out a solution.
+4. Deslop edits, tests, etc.
+5. Make sure documentation is updated.
+6. Update snapshots with `mise run test-update-snapshots` and manually review changes to make sure there were weren't any unintended side effects.
+7. Run `mise run test` and `mise run check` to make sure unit tests and all linters are clean.
+8. Submit a PR using this [PR template](.github/PULL_REQUEST_TEMPLATE.md).
+
+Pro-tip: point your agent at this guide.
 
 ## Building directly with BuildKit
 
@@ -57,8 +74,6 @@ Remember, `mise run` runs the cli in the root project directory. So, if you are 
 cd examples/node-angular/
 mise run cli build $(pwd)
 ```
-
-You need to have a BuildKit instance running (see below).
 
 ## Docker Images
 
@@ -161,10 +176,21 @@ Quick note about `builtctl` vs `docker buildx`. These two ways of invoking the r
 * `--opt` does not prefix the build arg at all. You must prefix args with `build-arg:` if they are
   arguments handled by the railpack frontend.
 
+## Unit Tests
+
+Railpack uses [go-snaps](https://github.com/gkampitakis/go-snaps) for snapshot
+testing. This helps prevent regressions to generated build plans. All example plans are snapshot tested in `core_test.go`
+
+If you see a test failure because of a snapshot change, please confirm that the
+change is intentional, and then update the snapshot by running:
+
+```bash
+mise run test-update-snapshots
+```
+
 ## Integration Tests
 
-Integration tests build and run example applications in containers to verify
-end-to-end functionality. Each example with a `test.json` file gets tested
+Integration tests build and run example applications (in `examples/`) in containers to verify end-to-end functionality. Each example with a `test.json` file gets tested
 automatically.
 
 ```bash
@@ -180,7 +206,9 @@ mise run test-integration-cwd
 ```
 
 The `test.json` file contains an array of test cases. Each case builds and runs the same
-image but checks for different expected output strings.
+image but checks for different expected output strings. See [this
+file](https://github.com/railwayapp/railpack/blob/main/integration_tests/run_test.go#L26)
+for the schema.
 
 ### HTTP Checks
 
@@ -266,7 +294,7 @@ docker run -it --network python-django_default --env DATABASE_URL="postgresql://
 
 ## Mise
 
-Mise is absolutely central to this entire project, so you'll have to dig into the details.
+Mise is critical to this project. For any serious change, you'll need to understand how mise works in detail.
 
 * `mise trust` state is located in `~/.local/state/mise/trusted-configs`
 * There are two mise 'environments' to keep in mind: the host environment, which uses a specific version of mise downloaded

--- a/mise.lock
+++ b/mise.lock
@@ -48,10 +48,6 @@ url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-
 checksum = "sha256:538f9c846355d9e847b2671bc00c47da4229a0befb24df3282b739770f3b475f"
 url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64-baseline.zip"
 
-[[tools."cargo:retry-cli"]]
-version = "0.0.5"
-backend = "cargo:retry-cli"
-
 [[tools.go]]
 version = "1.26.5"
 backend = "core:go"
@@ -107,54 +103,65 @@ backend = "aqua:golangci/golangci-lint"
 [tools.golangci-lint."platforms.linux-arm64"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-arm64-musl"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64-baseline"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64-musl"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
 checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-x64"]
 checksum = "sha256:f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470980"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-x64-baseline"]
 checksum = "sha256:f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470980"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.windows-x64"]
 checksum = "sha256:bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471017"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.windows-x64-baseline"]
 checksum = "sha256:bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471017"
 provenance = "github-attestations"

--- a/mise.lock
+++ b/mise.lock
@@ -48,6 +48,10 @@ url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-
 checksum = "sha256:538f9c846355d9e847b2671bc00c47da4229a0befb24df3282b739770f3b475f"
 url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64-baseline.zip"
 
+[[tools."cargo:retry-cli"]]
+version = "0.0.5"
+backend = "cargo:retry-cli"
+
 [[tools.go]]
 version = "1.26.5"
 backend = "core:go"

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ _.path = './bin'
 go = "1.26"
 golangci-lint = "latest"
 bun = "1.3"
+"cargo:retry-cli" = "latest"
 
 [settings]
 experimental = true

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ idiomatic_version_file_enable_tools = ["python", "node", "ruby", "bun"]
 # ensures homebrew go, etc doesn't take precedence
 activate_aggressive = true
 env_shell_expand = true
-locked = true
+# locked = true
 
 [tasks.setup]
 run = [

--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,6 @@ _.path = './bin'
 go = "1.26"
 golangci-lint = "latest"
 bun = "1.3"
-"cargo:retry-cli" = "latest"
 
 [settings]
 experimental = true
@@ -17,6 +16,7 @@ idiomatic_version_file_enable_tools = ["python", "node", "ruby", "bun"]
 # ensures homebrew go, etc doesn't take precedence
 activate_aggressive = true
 env_shell_expand = true
+locked = true
 
 [tasks.setup]
 run = [


### PR DESCRIPTION
## Motivation

Contribution expectations were spread across `CONTRIBUTING.md` and the local dev guide without a clear end-to-end workflow, and provider code repeated the same version-precedence comments that the call order already makes obvious.

## Description

- Consolidate contribution guidance in `CONTRIBUTING.md`: PR expectations, a formal AI policy, and a link to the new PR template
- Add `.github/PULL_REQUEST_TEMPLATE.md` so contributors follow a consistent structure
- Expand `developing-locally.md` with a "Lifecycle of a Change" section and move testing/snapshot details there from `CONTRIBUTING.md`
- Remove redundant version-precedence comments from the deno, python, and ruby providers; document overwrite behavior once on `UseMiseVersions` so env-based overrides stay applied last