### PR TITLE
feat: set RAILPACK_VERSION on runtime images

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-cmake_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-cmake_1.snap.json
@@ -11,7 +11,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "/build/cpp-cmake"
+  "startCommand": "/build/cpp-cmake",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-meson_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_cpp-meson_1.snap.json
@@ -11,7 +11,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "/build/cpp-meson"
+  "startCommand": "/build/cpp-meson",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
@@ -22,7 +22,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "deno run --allow-all main.ts"
+  "startCommand": "deno run --allow-all main.ts",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_dockerignore_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_dockerignore_1.snap.json
@@ -11,7 +11,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "sh start.sh"
+  "startCommand": "sh start.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-api_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-api_1.snap.json
@@ -32,7 +32,8 @@
    "ASPNETCORE_CONTENTROOT": "/app/out",
    "ASPNETCORE_ENVIRONMENT": "Production",
    "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
-   "DOTNET_ROOT": "/mise/installs/dotnet/8.0.404"
+   "DOTNET_ROOT": "/mise/installs/dotnet/8.0.404",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-cli_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-cli_1.snap.json
@@ -32,7 +32,8 @@
    "ASPNETCORE_CONTENTROOT": "/app/out",
    "ASPNETCORE_ENVIRONMENT": "Production",
    "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
-   "DOTNET_ROOT": "/mise/installs/dotnet/6.0"
+   "DOTNET_ROOT": "/mise/installs/dotnet/6.0",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-ecto_1.snap.json
@@ -19,7 +19,8 @@
    "LC_ALL": "en_US.UTF-8",
    "MIX_ARCHIVES": "/root/.mix/archives",
    "MIX_ENV": "prod",
-   "MIX_HOME": "/root/.mix"
+   "MIX_HOME": "/root/.mix",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-latest_1.snap.json
@@ -19,7 +19,8 @@
    "LC_ALL": "en_US.UTF-8",
    "MIX_ARCHIVES": "/root/.mix/archives",
    "MIX_ENV": "prod",
-   "MIX_HOME": "/root/.mix"
+   "MIX_HOME": "/root/.mix",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_elixir-phoenix_1.snap.json
@@ -19,7 +19,8 @@
    "LC_ALL": "en_US.UTF-8",
    "MIX_ARCHIVES": "/root/.mix/archives",
    "MIX_ENV": "prod",
-   "MIX_HOME": "/root/.mix"
+   "MIX_HOME": "/root/.mix",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_expo-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_expo-spa_1.snap.json
@@ -48,7 +48,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-custom-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-custom-version_1.snap.json
@@ -21,7 +21,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "./build/erlang-shipment/entrypoint.sh run"
+  "startCommand": "./build/erlang-shipment/entrypoint.sh run",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-include-source_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam-include-source_1.snap.json
@@ -21,7 +21,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "./build/erlang-shipment/entrypoint.sh run"
+  "startCommand": "./build/erlang-shipment/entrypoint.sh run",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_gleam_1.snap.json
@@ -21,7 +21,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "./build/erlang-shipment/entrypoint.sh run"
+  "startCommand": "./build/erlang-shipment/entrypoint.sh run",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-cmd-dirs_1.snap.json
@@ -17,7 +17,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "./out"
+  "startCommand": "./out",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-mod_1.snap.json
@@ -17,7 +17,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "./out"
+  "startCommand": "./out",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_go-workspaces_1.snap.json
@@ -17,7 +17,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "./out"
+  "startCommand": "./out",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-gradle_1.snap.json
@@ -27,7 +27,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "java $JAVA_OPTS -jar  $(ls -1 */build/libs/*jar | grep -v plain)"
+  "startCommand": "java $JAVA_OPTS -jar  $(ls -1 */build/libs/*jar | grep -v plain)",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-maven_1.snap.json
@@ -27,7 +27,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "java  $JAVA_OPTS -jar target/*jar"
+  "startCommand": "java  $JAVA_OPTS -jar target/*jar",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_java-zulu-version_1.snap.json
@@ -27,7 +27,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "java  $JAVA_OPTS -jar target/*jar"
+  "startCommand": "java  $JAVA_OPTS -jar target/*jar",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_mise-config_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
@@ -48,7 +48,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
@@ -62,7 +62,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
@@ -52,7 +52,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
@@ -49,7 +49,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -60,7 +60,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
@@ -48,7 +48,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
@@ -60,7 +60,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-lts-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-lts-npm-native-deps_1.snap.json
@@ -60,7 +60,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
@@ -52,7 +52,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -61,7 +61,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -60,7 +60,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-11-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-11-engines_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
@@ -65,7 +65,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
@@ -52,7 +52,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
@@ -56,7 +56,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
@@ -61,7 +61,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -64,7 +64,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-version-precedence_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-version-precedence_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-custom-caddyfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-custom-caddyfile_1.snap.json
@@ -52,7 +52,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-spa_1.snap.json
@@ -56,7 +56,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react-router-ssr_1.snap.json
@@ -65,7 +65,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
@@ -52,7 +52,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
@@ -52,7 +52,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -52,7 +52,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
@@ -61,6 +61,7 @@
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
    "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev",
    "YARN_PRODUCTION": "false"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
