### PR TITLE
docs: add mise GPG verification guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,11 @@ There are normal unit tests, snapshot tests, and integration tests. The integrat
 
 * Do not test log output.
 
+# Documentation
+
+- Assume the reader knows the documentation is about Railpack. Avoid
+  redundantly naming Railpack when the subject is clear from context.
+
 # File Conventions
 
 - Markdown files in @docs/src/content/docs/ should be limited to 80 columns

--- a/docs/src/content/docs/architecture/recommendations.md
+++ b/docs/src/content/docs/architecture/recommendations.md
@@ -116,6 +116,28 @@ locked = true
 Commit the generated `mise.lock` file alongside your `mise.toml`. Railpack
 automatically includes `mise.lock` files in the build when present.
 
+## GPG Verification
+
+Mise can verify OpenPGP signatures for tools that publish them. Enable
+verification for all supported tools in your `mise.toml`:
+
+```toml
+[settings]
+gpg_verify = true
+
+[settings.node]
+verify = true
+```
+
+Railpack disables Node.js GPG verification by default because newly released
+versions may not have a public key available yet. A project-local `mise.toml`
+takes precedence over Railpack's generated `/etc/mise/config.toml`, so
+`verify = true` reverses that default.
+
+With verification enabled, the build fails when mise cannot verify a tool's
+downloaded assets. Pin tool versions to avoid unexpectedly selecting a new
+release whose signatures are not yet available.
+
 ## Commit Package Manager Lockfiles
 
 Always generate and commit a lockfile from your package manager

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -20,6 +20,8 @@ the docs for each language that Railpack supports.
 - [Deno](languages/deno)
 - [Rust](languages/rust)
 - [Elixir](languages/elixir)
+- [Gleam](languages/gleam)
+- [C/C++](languages/cpp)
 - [Shell scripts](languages/shell)
 
 ---

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -30,6 +30,10 @@ We officially support actively maintained [Node.js LTS
 versions](https://nodejs.org/en/about/previous-releases). Older versions of Node.js will likely still
 work but are not officially supported.
 
+Node.js GPG verification is disabled by default; see the [GPG verification
+recommendation](/architecture/recommendations#gpg-verification)
+to enable it in your project.
+
 ### Bun
 
 The Bun version is determined in the following order:


### PR DESCRIPTION
## Motivation

Users need a supported way to enable mise GPG verification at the project level
without changing default build behavior. The supported language list also
omitted active providers.

## Description

- Documents mise GPG settings, including the project-local Node override, and
  links the guidance from the Node docs.
- Adds Gleam and C/C++ to the supported language list.
- Adds documentation guidance to avoid redundant product naming.

## Links

- Relates to #365
