### PR TITLE
fix(php): include Mise runtime layer for one package

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -32,6 +32,16 @@
   "inputs": [
    {
     "include": [
+     "/mise/shims",
+     "/mise/installs",
+     "/usr/local/bin/mise",
+     "/etc/mise/config.toml",
+     "/root/.local/state/mise"
+    ],
+    "step": "packages:mise"
+   },
+   {
+    "include": [
      "/app/node_modules"
     ],
     "step": "prune:node"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -32,6 +32,16 @@
   "inputs": [
    {
     "include": [
+     "/mise/shims",
+     "/mise/installs",
+     "/usr/local/bin/mise",
+     "/etc/mise/config.toml",
+     "/root/.local/state/mise"
+    ],
+    "step": "packages:mise"
+   },
+   {
+    "include": [
      "/app/node_modules"
     ],
     "step": "prune:node"

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -236,7 +236,7 @@ func (p *PhpProvider) DeployWithNode(ctx *generate.GenerateContext, nodeProvider
 
 // Include mise and packages in the final image if the user has specified any additional packages
 func (p *PhpProvider) ConditionallyIncludeMise(ctx *generate.GenerateContext) {
-	if len(ctx.GetMiseStepBuilder().MisePackages) > 1 {
+	if len(ctx.GetMiseStepBuilder().MisePackages) >= 1 {
 		ctx.Deploy.AddInputs([]plan.Layer{
 			ctx.GetMiseStepBuilder().GetLayer(),
 		})


### PR DESCRIPTION
 ## Motivation

 PHP applications that use exactly one Mise-managed runtime package currently omit that package from the runtime image.

 ## Description

 Include the Mise layer in PHP deploy images whenever at least one Mise-managed package is required, instead of at least 2.

 ## Test

 - Regenerated and reviewed the Laravel 11 and Laravel 12 React build-plan
   snapshots
 - Verified both plans include `packages:mise` in the deploy inputs
 - `core` and `core/providers/php` tests passed

 ## Links

 Fixes [#634](https://github.com/railwayapp/railpack/issues/634)