### PR TITLE
refactor(node): avoid duplicate detection log messages

### DIFF
--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -93,6 +93,11 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 	}
 
 	isSPA := p.isSPA(ctx)
+	if !isSPA && !ctx.Env.IsConfigVariableTruthy("NO_SPA") && p.hasCustomStartCommand(ctx) {
+		// it's easy for a user to trip over this wire and not understand that it would impact SPA deployment since using the start script
+		// is somewhat if a railpack-convention, so let's make it clear to them.
+		ctx.Logger.LogInfo("Custom start command detected, skipping Caddy start")
+	}
 
 	miseStep := ctx.GetMiseStepBuilder()
 	p.InstallMisePackages(ctx, miseStep)
@@ -219,6 +224,7 @@ func (p *NodeProvider) Build(ctx *generate.GenerateContext, build *generate.Comm
 		}
 	} else if _, projectName, ok := p.resolveNxDeployPackage(ctx); ok {
 		// TODO this `resolveNxDeployPackage` logic feels messy, we should refactor this a bit
+		ctx.Logger.LogInfo("Using Nx app %s", projectName)
 
 		// Nx infers targets from plugins; root package.json often has no build script
 		build.AddCommands([]plan.Command{

--- a/core/providers/node/nx.go
+++ b/core/providers/node/nx.go
@@ -132,7 +132,6 @@ func (p *NodeProvider) resolveNxDeployPackage(ctx *generate.GenerateContext) (*W
 		for _, pkg := range packages {
 			if matchesNxAppSelector(pkg, selector) {
 				name := nxProjectName(pkg)
-				ctx.Logger.LogInfo("Using Nx app %s (RAILPACK_NX_APP=%s)", name, selector)
 				return pkg, name, true
 			}
 		}
@@ -143,9 +142,7 @@ func (p *NodeProvider) resolveNxDeployPackage(ctx *generate.GenerateContext) (*W
 
 	if len(packages) == 1 {
 		pkg := packages[0]
-		name := nxProjectName(pkg)
-		ctx.Logger.LogInfo("Using Nx app %s", name)
-		return pkg, name, true
+		return pkg, nxProjectName(pkg), true
 	}
 
 	names := make([]string, 0, len(packages))

--- a/core/providers/node/spa.go
+++ b/core/providers/node/spa.go
@@ -31,9 +31,6 @@ func (p *NodeProvider) isSPA(ctx *generate.GenerateContext) bool {
 
 	// If there is a custom start command, we don't want to deploy with Caddy as an SPA
 	if p.hasCustomStartCommand(ctx) {
-		// it's easy for a user to trip over this wire and not understand that it would impact SPA deployment since using the start script
-		// is somewhat if a railpack-convention, so let's make it clear to them.
-		ctx.Logger.LogInfo("Custom start command detected, skipping Caddy start")
 		return false
 	}
 


### PR DESCRIPTION
## Motivation

Node planning calls detection helpers multiple times, which caused identical informational messages to be logged repeatedly.

## Description

- Make SPA detection side-effect-free and emit the custom-start warning once from the planning boundary.
- Keep Nx package resolution side-effect-free and log the selected app at the build call site.

## Test

- `mise run check`
- `mise run test`
- `mise run test-integration-cwd` from `examples/node-npm`
- `mise run test-integration -- -run "TestExamplesIntegration/node-vite-react-router-spa/case-0$"`