@@ -59,7 +59,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
@@ -58,7 +58,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
@@ -61,7 +61,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
@@ -61,7 +61,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
@@ -61,7 +61,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -46,7 +46,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -46,7 +46,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
@@ -9,7 +9,10 @@
   "base": {
    "step": "build"
   },
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
@@ -3,7 +3,10 @@
   "base": {
    "step": "build"
   },
-  "startCommand": "/start-container.sh"
+  "startCommand": "/start-container.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
@@ -60,7 +60,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
@@ -34,7 +34,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -51,7 +51,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
@@ -34,7 +34,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
@@ -51,7 +51,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
@@ -34,7 +34,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
@@ -34,7 +34,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -37,7 +37,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -37,7 +37,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -37,7 +37,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -51,7 +51,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-latest-locked_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-latest-locked_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
@@ -51,7 +51,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -43,7 +43,8 @@
    "PYTHONDONTWRITEBYTECODE": "1",
    "PYTHONFAULTHANDLER": "1",
    "PYTHONHASHSEED": "random",
-   "PYTHONUNBUFFERED": "1"
+   "PYTHONUNBUFFERED": "1",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_railpack-env-configuration_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_railpack-env-configuration_1.snap.json
@@ -11,7 +11,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "bash start.sh"
+  "startCommand": "bash start.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-2_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3-precompiled_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3-precompiled_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-3_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-execjs_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-execjs_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-jemalloc_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-jemalloc_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-latest_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-local-deps_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-no-version_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-api-app_1.snap.json
@@ -44,7 +44,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-rails-postgres_1.snap.json
@@ -44,7 +44,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-sinatra_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-vanilla_1.snap.json
@@ -43,7 +43,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
@@ -67,7 +67,8 @@
    "GEM_HOME": "/usr/local/bundle",
    "GEM_PATH": "/usr/local/bundle",
    "LD_PRELOAD": "libjemalloc.so.2",
