### PR TITLE
test(frontend): run e2e test on frontend image

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -99,6 +99,46 @@ jobs:
           cache-from: type=registry,ref=${{ env.PRODUCTION_BUILDER_IMAGE_REF }}
           cache-to: type=inline
 
+  frontend-e2e:
+    name: Frontend E2E
+    needs: [build-images, find-examples]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+
+      - name: Build Frontend Image
+        run: |
+          docker build \
+            -f images/alpine/frontend/Dockerfile \
+            -t railpack-frontend:local \
+            .
+
+      - name: Select Random Example
+        id: example
+        env:
+          EXAMPLES: ${{ needs.find-examples.outputs.examples }}
+        run: |
+          example=$(jq -r '.[]' <<< "$EXAMPLES" | shuf -n 1)
+          echo "Selected $example"
+          echo "name=$example" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Build Plan
+        env:
+          EXAMPLE: ${{ steps.example.outputs.name }}
+        run: |
+          mkdir -p tmp/frontend-plan
+          mise run cli plan "examples/$EXAMPLE" --out tmp/frontend-plan/railpack-plan.json
+
+      - name: Build Example With Frontend Image
+        env:
+          EXAMPLE: ${{ steps.example.outputs.name }}
+        run: |
+          docker buildx build \
+            --build-arg BUILDKIT_SYNTAX="railpack-frontend:local" \
+            -f tmp/frontend-plan/railpack-plan.json \
+            "examples/$EXAMPLE"
+
   test:
     needs: [build-images, find-examples]
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,6 +51,9 @@ jobs:
           # we need the full history to compare the mise version against origin/main
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1
+        with:
+          version: ${{ env.DOCKER_VERSION }}
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
@@ -107,6 +110,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
 
+      # GitHub's preinstalled Docker 28 uses the classic image store, which disables
+      # Railpack's merge operations. Fresh Docker 29+ daemons use containerd by default.
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1
+        with:
+          version: ${{ env.DOCKER_VERSION }}
+
       - name: Build Frontend Image
         run: |
           docker build \
@@ -151,6 +160,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1
+        with:
+          version: ${{ env.DOCKER_VERSION }}
 
       - name: Cache Go modules and build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
@@ -215,6 +227,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1
+        with:
+          version: ${{ env.DOCKER_VERSION }}
 
       - name: Cache Go modules and build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
       # duplicated on the integration-tests.yml job, keep these in sync
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1
+        with:
+          version: ${{ env.DOCKER_VERSION }}
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
@@ -61,6 +64,9 @@ jobs:
       # duplicated on the integration-tests.yml job, keep these in sync
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1
+        with:
+          version: ${{ env.DOCKER_VERSION }}
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
@@ -104,6 +110,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1
+        with:
+          version: ${{ env.DOCKER_VERSION }}
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nx-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nx-next_1.snap.json
@@ -86,7 +86,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.7.7"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.7.11"
     }
    ],
    "name": "packages:mise",
@@ -198,7 +198,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.7.7"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.7.11"
     }
    ],
    "name": "packages:apt:runtime"

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -86,6 +86,12 @@ Multiple Docker images are used in Railpack:
   * `images/debian/build` used during the llb build process. These contain common tools, languages, mise, etc that might be used during the build process. Note that all of these utilities are *not* included in the final image in order to reduce the total image size.
   * `images/debian/runtime` a bare bones debian image used at runtime. The tools, build artifacts, etc generated during the railpack build are added to this base image.
 
+Build the runtime image for local development with:
+
+```bash
+mise run image-runtime-build
+```
+
 ## Custom frontend
 
 You can build with a [custom BuildKit frontend](/guides/custom-frontend), but
@@ -94,7 +100,10 @@ this is a bit tedious for local iteration.
 The frontend needs to be built into an image and accessible to the BuildKit instance:
 
 ```bash
-mise run image-runtime-build
+docker build \
+  -f images/alpine/frontend/Dockerfile \
+  -t railpack-frontend:local \
+  .
 ```
 
 Then, generate a build plan for an app:
