### PR TITLE
fix(mise): use musl binaries for linux host builds

### DIFF
--- a/.mise/tasks/mise-linux-shell
+++ b/.mise/tasks/mise-linux-shell
@@ -27,6 +27,8 @@ MISE_CACHE_DIR_GUEST=/var/cache/mise
 MISE_CONFIG_DIR_GUEST=/var/lib/mise/config
 # Host path of this repo (same path inside the machine via the /Users mount).
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RAILPACK_MISE_VERSION="$(<"${PROJECT_ROOT}/core/mise/version.txt")"
+RAILPACK_MISE_DIR=/tmp/railpack/mise
 RUNTIME_ROOT="${TMPDIR:-/tmp}"
 PROXY_STATE_DIR="${RUNTIME_ROOT%/}/railpack-linux-shell-${UID}"
 PROXY_STATE_FILE="${PROXY_STATE_DIR}/socat.state"
@@ -472,12 +474,13 @@ bootstrap_machine() {
 	wait_machine_ready
 
 	log "==> Bootstrapping machine packages"
+	# bash/git: mise's Python backend uses python-build to resolve versions
 	# docker-cli: talk to host Docker via DOCKER_HOST
 	# zsh: interactive shell
 	# libstdc++/libgcc/gcompat: many mise tools ship glibc/musl hybrids
 	# curl: mise installer
 	machine_run --root -- \
-		apk add docker-cli zsh curl libstdc++ libgcc gcompat
+		apk add bash git docker-cli zsh curl libstdc++ libgcc gcompat
 
 	log "==> Installing mise"
 	machine_run --root -- \
@@ -486,10 +489,21 @@ bootstrap_machine() {
 	machine_run --root \
 		-e MISE_INSTALL_MUSL=1 \
 		-e MISE_INSTALL_PATH=/usr/local/bin/mise \
+		-e "MISE_VERSION=${RAILPACK_MISE_VERSION}" \
 		-- sh /tmp/mise-install.sh
 
 	ensure_mise_dirs
 	setup_zsh
+}
+
+# Railpack caches a separate mise binary for host-side version resolution. Its
+# generic Linux download is glibc-linked, so reuse the pinned musl binary that
+# this Alpine machine already installed instead.
+configure_railpack_mise() {
+	log "==> Configuring Railpack to use musl mise ${RAILPACK_MISE_VERSION}"
+	machine_run -- mkdir -p "$RAILPACK_MISE_DIR"
+	machine_run -- \
+		ln -sfn /usr/local/bin/mise "${RAILPACK_MISE_DIR}/mise-${RAILPACK_MISE_VERSION}"
 }
 
 # mise stops at the ceiling and does not load configs *at* that path. Use the
@@ -616,6 +630,7 @@ else
 fi
 
 wait_machine_ready
+configure_railpack_mise
 
 CEILING="$(guest_ceiling)"
 

--- a/core/mise/install.go
+++ b/core/mise/install.go
@@ -18,15 +18,9 @@ import (
 )
 
 //go:embed version.txt
-var miseVersionRaw string
-
 var Version string
 
 const githubReleaseBase = "https://github.com/jdx/mise/releases/download"
-
-func init() {
-	Version = miseVersionRaw
-}
 
 // returns name of the mise binary based on the operating system
 func getBinaryName() string {
@@ -37,30 +31,30 @@ func getBinaryName() string {
 }
 
 // returns platform-specific mise github asset download name
-func getAssetName() (string, error) {
+func getAssetName(goos, goarch string) (string, error) {
 	var platform string
 
 	switch {
-	case runtime.GOOS == "linux" && runtime.GOARCH == "amd64":
-		platform = "linux-x64"
-	case runtime.GOOS == "linux" && runtime.GOARCH == "arm64":
-		platform = "linux-arm64"
-	case runtime.GOOS == "linux" && runtime.GOARCH == "arm":
-		platform = "linux-armv7"
-	case runtime.GOOS == "darwin" && runtime.GOARCH == "amd64":
+	case goos == "linux" && goarch == "amd64":
+		platform = "linux-x64-musl"
+	case goos == "linux" && goarch == "arm64":
+		platform = "linux-arm64-musl"
+	case goos == "linux" && goarch == "arm":
+		platform = "linux-armv7-musl"
+	case goos == "darwin" && goarch == "amd64":
 		platform = "macos-x64"
-	case runtime.GOOS == "darwin" && runtime.GOARCH == "arm64":
+	case goos == "darwin" && goarch == "arm64":
 		platform = "macos-arm64"
-	case runtime.GOOS == "windows" && runtime.GOARCH == "amd64":
+	case goos == "windows" && goarch == "amd64":
 		platform = "windows-x64"
-	case runtime.GOOS == "windows" && runtime.GOARCH == "arm64":
+	case goos == "windows" && goarch == "arm64":
 		platform = "windows-arm64"
 	default:
-		return "", fmt.Errorf("unsupported platform: %s %s", runtime.GOOS, runtime.GOARCH)
+		return "", fmt.Errorf("unsupported platform: %s %s", goos, goarch)
 	}
 
 	extension := "tar.gz"
-	if runtime.GOOS == "windows" {
+	if goos == "windows" {
 		extension = "zip"
 	}
 
@@ -101,7 +95,7 @@ func ensureInstalled(cacheDir string) (string, error) {
 }
 
 func downloadAndInstall(cacheDir string) error {
-	assetName, err := getAssetName()
+	assetName, err := getAssetName(runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return err
 	}

--- a/core/mise/mise_test.go
+++ b/core/mise/mise_test.go
@@ -1,6 +1,7 @@
 package mise
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -126,7 +127,36 @@ func TestMiseGetAllVersions(t *testing.T) {
 }
 
 func TestMiseVersion(t *testing.T) {
-	require.NotEmpty(t, miseVersionRaw, "mise version file should not be empty")
-	require.Equal(t, strings.TrimSpace(miseVersionRaw), miseVersionRaw, "mise version file should be trimmed")
-	require.Regexp(t, `^\d+\.\d+\.\d+$`, miseVersionRaw, "mise version should match format YYYY.M.D")
+	require.NotEmpty(t, Version, "mise version file should not be empty")
+	require.Equal(t, strings.TrimSpace(Version), Version, "mise version file should be trimmed")
+	require.Regexp(t, `^\d+\.\d+\.\d+$`, Version, "mise version should match format YYYY.M.D")
+}
+
+func TestGetAssetName(t *testing.T) {
+	tests := []struct {
+		goos     string
+		goarch   string
+		expected string
+	}{
+		{goos: "linux", goarch: "amd64", expected: "linux-x64-musl.tar.gz"},
+		{goos: "linux", goarch: "arm64", expected: "linux-arm64-musl.tar.gz"},
+		{goos: "linux", goarch: "arm", expected: "linux-armv7-musl.tar.gz"},
+		{goos: "darwin", goarch: "amd64", expected: "macos-x64.tar.gz"},
+		{goos: "darwin", goarch: "arm64", expected: "macos-arm64.tar.gz"},
+		{goos: "windows", goarch: "amd64", expected: "windows-x64.zip"},
+		{goos: "windows", goarch: "arm64", expected: "windows-arm64.zip"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.goos+"-"+tt.goarch, func(t *testing.T) {
+			assetName, err := getAssetName(tt.goos, tt.goarch)
+			require.NoError(t, err)
+			require.Equal(t, fmt.Sprintf("mise-v%s-%s", Version, tt.expected), assetName)
+		})
+	}
+}
+
+func TestGetAssetNameUnsupportedPlatform(t *testing.T) {
+	_, err := getAssetName("plan9", "amd64")
+	require.EqualError(t, err, "unsupported platform: plan9 amd64")
 }


### PR DESCRIPTION
## Motivation

Railpack’s default Linux mise binary is glibc-linked and can fail in Alpine or other musl-based environments.

## Description

Configure the Linux shell task to install and cache a pinned musl-compatible mise binary, and select musl assets for supported Linux architectures.

## Test

- Added unit coverage for platform-specific asset names and unsupported platforms.