### PR TITLE
refactor(deno): simplify main file resolution

### DIFF
--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -3,6 +3,7 @@ package deno
 import (
 	"fmt"
 
+	"github.com/railwayapp/railpack/core/app"
 	"github.com/railwayapp/railpack/core/generate"
 	"github.com/railwayapp/railpack/core/plan"
 )
@@ -11,10 +12,6 @@ const (
 	DEFAULT_DENO_VERSION = "2"
 	ROOT_CACHE           = "/root/.cache"
 )
-
-type DenoJson struct {
-	Tasks map[string]string `json:"tasks"`
-}
 
 type DenoProvider struct {
 	mainFile string
@@ -30,7 +27,7 @@ func (p *DenoProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
 }
 
 func (p *DenoProvider) Initialize(ctx *generate.GenerateContext) error {
-	p.mainFile = p.findMainFile(ctx)
+	p.mainFile = findMainFile(ctx.App)
 	return nil
 }
 
@@ -100,22 +97,16 @@ func (p *DenoProvider) InstallMisePackages(ctx *generate.GenerateContext, miseSt
 	}
 }
 
-func (p *DenoProvider) findMainFile(ctx *generate.GenerateContext) string {
-	files := []string{"main.ts", "main.js", "main.mjs", "main.mts"}
-	for _, file := range files {
-		if ctx.App.HasFile(file) {
-			return file
-		}
+// selects the entrypoint for a Deno app. It prefers an explicit main.* file in the
+// project root, falling back to the first .ts/.js/.mjs/.mts file found anywhere in the tree.
+func findMainFile(app *app.App) string {
+	if name, _, _ := app.ReadFirstFileOf("main.ts", "main.js", "main.mjs", "main.mts"); name != "" {
+		return name
 	}
 
-	files, err := ctx.App.FindFiles("**/*.{ts,js,mjs,mts}")
-	if err != nil {
+	matches, err := app.FindFiles("**/*.{ts,js,mjs,mts}")
+	if err != nil || len(matches) == 0 {
 		return ""
 	}
-
-	if len(files) == 0 {
-		return ""
-	}
-
-	return files[0]
+	return matches[0]
 }


### PR DESCRIPTION
## Motivation

Deno entrypoint resolution used hand-rolled file checks and an unused type; using shared App helpers keeps the same root-first preference with less code.

## Description

- Resolve the entrypoint via `app.ReadFirstFileOf` for root `main.*` files, then fall back to the first matching `.ts`/`.js`/`.mjs`/`.mts` under the tree.
- Drop the unused `DenoJson` struct and take `*app.App` directly instead of routing through the provider method.

## Test

No new tests. Existing Deno provider/unit coverage of main-file detection should continue to apply; run `mise run check` and Deno-related tests if available.