### PR TITLE
feat(build): support build networking flags for exec steps

### DIFF
--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/system"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/railwayapp/railpack/buildkit/graph"
@@ -30,6 +31,13 @@ type BuildGraph struct {
 	githubToken     string
 	secretsFile     *llb.State
 	usedSecretsBase *llb.State
+
+	// networkMode and extraHosts come from dockerui-compatible frontend opts
+	// (force-network-mode / add-hosts). Applied to plan exec steps like the
+	// Dockerfile frontend:
+	// https://github.com/moby/buildkit/blob/v0.31.1/frontend/dockerfile/dockerfile2llb/convert.go
+	networkMode pb.NetMode
+	extraHosts  []llb.HostIP
 }
 
 type BuildGraphOutput struct {
@@ -37,7 +45,7 @@ type BuildGraphOutput struct {
 	GraphEnv BuildEnvironment
 }
 
-func NewBuildGraph(plan *plan.BuildPlan, localState *llb.State, cacheStore *BuildKitCacheStore, secretsHash string, platform *specs.Platform, githubToken string) (*BuildGraph, error) {
+func NewBuildGraph(plan *plan.BuildPlan, localState *llb.State, cacheStore *BuildKitCacheStore, secretsHash string, platform *specs.Platform, githubToken string, networkMode pb.NetMode, extraHosts []llb.HostIP) (*BuildGraph, error) {
 	var secretsFile *llb.State
 	if secretsHash != "" {
 		st := llb.Scratch().File(llb.Mkfile("/secrets-hash", 0644, []byte(secretsHash)), llb.WithCustomName("[railpack] secrets hash"))
@@ -55,6 +63,8 @@ func NewBuildGraph(plan *plan.BuildPlan, localState *llb.State, cacheStore *Buil
 		githubToken:     githubToken,
 		secretsFile:     secretsFile,
 		usedSecretsBase: &usedSecretsBase,
+		networkMode:     networkMode,
+		extraHosts:      extraHosts,
 	}
 
 	// Create a node for each step
@@ -283,6 +293,17 @@ func (g *BuildGraph) convertExecCommandToLLB(node *StepNode, cmd plan.ExecComman
 	githubTokenOpts := g.addGitHubTokenToMiseInstall(cmd)
 	if githubTokenOpts != nil {
 		opts = append(opts, githubTokenOpts...)
+	}
+
+	// Apply dockerui-compatible network mode and extra hosts so buildx
+	// --network / --add-host affect plan execs the same way as Dockerfile RUN.
+	// Dockerfile frontend: stage.Network(mode) + llb.AddExtraHost per RUN
+	// https://github.com/moby/buildkit/blob/v0.31.1/frontend/dockerfile/dockerfile2llb/convert.go
+	if g.networkMode != llb.NetModeSandbox {
+		opts = append(opts, llb.Network(g.networkMode))
+	}
+	for _, h := range g.extraHosts {
+		opts = append(opts, llb.AddExtraHost(h.Host, h.IP))
 	}
 
 	s := state.Run(opts...).Root()

--- a/buildkit/convert.go
+++ b/buildkit/convert.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/system"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/railwayapp/railpack/buildkit/build_llb"
@@ -28,6 +29,13 @@ type ConvertPlanOptions struct {
 
 	// Token used to make authenticated API requests to GitHub to increase rate limits
 	GitHubToken string
+
+	// NetworkMode for RUN/exec steps (from docker buildx --network / force-network-mode).
+	// Default is sandbox (NetMode_UNSET).
+	NetworkMode pb.NetMode
+
+	// ExtraHosts for RUN/exec steps (from docker buildx --add-host / add-hosts).
+	ExtraHosts []llb.HostIP
 }
 
 const (
@@ -45,7 +53,7 @@ func ConvertPlanToLLB(plan *p.BuildPlan, opts ConvertPlanOptions) (*llb.State, *
 	)
 
 	cacheStore := build_llb.NewBuildKitCacheStore(opts.CacheKey)
-	graph, err := build_llb.NewBuildGraph(plan, &localState, cacheStore, opts.SecretsHash, &platform, opts.GitHubToken)
+	graph, err := build_llb.NewBuildGraph(plan, &localState, cacheStore, opts.SecretsHash, &platform, opts.GitHubToken, opts.NetworkMode, opts.ExtraHosts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildkit/convert_network_test.go
+++ b/buildkit/convert_network_test.go
@@ -1,0 +1,94 @@
+package buildkit
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/railwayapp/railpack/core/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertPlanToLLB_NetworkModeAndExtraHosts(t *testing.T) {
+	t.Parallel()
+
+	// Deploy inputs need include filters so the step state (and its exec) is
+	// wired into the final image LLB rather than being dropped by copy/merge.
+	buildPlan := &plan.BuildPlan{
+		Steps: []plan.Step{
+			{
+				Name:   "build",
+				Inputs: []plan.Layer{plan.NewImageLayer("alpine:latest")},
+				Commands: []plan.Command{
+					plan.NewExecCommand("curl my-other-container"),
+				},
+			},
+		},
+		Deploy: plan.Deploy{
+			Base: plan.NewImageLayer("alpine:latest"),
+			Inputs: []plan.Layer{
+				plan.NewStepLayer("build", plan.NewIncludeFilter([]string{"."})),
+			},
+		},
+	}
+
+	t.Run("defaults are sandbox with no extra hosts", func(t *testing.T) {
+		state, _, err := ConvertPlanToLLB(buildPlan, ConvertPlanOptions{
+			BuildPlatform: specs.Platform{OS: "linux", Architecture: "amd64"},
+		})
+		require.NoError(t, err)
+
+		execs := marshalExecOps(t, state)
+		require.NotEmpty(t, execs)
+		for _, exec := range execs {
+			require.Equal(t, pb.NetMode_UNSET, exec.Network)
+			require.Empty(t, exec.Meta.ExtraHosts)
+		}
+	})
+
+	t.Run("host network and extra hosts applied to execs", func(t *testing.T) {
+		state, _, err := ConvertPlanToLLB(buildPlan, ConvertPlanOptions{
+			BuildPlatform: specs.Platform{OS: "linux", Architecture: "amd64"},
+			NetworkMode:   llb.NetModeHost,
+			ExtraHosts: []llb.HostIP{
+				{Host: "my-other-container", IP: net.ParseIP("192.168.107.2")},
+			},
+		})
+		require.NoError(t, err)
+
+		execs := marshalExecOps(t, state)
+		require.NotEmpty(t, execs)
+
+		var found bool
+		for _, exec := range execs {
+			if exec.Network != pb.NetMode_HOST {
+				continue
+			}
+			found = true
+			require.Len(t, exec.Meta.ExtraHosts, 1)
+			require.Equal(t, "my-other-container", exec.Meta.ExtraHosts[0].Host)
+			require.Equal(t, "192.168.107.2", exec.Meta.ExtraHosts[0].IP)
+		}
+		require.True(t, found, "expected at least one exec op with host network mode")
+	})
+}
+
+func marshalExecOps(t *testing.T, state *llb.State) []*pb.ExecOp {
+	t.Helper()
+
+	def, err := state.Marshal(context.Background())
+	require.NoError(t, err)
+
+	var execs []*pb.ExecOp
+	for _, dt := range def.Def {
+		var op pb.Op
+		require.NoError(t, op.Unmarshal(dt))
+		if exec := op.GetExec(); exec != nil {
+			execs = append(execs, exec)
+		}
+	}
+	return execs
+}

--- a/buildkit/frontend.go
+++ b/buildkit/frontend.go
@@ -65,6 +65,17 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		return nil, err
 	}
 
+	// docker buildx --network / --add-host → force-network-mode / add-hosts
+	// (same dockerui opts as the Dockerfile frontend; see network_opts.go)
+	networkMode, err := parseNetMode(opts[keyForceNetwork])
+	if err != nil {
+		return nil, err
+	}
+	extraHosts, err := parseExtraHosts(opts[keyGlobalAddHosts])
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse additional hosts")
+	}
+
 	plan, err := readRailpackPlan(ctx, c)
 	if err != nil {
 		return nil, err
@@ -81,6 +92,8 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		CacheKey:      cacheKey,
 		SessionID:     c.BuildOpts().SessionID,
 		GitHubToken:   githubToken,
+		NetworkMode:   networkMode,
+		ExtraHosts:    extraHosts,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error converting plan to LLB: %w", err)

--- a/buildkit/network_opts.go
+++ b/buildkit/network_opts.go
@@ -1,0 +1,70 @@
+package buildkit
+
+import (
+	"net"
+	"strings"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/pkg/errors"
+)
+
+// Frontend opts for build networking, matching the Dockerfile frontend's dockerui
+// contract so docker buildx --network / --add-host work with railpack:
+//
+//	https://github.com/moby/buildkit/blob/v0.31.1/frontend/dockerui/config.go
+//	https://github.com/moby/buildkit/blob/v0.31.1/frontend/dockerui/attr.go
+//
+// buildx maps --network=host → force-network-mode=host and --add-host host:ip →
+// add-hosts=host=ip. The Dockerfile frontend reads these and applies them to
+// RUN via llb.Network / llb.AddExtraHost; we do the same for plan exec steps.
+const (
+	keyForceNetwork   = "force-network-mode"
+	keyGlobalAddHosts = "add-hosts"
+)
+
+// parseNetMode mirrors dockerui.parseNetMode.
+// https://github.com/moby/buildkit/blob/v0.31.1/frontend/dockerui/attr.go
+func parseNetMode(v string) (pb.NetMode, error) {
+	if v == "" {
+		return llb.NetModeSandbox, nil
+	}
+	switch v {
+	case "none":
+		return llb.NetModeNone, nil
+	case "host":
+		return llb.NetModeHost, nil
+	case "sandbox":
+		return llb.NetModeSandbox, nil
+	default:
+		return 0, errors.Errorf("invalid netmode %s", v)
+	}
+}
+
+// parseExtraHosts mirrors dockerui.parseExtraHosts (CSV of host=ip pairs).
+// https://github.com/moby/buildkit/blob/v0.31.1/frontend/dockerui/attr.go
+func parseExtraHosts(v string) ([]llb.HostIP, error) {
+	if v == "" {
+		return nil, nil
+	}
+
+	out := make([]llb.HostIP, 0)
+	for field := range strings.SplitSeq(v, ",") {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		// dockerui lowercases the field before splitting so hostnames are
+		// normalized the same way buildx/Dockerfile would.
+		key, val, ok := strings.Cut(strings.ToLower(field), "=")
+		if !ok {
+			return nil, errors.Errorf("invalid key-value pair %s", field)
+		}
+		ip := net.ParseIP(val)
+		if ip == nil {
+			return nil, errors.Errorf("failed to parse IP %s", val)
+		}
+		out = append(out, llb.HostIP{Host: key, IP: ip})
+	}
+	return out, nil
+}

--- a/buildkit/network_opts_test.go
+++ b/buildkit/network_opts_test.go
@@ -1,0 +1,84 @@
+package buildkit
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNetMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    pb.NetMode
+		wantErr bool
+	}{
+		{name: "empty defaults to sandbox", input: "", want: llb.NetModeSandbox},
+		{name: "sandbox", input: "sandbox", want: llb.NetModeSandbox},
+		{name: "host", input: "host", want: llb.NetModeHost},
+		{name: "none", input: "none", want: llb.NetModeNone},
+		{name: "invalid", input: "bridge", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNetMode(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseExtraHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		got, err := parseExtraHosts("")
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("single host", func(t *testing.T) {
+		got, err := parseExtraHosts("my-other-container=192.168.107.2")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "my-other-container", got[0].Host)
+		require.Equal(t, "192.168.107.2", got[0].IP.String())
+	})
+
+	t.Run("lowercases host", func(t *testing.T) {
+		got, err := parseExtraHosts("My-Host=10.0.0.1")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "my-host", got[0].Host)
+		require.Equal(t, "10.0.0.1", got[0].IP.String())
+	})
+
+	t.Run("multiple hosts", func(t *testing.T) {
+		got, err := parseExtraHosts("a=1.1.1.1,b=2.2.2.2")
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		require.Equal(t, "a", got[0].Host)
+		require.Equal(t, "1.1.1.1", got[0].IP.String())
+		require.Equal(t, "b", got[1].Host)
+		require.Equal(t, "2.2.2.2", got[1].IP.String())
+	})
+
+	t.Run("invalid pair", func(t *testing.T) {
+		_, err := parseExtraHosts("not-a-pair")
+		require.Error(t, err)
+	})
+
+	t.Run("invalid IP", func(t *testing.T) {
+		_, err := parseExtraHosts("host=not-an-ip")
+		require.Error(t, err)
+	})
+}

--- a/docs/src/content/docs/guides/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/guides/running-railpack-in-production.mdx
@@ -68,7 +68,9 @@ buildctl build \
 
 Building with the Docker or BuildKit command is useful because you can pass any
 additional flags you want to the build, without them having to be supported by
-the Railpack CLI.
+the Railpack CLI. This includes standard networking flags such as
+`--network=host` and `--add-host` (see the
+[frontend reference](../reference/frontend#build-networking)).
 
 ## Secrets
 

--- a/docs/src/content/docs/reference/frontend.md
+++ b/docs/src/content/docs/reference/frontend.md
@@ -80,6 +80,60 @@ buildctl build \
 
 Note that the `build-arg:` prefix is required only when using `buildctl` to ensure the arg structure matches `docker buildx`.
 
+## Build networking
+
+The frontend honors the same network-related options as the Dockerfile
+frontend. Docker/buildx map CLI flags to frontend opts that railpack applies to
+every plan exec step:
+
+| Flag | Frontend opt | Effect |
+| ---- | ------------ | ------ |
+| `--network=host` | `force-network-mode=host` | Host networking for exec |
+| `--network=none` | `force-network-mode=none` | No network for exec |
+| `--add-host=name:ip` | `add-hosts=name=ip` | Host entries during build |
+
+**Docker:**
+
+```sh
+docker buildx build \
+  --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend" \
+  --network=host \
+  --add-host=my-service:10.0.0.5 \
+  -f /path/to/railpack-plan.json \
+  /path/to/app/to/build
+```
+
+**BuildKit:**
+
+```sh
+buildctl build \
+  --frontend=gateway.v0 \
+  --opt source=ghcr.io/railwayapp/railpack-frontend:latest \
+  --opt force-network-mode=host \
+  --opt add-hosts=my-service=10.0.0.5 \
+  --allow network.host \
+  --local context=/path/to/app/to/build \
+  --local dockerfile=/path/to/dir/containing/railpack-plan.json
+```
+
+`--network=host` requires the `network.host` entitlement. Docker buildx grants
+this when you pass `--network=host`. With `buildctl`, pass
+`--allow network.host`.
+
+Custom Docker networks (for example so build steps can reach other containers
+by hostname) are configured on the **builder**, not via `--network=<name>`:
+
+```sh
+docker buildx create \
+  --name custom_network_builder \
+  --driver docker-container \
+  --driver-opt network=my-network
+```
+
+Then build with that builder and `--network=host` so exec steps share the
+builder container network (including Docker embedded DNS). This matches how
+plain Dockerfiles work with a networked builder.
+
 ## Secrets
 
 To use secrets in your build, you must:


### PR DESCRIPTION
## Motivation

`docker buildx --network` and `--add-host` were ignored by the Railpack frontend, so build-time network access did not match Dockerfile behavior.

## Description

Parse the same dockerui frontend opts as the Dockerfile frontend (`force-network-mode`, `add-hosts`) and apply them to plan exec steps via `llb.Network` / `llb.AddExtraHost`. Document the Docker and BuildKit usage.

## Test

- Unit tests for network opt parsing (`network_opts_test.go`)
- Convert-path tests that network mode and extra hosts flow through to LLB (`convert_network_test.go`)

## Links

Fixes https://github.com/railwayapp/railpack/issues/145