### PR TITLE
build: clean additional railpack images in mise clean

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -55,11 +55,16 @@ run = [
   "docker exec buildkit buildctl prune",
   "rm -f *.test",
   # stop all railpack containers
-  "docker stop $(docker ps -q --filter name=railpack)",
+  "docker ps -q --filter name=railpack | xargs -r docker stop",
   # remove all images created by the integration test suite
   "docker images 'railpack-test-*' -q | xargs -r docker rmi -f",
   # remove images created by manually running `railpack build` against a project example
   "find examples -name test.json -exec dirname {} \\; | xargs -n 1 basename | xargs -r -I {} docker rmi -f {}",
+  # remove railpack builder/frontend base images (ghcr + local tags)
+  "docker images 'ghcr.io/railwayapp/railpack-builder' -q | xargs -r docker rmi -f",
+  "docker images 'ghcr.io/railwayapp/railpack-frontend' -q | xargs -r docker rmi -f",
+  "docker images 'railpack-builder' -q | xargs -r docker rmi -f",
+  "docker images 'railpack-frontend' -q | xargs -r docker rmi -f",
   # tear down Apple container machine + host Docker TCP proxy used by mise-linux-shell
   "mise run mise-linux-shell --stop",
   "go clean -testcache",


### PR DESCRIPTION
## Motivation

`mise run clean` left behind local and GHCR `railpack-builder` / `railpack-frontend` images, so subsequent builds could keep using stale layers.

## Description

Extend the clean task to remove those images (both `ghcr.io/railwayapp/…` and short names). Also make stopping railpack containers a no-op when none are running, so clean does not fail on an empty `docker stop`.

## Test

- Ran `mise run clean` and confirmed builder/frontend images (GHCR and local tags) were removed and the task exited 0.