### PR TITLE
feat(node): gracefully handle out of sync `package-lock.json`

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
@@ -105,7 +105,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
@@ -109,7 +109,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
@@ -105,7 +105,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
@@ -125,7 +125,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
@@ -109,7 +109,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -118,7 +118,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
@@ -114,7 +114,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -137,7 +137,7 @@
      "src": "packages/web/package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -114,7 +114,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -103,9 +103,6 @@
      "path": "/app/node_modules/.bin"
     },
     {
-     "cmd": "mkdir -p /app/node_modules/.cache"
-    },
-    {
      "dest": "package-lock.json",
      "src": "package-lock.json"
     },
@@ -114,7 +111,8 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm install"
+     "cmd": "sh -c 'npm ci'",
+     "customName": "npm ci"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
@@ -106,7 +106,7 @@
      "cmd": "mkdir -p /app/node_modules/.cache"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
@@ -118,7 +118,7 @@
      "src": "prisma"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
@@ -114,7 +114,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
@@ -122,7 +122,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
@@ -109,7 +109,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -153,7 +153,7 @@
      "src": "packages/utils/package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
@@ -109,7 +109,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
@@ -57,7 +57,8 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
   }
  },
  "steps": [
@@ -81,7 +82,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.7.7"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.7.11"
     }
    ],
    "name": "packages:mise",
@@ -164,7 +165,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.7.7"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.7.11"
     }
    ],
    "name": "packages:apt:runtime"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
@@ -45,10 +45,7 @@
     ],
     "include": [
      "/root/.cache",
-     ".",
-     "/opt/corepack",
-     "/mise/installs",
-     "/mise/shims"
+     "."
     ],
     "step": "build"
    }
@@ -60,8 +57,7 @@
    "NPM_CONFIG_FETCH_RETRIES": "5",
    "NPM_CONFIG_FUND": "false",
    "NPM_CONFIG_PRODUCTION": "false",
-   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
-   "RAILPACK_VERSION": "dev"
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false"
   }
  },
  "steps": [
@@ -72,10 +68,6 @@
    "commands": [
     {
      "path": "/mise/shims"
-    },
-    {
-     "dest": "mise.toml",
-     "src": "mise.toml"
     },
     {
      "customName": "create mise config",
@@ -89,7 +81,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.7.11"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.7.7"
     }
    ],
    "name": "packages:mise",
@@ -108,14 +100,6 @@
    "commands": [
     {
      "path": "/app/node_modules/.bin"
-    },
-    {
-     "dest": "package.json",
-     "src": "package.json"
-    },
-    {
-     "cmd": "sh -c 'npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate'",
-     "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
     },
     {
      "cmd": "mkdir -p /app/node_modules/.cache"
@@ -140,7 +124,6 @@
    "name": "install",
    "variables": {
     "CI": "true",
-    "COREPACK_HOME": "/opt/corepack",
     "NODE_ENV": "production",
     "NPM_CONFIG_FETCH_RETRIES": "5",
     "NPM_CONFIG_FUND": "false",
@@ -181,7 +164,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.7.11"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.7.7"
     }
    ],
    "name": "packages:apt:runtime"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -228,7 +228,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -228,7 +228,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_ruby-with-node_1.snap.json
@@ -181,7 +181,7 @@
      "src": "package.json"
     },
     {
-     "cmd": "npm ci"
+     "cmd": "npm install"
     }
    ],
    "inputs": [

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -33,8 +33,6 @@ var (
 	// PackageManifestFiles is the precedence order Railpack searches for a Node
 	// package manifest. package.json wins if both are present; package.json5 is
 	// supported because pnpm reads it natively (https://pnpm.io/package_json).
-	// Railpack's App.ReadJSON pipes through hujson, which accepts comments and
-	// trailing commas — the common subset of JSON5 used in real manifests.
 	PackageManifestFiles = []string{"package.json", "package.json5"}
 )
 

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -132,9 +132,13 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 			ctx.Logger.LogSuggestion("Add a `package-lock.json` for more deterministic installs", "/architecture/recommendations")
 		}
 
-		// ideally, `npm ci` should be used instead of `npm install`, but we always use npm install to avoid build failures
+		// ideally, `npm ci` should be used instead of `npm install`, but we default to npm install to avoid build failures
 		// https://github.com/railwayapp/railpack/pull/643