-   "MALLOC_ARENA_MAX": "2"
+   "MALLOC_ARENA_MAX": "2",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces-glob_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces-glob_1.snap.json
@@ -26,6 +26,7 @@
   ],
   "startCommand": "./bin/binary",
   "variables": {
+   "RAILPACK_VERSION": "dev",
    "ROCKET_ADDRESS": "0.0.0.0"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-cargo-workspaces_1.snap.json
@@ -26,6 +26,7 @@
   ],
   "startCommand": "./bin/binary",
   "variables": {
+   "RAILPACK_VERSION": "dev",
    "ROCKET_ADDRESS": "0.0.0.0"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
@@ -30,6 +30,7 @@
   ],
   "startCommand": "./bin/rust-custom-toolchain",
   "variables": {
+   "RAILPACK_VERSION": "dev",
    "ROCKET_ADDRESS": "0.0.0.0"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-version_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-version_1.snap.json
@@ -30,6 +30,7 @@
   ],
   "startCommand": "./bin/rust-custom-version",
   "variables": {
+   "RAILPACK_VERSION": "dev",
    "ROCKET_ADDRESS": "0.0.0.0"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-multiple-bins_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-multiple-bins_1.snap.json
@@ -30,6 +30,7 @@
   ],
   "startCommand": "./bin/bin1",
   "variables": {
+   "RAILPACK_VERSION": "dev",
    "ROCKET_ADDRESS": "0.0.0.0"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-rocket_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-rocket_1.snap.json
@@ -30,6 +30,7 @@
   ],
   "startCommand": "./bin/rocket",
   "variables": {
+   "RAILPACK_VERSION": "dev",
    "ROCKET_ADDRESS": "0.0.0.0"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-system-deps_1.snap.json
@@ -30,6 +30,7 @@
   ],
   "startCommand": "./bin/rust-open-ssl",
   "variables": {
+   "RAILPACK_VERSION": "dev",
    "ROCKET_ADDRESS": "0.0.0.0"
   }
  },

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
@@ -17,7 +17,10 @@
     "step": "usesSecrets"
    }
   ],
-  "startCommand": "./run.sh"
+  "startCommand": "./run.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "secrets": [
   "MY_SECRET",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-bash-arrays_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-bash-arrays_1.snap.json
@@ -11,7 +11,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "bash start.sh"
+  "startCommand": "bash start.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-platform-arch_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-platform-arch_1.snap.json
@@ -21,7 +21,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "zsh start.sh"
+  "startCommand": "zsh start.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-script_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_shell-script_1.snap.json
@@ -11,7 +11,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "sh start.sh"
+  "startCommand": "sh start.sh",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-config_1.snap.json
@@ -17,7 +17,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261"
+  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index-fallback_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index-fallback_1.snap.json
@@ -17,7 +17,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261"
+  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_staticfile-index_1.snap.json
@@ -17,7 +17,10 @@
     "step": "build"
    }
   ],
-  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261"
+  "startCommand": "caddy run --config Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
  },
  "steps": [
   {

--- a/core/core.go
+++ b/core/core.go
@@ -115,6 +115,13 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 		return &BuildResult{Success: false, Logs: logger.Logs}
 	}
 
+	railpackVersion := options.RailpackVersion
+	if railpackVersion == "" {
+		railpackVersion = "dev"
+	}
+	// Bake the builder version into the runtime image for observability
+	buildPlan.Deploy.Variables["RAILPACK_VERSION"] = railpackVersion
+
 	if providerToUse != nil {
 		providerToUse.CleansePlan(buildPlan)
 	}
@@ -127,7 +134,7 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 	}
 
 	buildResult := &BuildResult{
-		RailpackVersion:   options.RailpackVersion,
+		RailpackVersion:   railpackVersion,
 		Plan:              buildPlan,
 		ResolvedPackages:  resolvedPackages,
 		Metadata:          ctx.Metadata.Properties,

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -42,6 +42,9 @@ Environment variables can be set in two ways:
 }
 ```
 
+Railpack always sets `RAILPACK_VERSION` on the final runtime image to the
+Railpack version that produced the image (for example `0.12.3`).
+
 ## Secrets
 
 The names of all secrets that should be used during the build are added to the


### PR DESCRIPTION
## Motivation

There is no way to tell which Railpack version built a deployed image from the container itself. There's also no way to know if a container was built with Railpack.

## Description

Bake `RAILPACK_VERSION` into deploy variables so the final runtime image always exposes the Railpack version that produced it (e.g. `0.12.3`).