### PR TITLE
fix(python): install poetry via mise default backend

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -30,7 +30,7 @@
     "step": "build"
    }
   ],
-  "startCommand": "poetry run python main.py",
+  "startCommand": "python main.py",
   "variables": {
    "PIP_DEFAULT_TIMEOUT": "100",
    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -56,7 +56,7 @@
     },
     {
      "cmd": "mise install",
-     "customName": "install mise packages: pipx, pipx:poetry, python, uv"
+     "customName": "install mise packages: poetry, python"
     }
    ],
    "inputs": [

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -319,7 +319,7 @@ func (p *PythonProvider) InstallMisePackages(ctx *generate.GenerateContext, mise
 	packages := []string{"python"}
 
 	// Install package managers
-	if p.hasPoetry(ctx) || p.hasPdm(ctx) || p.hasPipfile(ctx) {
+	if p.hasPdm(ctx) || p.hasPipfile(ctx) {
 		miseStep.Default("pipx", "latest")
 		packages = append(packages, "pipx")
 
@@ -332,10 +332,8 @@ func (p *PythonProvider) InstallMisePackages(ctx *generate.GenerateContext, mise
 	}
 
 	if p.hasPoetry(ctx) {
-		// as of 2025-10-18 the default mise poetry backend is asdf, which is very poorly maintained and has caused build
-		// issues for users, which is why we install poetry via pipx here.
-		miseStep.Default("pipx:poetry", "latest")
-		packages = append(packages, "pipx:poetry")
+		miseStep.Default("poetry", "latest")
+		packages = append(packages, "poetry")
 	}
 
 	if p.hasPdm(ctx) {

--- a/examples/python-poetry/railpack.json
+++ b/examples/python-poetry/railpack.json
@@ -1,3 +1,0 @@
-{
-    "$schema": "https://schema.railpack.com"
-}

--- a/examples/python-poetry/railpack.json
+++ b/examples/python-poetry/railpack.json
@@ -1,9 +1,3 @@
 {
-    "$schema": "https://schema.railpack.com",
-    "deploy": {
-      // without this, `python` is used directly, running `poetry` directly could fail if it was copied
-      // into the poetry venv from a previous step's binary which has since been removed from the image
-      // we ran into this originally when installing python3-dev
-      "startCommand": "poetry run python main.py"
-    }
+    "$schema": "https://schema.railpack.com"
 }


### PR DESCRIPTION
## Motivation

Poetry was installed via pipx to work around a poorly maintained mise/asdf backend and related venv path issues. Those constraints no longer apply, so we can use mise’s native poetry package again and drop the example-level workarounds.

## Description

- Install Poetry with mise’s native `poetry` package instead of `pipx:poetry`, so poetry no longer depends on a pipx install path.
- Remove the python-poetry example’s forced `poetry run python main.py` start command so it uses the normal project runtime default (`python main.py`).
- Simplify Deno main-file resolution with `App` helpers: prefer root `main.*`, then fall back to the first matching source file.

## Test

- Updated the `python-poetry` build plan snapshot for the new install packages and start command.