-		install.AddCommand(plan.NewExecCommand("npm install"))
+		installCmd := "npm install"
+		if customInstallCmd, _ := ctx.Env.GetConfigVariable("NODE_NPM_INSTALL"); customInstallCmd != "" {
+			installCmd = customInstallCmd
+		}
+		install.AddCommand(plan.NewExecCommand(installCmd))
 	case PackageManagerPnpm:
 		install.AddEnvVars(map[string]string{
 			"PNPM_HOME":      PNPM_HOME,

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -129,7 +129,7 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 	switch p {
 	case PackageManagerNpm:
 		if !ctx.App.HasFile("package-lock.json") {
-			ctx.Logger.LogWarn("No package-lock.json found, consider generating this file")
+			ctx.Logger.LogSuggestion("Add a `package-lock.json` for more deterministic installs", "/architecture/recommendations")
 		}
 
 		// ideally, `npm ci` should be used instead of `npm install`, but we always use npm install to avoid build failures
@@ -163,10 +163,10 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 			install.AddCommand(plan.NewExecCommand("pnpm add -g node-gyp"))
 		}
 
-		hasLockfile := ctx.App.HasFile("pnpm-lock.yaml")
-		if hasLockfile {
+		if ctx.App.HasFile("pnpm-lock.yaml") {
 			install.AddCommand(plan.NewExecCommand("pnpm install --frozen-lockfile --prefer-offline"))
 		} else {
+			ctx.Logger.LogSuggestion("Add a `pnpm-lock.yaml` for more deterministic installs", "/architecture/recommendations")
 			install.AddCommand(plan.NewExecCommand("pnpm install"))
 		}
 	case PackageManagerBun:

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -128,12 +128,13 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 
 	switch p {
 	case PackageManagerNpm:
-		hasLockfile := ctx.App.HasFile("package-lock.json")
-		if hasLockfile {
-			install.AddCommand(plan.NewExecCommand("npm ci"))
-		} else {
-			install.AddCommand(plan.NewExecCommand("npm install"))
+		if !ctx.App.HasFile("package-lock.json") {
+			ctx.Logger.LogWarn("No package-lock.json found, consider generating this file")
 		}
+
+		// ideally, `npm ci` should be used instead of `npm install`, but we always use npm install to avoid build failures
+		// https://github.com/railwayapp/railpack/pull/643
+		install.AddCommand(plan.NewExecCommand("npm install"))
 	case PackageManagerPnpm:
 		install.AddEnvVars(map[string]string{
 			"PNPM_HOME":      PNPM_HOME,

--- a/core/providers/node/package_manager_test.go
+++ b/core/providers/node/package_manager_test.go
@@ -5,10 +5,25 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/resolver"
 	testingUtils "github.com/railwayapp/railpack/core/testing"
 	"github.com/stretchr/testify/require"
 )
+
+func TestInstallDeps_NpmInstallOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "package-lock.json"), []byte("{}"), 0o644))
+
+	ctx := testingUtils.CreateGenerateContext(t, tmpDir)
+	ctx.Env.Variables["RAILPACK_NODE_NPM_INSTALL"] = "npm ci"
+	install := ctx.NewCommandStep("install")
+
+	PackageManagerNpm.installDeps(ctx, install, false)
+
+	require.Contains(t, install.Commands, plan.NewExecCommand("npm ci"))
+}
 
 func TestGetPackageManagerPackages_PnpmLockfileVersion(t *testing.T) {
 	tests := []struct {

--- a/docs/src/content/docs/architecture/recommendations.md
+++ b/docs/src/content/docs/architecture/recommendations.md
@@ -121,8 +121,15 @@ automatically includes `mise.lock` files in the build when present.
 Commit a `package-lock.json` (run `npm install` locally and check it in).
 Without one, installs are non-deterministic and you cannot use `npm ci`.
 
-When using npm as your package manager, customize the install command in
-`railpack.json` to use `npm ci` instead of the default `npm install`:
+When using npm as your package manager, set `RAILPACK_NODE_NPM_INSTALL` to
+opt into `npm ci` instead of the default `npm install`:
+
+```bash
+RAILPACK_NODE_NPM_INSTALL="npm ci"
+```
+
+You can also customize the install command in `railpack.json` if you need more
+control over the install step:
 
 ```json
 {

--- a/docs/src/content/docs/architecture/recommendations.md
+++ b/docs/src/content/docs/architecture/recommendations.md
@@ -115,3 +115,46 @@ locked = true
 
 Commit the generated `mise.lock` file alongside your `mise.toml`. Railpack
 automatically includes `mise.lock` files in the build when present.
+
+## Prefer `npm ci` for npm Node Projects
+
+When using npm as your package manager, customize the install command in
+`railpack.json` to use `npm ci` instead of the default `npm install`:
+
+```json
+{
+  "$schema": "https://schema.railpack.com",
+  "steps": {
+    "install": {
+      // Configuring a step auto-adds it to deploy with include: ["."]. Use an empty
+      // deployOutputs so install is not copied into the final image; node_modules
+      // still reach the image via the build step.
+      "deployOutputs": [],
+      "commands": [
+        // auto-generated commands from railpack
+        { "path": "/app/node_modules/.bin" },
+        { "src": "package-lock.json", "dest": "package-lock.json" },
+        { "src": "package.json", "dest": "package.json" },
+        // by default, `npm install` is used here; use `npm ci` for increased determinism
+        "npm ci"
+      ]
+    }
+  }
+}
+```
+
+Railpack defaults to `npm install` because `package.json` and
+`package-lock.json` often drift out of sync — usually from npm bugs rather than
+intentional local changes. That mismatch rarely shows up in development and only
+fails at image build time with:
+
+> `npm ci` can only install packages when your package.json and package-lock.json
+> or npm-shrinkwrap.json are in sync.
+
+Using `npm install` avoids build failures at the cost of weaker
+determinism. You should keep your lockfile in sync and opt into `npm ci` for:
+
+- **Deterministic installs** — exact versions from the lockfile, matching local
+  and CI environments, with no silent drift in production
+- **Faster installs** — `npm ci` installs from the lockfile instead of resolving
+  `package.json` again

--- a/docs/src/content/docs/architecture/recommendations.md
+++ b/docs/src/content/docs/architecture/recommendations.md
@@ -116,10 +116,17 @@ locked = true
 Commit the generated `mise.lock` file alongside your `mise.toml`. Railpack
 automatically includes `mise.lock` files in the build when present.
 
-## Prefer `npm ci` for npm Node Projects
+## Commit Package Manager Lockfiles
 
-Commit a `package-lock.json` (run `npm install` locally and check it in).
-Without one, installs are non-deterministic and you cannot use `npm ci`.
+Always generate and commit a lockfile from your package manager
+(`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `Cargo.lock`,
+`poetry.lock`, etc.), and keep it in sync with your dependency manifests.
+
+Without a lockfile (or with one that has drifted) installs resolve versions
+at build time. That leads to non-deterministic images and therefore possible
+bugs that don't occur locally.
+
+## Prefer `npm ci` for npm Node Projects
 
 When using npm as your package manager, set `RAILPACK_NODE_NPM_INSTALL` to
 opt into `npm ci` instead of the default `npm install`:

--- a/docs/src/content/docs/architecture/recommendations.md
+++ b/docs/src/content/docs/architecture/recommendations.md
@@ -118,6 +118,9 @@ automatically includes `mise.lock` files in the build when present.
 
 ## Prefer `npm ci` for npm Node Projects
 
+Commit a `package-lock.json` (run `npm install` locally and check it in).
+Without one, installs are non-deterministic and you cannot use `npm ci`.
+
 When using npm as your package manager, customize the install command in
 `railpack.json` to use `npm ci` instead of the default `npm install`:
 

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -92,6 +92,7 @@ Railpack determines the start command in the following order:
 | `RAILPACK_NO_SPA`                | Disable SPA mode                        | `true`                                  |
 | `RAILPACK_SPA_OUTPUT_DIR`        | Directory containing built static files | `dist`                                  |
 | `RAILPACK_PRUNE_DEPS`            | Remove development dependencies         | `true`                                  |
+| `RAILPACK_NODE_NPM_INSTALL`      | Custom npm install command              | `npm ci`                                |
 | `RAILPACK_NODE_PRUNE_CMD`        | Custom command to prune dependencies    | `npm prune --omit=dev --ignore-scripts` |
 | `RAILPACK_NODE_INSTALL_PATTERNS` | Custom patterns to install dependencies | `prisma`                                |
 | `RAILPACK_ANGULAR_PROJECT`       | Name of the Angular project to build    | `my-app`                                |

--- a/examples/node-npm/railpack.json
+++ b/examples/node-npm/railpack.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "steps": {
+    "install": {
+      // Railpack defaults to `npm install` so out-of-sync lockfiles still succeed.
+      // Opt into `npm ci` when the lockfile is kept in sync for deterministic installs.
+      //
+      // Configuring a step auto-adds it to deploy with include: ["."]. Use an empty
+      // deployOutputs so install is not copied into the final image; node_modules
+      // still reach the image via the build step.
+      "deployOutputs": [],
+      "commands": [
+        { "path": "/app/node_modules/.bin" },
+        { "src": "package-lock.json", "dest": "package-lock.json" },
+        { "src": "package.json", "dest": "package.json" },
+        "npm ci"
+      ]
+    }
+  }
+}

--- a/examples/npm-out-of-sync-package-lock/README.md
+++ b/examples/npm-out-of-sync-package-lock/README.md
@@ -1,0 +1,9 @@
+# Out-of-sync npm lockfile
+
+This example intentionally keeps `package-lock.json` out of sync with
+`package.json` to reproduce an `npm ci` failure. The lockfile was generated
+with only `dayjs` installed; `is-number` was then added to `package.json`
+without regenerating the lockfile.
+
+Do not run `npm install` in this directory unless you are recreating the
+out-of-sync fixture.

--- a/examples/npm-out-of-sync-package-lock/index.js
+++ b/examples/npm-out-of-sync-package-lock/index.js
@@ -1,0 +1,4 @@
+import dayjs from "dayjs";
+import isNumber from "is-number";
+
+console.log(`npm dependencies loaded: ${dayjs("2026-07-21").format("YYYY-MM-DD")} ${isNumber(42)}`);

--- a/examples/npm-out-of-sync-package-lock/package-lock.json
+++ b/examples/npm-out-of-sync-package-lock/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "npm-out-of-sync-package-lock",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-out-of-sync-package-lock",
+      "version": "1.0.0",
+      "dependencies": {
+        "dayjs": "1.11.13"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/npm-out-of-sync-package-lock/package.json
+++ b/examples/npm-out-of-sync-package-lock/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "npm-out-of-sync-package-lock",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "dayjs": "1.11.13",
+    "is-number": "7.0.0"
+  }
+}

--- a/examples/npm-out-of-sync-package-lock/test.json
+++ b/examples/npm-out-of-sync-package-lock/test.json
@@ -1,0 +1,7 @@
+[
+  {
+    "expectedOutput": "npm dependencies loaded: 2026-07-21 true",
+    // NPM_CONFIG_PRODUCTION currently emits a deprecation warning during installation.
+    "stderrAllowed": true
+  }
+]


### PR DESCRIPTION
## Motivation

A user's lock file can get out of sync for many different reasons. Most of which are triggered by misc npm bugs. This does not show up in dev and only becomes an issue when a user attempts to build an image and receives this message:

> `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.

## Implementation Choices

Not using `npm ci` introduces the following risks:

* Non-deterministic builds. The lockfile check ensures that the _exact_ package versions are installed that are used locally, in CI, etc. Not asserting this check means the prod env can drift from dev and introduce hard-to-debug problems. The biggest issue here from my POV is users won't even know this is happening.
* Slightly slower builds (`npm install` has to resolve package.json, where `npm ci` just looks at the lockfile). Not a big deal IMHO.

Moving to `npm install` _shouldn't_ not impact users. `npm ci` nukes `node_modules`, but this is not cached so it doesn't matter for us.

Here are two ways we could handle this:

### 1. Use `npm install`

Swap `npm ci` with `npm install`. More builds succeed, users are less frustrated, and our code and the user's mental model of what we are doing remain simple.

**My choice:** this decreases build determinism, which I really don't like, but it's the most simple and least failure-prone.

### 2. Run a custom install script

The only benefit this gives the user is a warning message in their builtkit logs. Very few people will see this and we'd have to bundle this custom (more complex) script into railpack and then one of the layers. Ugh.

I don't think there's any benefit here.

```bash
#!/bin/sh

if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
    if ! npm ci; then
        echo >&2 "Warning: lockfile is inconsistent; falling back to npm install."
        echo >&2 "Run npm install locally and commit the updated lockfile."

        rm -rf node_modules
        npm install
    fi
else
    npm install
fi
```

### 3. `npm install` by default, opt-in `npm ci`

Switch the default install script, allow a user to opt-in to `npm ci` via an environment variable config.

I don't think this is worth it. They can just customize the install script using `railpack.json` and we include something about this in the docs.

## Links

* https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable
* https://docs.npmjs.com/cli/v10/commands/npm-ci?v=true