### PR TITLE
feat(node): support SvelteKit with adapter-auto

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
@@ -50,6 +50,7 @@
     "step": "build"
    }
   ],
+  "startCommand": "node build",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -160,7 +161,10 @@
    "name": "build",
    "secrets": [
     "*"
-   ]
+   ],
+   "variables": {
+    "GCP_BUILDPACKS": "true"
+   }
   },
   {
    "caches": [

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -124,6 +124,8 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 		return err
 	}
 
+	p.configureSvelteKit(ctx, build)
+
 	// All the files we need to include in the deploy
 	buildIncludeDirs := []string{"/root/.cache", "."}
 
@@ -193,6 +195,8 @@ func (p *NodeProvider) GetStartCommand(ctx *generate.GenerateContext) string {
 	} else if p.isNuxt() {
 		// Default Nuxt start command
 		return "node .output/server/index.mjs"
+	} else if start := p.getSvelteKitStartCommand(); start != "" {
+		return start
 	} else if pkg, _, ok := p.resolveNxDeployPackage(ctx); ok {
 		// Prefer next start from the app dir so prune does not require the nx CLI at runtime
 		if p.isNextAppPackage(pkg, ctx) {

--- a/core/providers/node/spa_test.go
+++ b/core/providers/node/spa_test.go
@@ -36,6 +36,12 @@ func TestVite(t *testing.T) {
 			outputDir: "theoutput",
 		},
 		{
+			name:   "svelte-kit",
+			path:   "../../../examples/node-svelte-kit",
+			isSPA:  false,
+			isVite: false,
+		},
+		{
 			name:      "cra",
 			path:      "../../../examples/node-cra",
 			isSPA:     true,

--- a/core/providers/node/svelte.go
+++ b/core/providers/node/svelte.go
@@ -9,8 +9,8 @@ func (p *NodeProvider) configureSvelteKit(ctx *generate.GenerateContext, build *
 		return
 	}
 
-	// adapter-auto recognizes this buildpack signal and emits an adapter-node server.
-	// GCP_BUILDPACKS is normally set by Google Cloud Buildpacks.
+	// Causes @sveltejs/adapter-auto to select adapter-node, so the build emits a Node server.
+	// Oddly, GCP_BUILDPACKS is the only env var adapter-auto recognizes for Node; there is no generic/Railway signal.
 	ctx.Logger.LogInfo("SvelteKit with adapter-auto detected, forcing adapter-node")
 	build.AddVariables(map[string]string{"GCP_BUILDPACKS": "true"})
 }

--- a/core/providers/node/svelte.go
+++ b/core/providers/node/svelte.go
@@ -1,0 +1,40 @@
+package node
+
+import "github.com/railwayapp/railpack/core/generate"
+
+const DefaultSvelteKitStartCommand = "node build"
+
+func (p *NodeProvider) configureSvelteKit(ctx *generate.GenerateContext, build *generate.CommandStepBuilder) {
+	if !p.isSvelteKit() || !p.usesSvelteKitAdapterAuto() {
+		return
+	}
+
+	// adapter-auto recognizes this buildpack signal and emits an adapter-node server.
+	// GCP_BUILDPACKS is normally set by Google Cloud Buildpacks.
+	ctx.Logger.LogInfo("SvelteKit with adapter-auto detected, forcing adapter-node")
+	build.AddVariables(map[string]string{"GCP_BUILDPACKS": "true"})
+}
+
+func (p *NodeProvider) getSvelteKitStartCommand() string {
+	if !p.isSvelteKit() || !p.usesSvelteKitAdapterAuto() {
+		return ""
+	}
+
+	return DefaultSvelteKitStartCommand
+}
+
+func (p *NodeProvider) isSvelteKit() bool {
+	return p.isSvelteKitPackage(p.workspace.Root)
+}
+
+func (p *NodeProvider) isSvelteKitPackage(pkg *WorkspacePackage) bool {
+	if pkg == nil || pkg.PackageJson == nil {
+		return false
+	}
+
+	return pkg.PackageJson.hasDependency("svelte") && pkg.PackageJson.hasDependency("@sveltejs/kit")
+}
+
+func (p *NodeProvider) usesSvelteKitAdapterAuto() bool {
+	return p.hasDependency("@sveltejs/adapter-auto")
+}

--- a/core/providers/node/svelte_test.go
+++ b/core/providers/node/svelte_test.go
@@ -1,0 +1,24 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/railwayapp/railpack/core/generate"
+	testingUtils "github.com/railwayapp/railpack/core/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSvelteKitAdapterAuto(t *testing.T) {
+	ctx := testingUtils.CreateGenerateContext(t, "../../../examples/node-svelte-kit")
+	provider := NodeProvider{}
+	require.NoError(t, provider.Initialize(ctx))
+	require.NoError(t, provider.Plan(ctx))
+
+	require.Equal(t, DefaultSvelteKitStartCommand, ctx.Deploy.StartCmd)
+
+	step := ctx.GetStepByName("build")
+	require.NotNil(t, step)
+	build, ok := (*step).(*generate.CommandStepBuilder)
+	require.True(t, ok)
+	require.Equal(t, "true", build.Variables["GCP_BUILDPACKS"])
+}

--- a/core/providers/node/vite.go
+++ b/core/providers/node/vite.go
@@ -66,7 +66,3 @@ func (p *NodeProvider) getViteOutputDirectory(ctx *generate.GenerateContext) str
 
 	return DefaultViteOutputDirectory
 }
-
-func (p *NodeProvider) isSvelteKitPackage(pkg *WorkspacePackage) bool {
-	return pkg.PackageJson.hasDependency("svelte") && pkg.PackageJson.hasDependency("@sveltejs/kit")
-}

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -230,7 +230,8 @@ for the schema.
 
 ### HTTP Checks
 
-In addition to a basic `justBuild: true` check or an output assertion, you can also run an HTTP check that starts the container and asserts that a specific route returns an expected HTTP code:
+In addition to an output assertion, you can run an HTTP check that starts the
+container and asserts that a specific route returns an expected HTTP code:
 
 ```json
 {

--- a/examples/expo-spa/test.json
+++ b/examples/expo-spa/test.json
@@ -1,5 +1,9 @@
 [
   {
-    "justBuild": true
+    "httpCheck": {
+      "path": "/",
+      "expected": 200,
+      "internalPort": 80
+    }
   }
 ]

--- a/examples/node-svelte-kit/test.json
+++ b/examples/node-svelte-kit/test.json
@@ -1,13 +1,9 @@
 [
   {
-    "justBuild": true
+    "httpCheck": {
+      "path": "/",
+      "expected": 200,
+      "internalPort": 3000
+    }
   }
-  // TODO right now caddy is not automatically added to a svelte project
-  // {
-  //   "httpCheck": {
-  //     "path": "/",
-  //     "expected": 200,
-  //     "internalPort": 3000
-  //   }
-  // }
 ]

--- a/examples/node-vite-svelte/test.json
+++ b/examples/node-vite-svelte/test.json
@@ -1,5 +1,9 @@
 [
   {
-    "justBuild": true
+    "httpCheck": {
+      "path": "/",
+      "expected": 200,
+      "internalPort": 80
+    }
   }
 ]

--- a/examples/python-uv-workspace-postgres/test.json
+++ b/examples/python-uv-workspace-postgres/test.json
@@ -1,5 +1,5 @@
 [
   {
-    "justBuild": true
+    "expectedOutput": "Connection: postgresql://localhost/test"
   }
 ]

--- a/integration_tests/run_test.go
+++ b/integration_tests/run_test.go
@@ -52,7 +52,6 @@ type TestCase struct {
 	ExpectedOutput StringOrArray     `json:"expectedOutput"`
 	Envs           map[string]string `json:"envs"`
 	ConfigFilePath string            `json:"configFile"`
-	JustBuild      bool              `json:"justBuild"`
 	ShouldFail     bool              `json:"shouldFail"`
 	HTTPCheck      *HTTPCheck        `json:"httpCheck"`
 	StderrAllowed  bool              `json:"stderrAllowed"`
@@ -102,11 +101,6 @@ func TestExamplesIntegration(t *testing.T) {
 			// Check if both httpCheck and expectedOutput are specified in the same test case
 			if testCase.HTTPCheck != nil && len(testCase.ExpectedOutput) > 0 {
 				t.Fatalf("%s case-%d: cannot have both httpCheck and expectedOutput in the same test case", entry.Name(), i)
-			}
-
-			// Check if justBuild is used alongside other test cases
-			if testCase.JustBuild && len(testCases) > 1 {
-				t.Fatalf("%s: justBuild can only be used alone (no other test cases allowed in the same file)", entry.Name())
 			}
 		}
 
@@ -189,10 +183,6 @@ func TestExamplesIntegration(t *testing.T) {
 					}
 				}
 
-				if testCase.JustBuild {
-					return
-				}
-
 				// Start docker-compose services for this test case if they exist
 				composeConfig, err := detectAndStartCompose(examplePath, t)
 				if err != nil {
@@ -206,7 +196,6 @@ func TestExamplesIntegration(t *testing.T) {
 						}
 					})
 				}
-
 				networkName := ""
 				if composeConfig != nil {
 					networkName = composeConfig.NetworkName

--- a/mise.toml
+++ b/mise.toml
@@ -123,7 +123,7 @@ echo "Running example: 'docker run $example_name'"
 [tasks.test-update-snapshots]
 run = [
   "UPDATE_SNAPS=true go test -short ./...",
-  "find . -type d -name '__snapshots__' -exec git add -- {} +",
+  "find . -path ./tmp -prune -o -type d -name '__snapshots__' -exec git add -- {} +",
   "echo 'test: update snapshots' > $(git rev-parse --git-dir)/COMMIT_EDITMSG",
 ]
 


### PR DESCRIPTION
## Motivation

SvelteKit projects using `adapter-auto` need predictable server output and startup behavior for Railpack builds. The obsolete `justBuild` path also bypassed meaningful example assertions.

## Description

- Detects SvelteKit projects and configures adapter-node output through `GCP_BUILDPACKS`.
- Sets the appropriate SvelteKit server start command.
- Removes `justBuild` support and replaces affected examples with specific assertions.

## Test

- Added unit coverage for SvelteKit detection and configuration.
- Updated affected integration test definitions.