@@ -106,7 +115,7 @@ mise run cli plan examples/node-bun --out test/railpack-plan.json
 With the image you built previously, you can now run the build:
 
 ```bash
-docker buildx \
+docker buildx build \
   --build-arg BUILDKIT_SYNTAX="railpack-frontend:local" \
   -f test/railpack-plan.json \
   examples/node-bun
@@ -115,14 +124,20 @@ docker buildx \
 You can also use the `buildctl` command to run BuildKit directly. This is helpful as it's a lower level command which
 exposes helpful debugging flags. However, you can't reference the locally built image without loading it into a registry first.
 
-This is done automatically for you with `image-runtime-build` but you must start the registry first with `image-run-registry`.
+Start the registry, then build and push the frontend image with
+`image-frontend-build`:
+
+```bash
+mise run image-run-registry
+mise run image-frontend-build
+```
 
 Then, you can run the build with the locally-build frontend:
 
 ```bash
 buildctl build \
   --frontend=gateway.v0 \
-  --opt source=railpack-frontend:local \
+  --opt source=host.docker.internal:7890/railpack-frontend:local \
   --local context=examples/node-bun \
   --local dockerfile=test \
   --output type=docker,name=test | docker load
@@ -143,7 +158,7 @@ buildctl build \
   --frontend=gateway.v0 \
   --opt source=host.docker.internal:7890/railpack-frontend:local \
   --local context=examples/node-bun \
-  --local dockerfile=tmp/frontend-plan \
+  --local dockerfile=test \
   --export-cache type=registry,ref=host.docker.internal:7890/node-bun:cache,mode=max \
   --import-cache type=registry,ref=host.docker.internal:7890/node-bun:cache
 ```
@@ -155,8 +170,8 @@ Note that the cache arguments are different than what `docker buildx`. The equiv
 docker buildx build \
   --build-arg BUILDKIT_SYNTAX="host.docker.internal:7890/railpack-frontend:local" \
   --cache-to=type=registry,ref=host.docker.internal:7890/node-bun:cache,mode=max \
-  --cache-from=type=registry,ref=host.docker.internal:7890/node-bun:cache \ 
-  -f tmp/frontend-plan/railpack-plan.json \
+  --cache-from=type=registry,ref=host.docker.internal:7890/node-bun:cache \
+  -f test/railpack-plan.json \
   examples/node-bun
 ```
 
@@ -165,14 +180,15 @@ Debugging a buildkit related problem? Enable debug logging:
 ```bash
 buildctl --debug build \
   --frontend=gateway.v0 \
-  --opt source=railpack-frontend:local \
+  --opt source=host.docker.internal:7890/railpack-frontend:local \
   --local context=examples/node-bun \
+  --local dockerfile=test \
   --progress=plain \
-  --trace=tmp/builtctl-build-trace.log \
+  --trace=tmp/buildctl-build-trace.log \
   --debug-json-cache-metrics stdout
 ```
 
-Quick note about `builtctl` vs `docker buildx`. These two ways of invoking the railpack frontend handle arguments differently:
+Quick note about `buildctl` vs `docker buildx`. These two ways of invoking the railpack frontend handle arguments differently:
 
 * `--build-arg` prefixes the argument with `build-arg:`.
 * `--opt` does not prefix the build arg at all. You must prefix args with `build-arg:` if they are

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,6 +1,9 @@
 # define all required variables for CI, so we can limit the configuration and logic within GHA to test more of the CI process locally
 
 [env]
+# Check https://docs.docker.com/engine/release-notes/ for newer stable releases.
+DOCKER_VERSION = "v29.6.2"
+
 PRODUCTION_CONTAINER_REGISTRY = "ghcr.io"
 PRODUCTION_GITHUB_REPOSITORY = "railwayapp/railpack"
 PRODUCTION_MISE_TAG = "mise-${RAILPACK_MISE_VERSION}"


### PR DESCRIPTION
## Motivation

Frontend builds need coverage across representative examples in CI. The workflow ensures end-to-end builds use the frontend image and produce consistent build plans.

## Description

- Adds a CI job that tests randomized frontend examples.
- Generates and validates build plans during integration testing.
- Enables local Railpack image usage for frontend builds.
- Updates affected builder and runtime snapshot versions.

## Test

- Frontend integration tests run through the new GitHub Actions workflow.
- Updated snapshots reflect the current image versions.