### PR TITLE
docs: improve code block styling

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,6 +34,15 @@ export default defineConfig({
         "@fontsource/inter/400.css",
         "@fontsource/inter/600.css",
       ],
+      expressiveCode: {
+        defaultProps: {
+          overridesByLang: {
+            "bash,sh,shell,zsh": {
+              frame: "code",
+            },
+          },
+        },
+      },
       plugins: [
         starlightPageActions(),
         starlightLlmsTxt({

--- a/docs/src/tailwind.css
+++ b/docs/src/tailwind.css
@@ -130,6 +130,31 @@ site-search button[data-open-modal] {
 /* MARKDOWN CONTENT STYLES */
 
 .sl-markdown-content {
+  /* Match wrapper sizes to custom headings so anchor icons stay aligned. */
+  .sl-heading-wrapper.level-h1 {
+    @apply text-3xl;
+  }
+
+  .sl-heading-wrapper.level-h2 {
+    @apply text-2xl;
+  }
+
+  .sl-heading-wrapper.level-h3 {
+    @apply text-xl;
+  }
+
+  .sl-heading-wrapper.level-h4 {
+    @apply text-lg;
+  }
+
+  .sl-heading-wrapper.level-h5 {
+    @apply text-base;
+  }
+
+  .sl-heading-wrapper.level-h6 {
+    @apply text-sm;
+  }
+
   h1 {
     @apply text-3xl font-bold dark:text-white;
   }
@@ -162,7 +187,7 @@ site-search button[data-open-modal] {
     @apply text-violet-600 dark:text-violet-400 no-underline hover:underline hover:text-violet-700 dark:hover:text-violet-300;
   }
 
-  code {
+  :not(pre) > code {
     @apply font-mono bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-1.5 py-0.5 text-sm text-gray-600 dark:text-gray-300 rounded-md;
   }
 
@@ -173,6 +198,16 @@ site-search button[data-open-modal] {
 
   :not(a, strong, em, del, span, input, code, br) + hr {
     @apply my-8;
+  }
+}
+
+/* Keep code-copy actions discoverable without requiring hover. */
+.expressive-code .copy button {
+  opacity: 0.75;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Motivation

The documentation code blocks had inconsistent framing, oversized heading anchors, and hidden copy controls.

## Description

Align heading wrapper sizing with custom typography, use plain code frames for shell snippets, prevent inline-code styles from leaking into fenced blocks, and keep copy buttons visible.