### PR TITLE
fix(node): warn when package manager is inferred

### DIFF
--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -66,7 +66,7 @@ func (p *NodeProvider) Initialize(ctx *generate.GenerateContext) error {
 	}
 	p.packageJson = packageJson
 
-	p.packageManager = p.getPackageManager(ctx.App)
+	p.packageManager = p.getPackageManager(ctx)
 
 	workspace, err := NewWorkspace(ctx.App)
 	if err != nil {
@@ -430,7 +430,9 @@ func parseYarnPackageManager(pmVersion string) PackageManager {
 	return PackageManagerYarnBerry
 }
 
-func (p *NodeProvider) getPackageManager(app *app.App) PackageManager {
+func (p *NodeProvider) getPackageManager(ctx *generate.GenerateContext) PackageManager {
+	app := ctx.App
+
 	// Check packageManager field first
 	if packageJson, err := p.GetPackageJson(app); err == nil && packageJson.PackageManager != nil {
 		pmName, pmVersion := packageJson.GetPackageManagerInfo()
@@ -475,7 +477,7 @@ func (p *NodeProvider) getPackageManager(app *app.App) PackageManager {
 		}
 	}
 
-	log.Info("No package manager inferred, using npm default")
+	ctx.Logger.LogWarn("No node package manager detected, using npm")
 
 	return PackageManagerNpm
 }

--- a/core/providers/node/node_test.go
+++ b/core/providers/node/node_test.go
@@ -80,8 +80,7 @@ func TestNode(t *testing.T) {
 				err = provider.Initialize(ctx)
 				require.NoError(t, err)
 
-				packageManager := provider.getPackageManager(ctx.App)
-				require.Equal(t, tt.packageManager, packageManager)
+				require.Equal(t, tt.packageManager, provider.packageManager)
 
 				err = provider.Plan(ctx)
 				require.NoError(t, err)


### PR DESCRIPTION
## Motivation

Package-manager fallback should be visible in the generated plan as a warning instead of being emitted as a top-level info log.

## Description

Route the npm fallback message through the generation-context logger at warning level, and assert the package manager selected during provider initialization.

## Test

- `mise run check`
- `mise run test -- -run '^TestNode$'`\n- Full `mise run test` was blocked by unrelated external-version snapshot drift for Caddy and FrankenPHP images.