### PR TITLE
docs(bun): extract Bun documentation into dedicated page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -180,6 +180,7 @@ export default defineConfig({
           label: "Languages",
           items: [
             { label: "Node", link: "/languages/node" },
+            { label: "Bun", link: "/languages/bun" },
             { label: "Python", link: "/languages/python" },
             { label: "Go", link: "/languages/golang" },
             { label: "PHP", link: "/languages/php" },

--- a/docs/src/content/docs/languages/bun.md
+++ b/docs/src/content/docs/languages/bun.md
@@ -1,0 +1,36 @@
+---
+title: Bun
+description: Building Bun applications with Railpack
+---
+
+Railpack supports Bun as a JavaScript runtime and package manager.
+
+## Detection
+
+Railpack selects Bun through JavaScript package manager detection. Bun is
+selected when the `packageManager` field declares it, or when no
+higher-priority package manager is configured and an `engines.bun` field,
+`bun.lock`, or `bun.lockb` file exists.
+
+Bun is also installed when a package script or configured start command invokes
+it.
+
+## Versions
+
+The Bun version can be configured using:
+
+- The `RAILPACK_BUN_VERSION` environment variable
+- The `packageManager` field in `package.json`, such as `bun@1.2.0`
+- The `engines.bun` field in `package.json`
+- A `.bun-version`, `mise.toml`, or `.tool-versions` file
+
+The version defaults to `latest` when none is configured.
+
+## Node.js Compatibility
+
+Some Bun projects also require Node.js for Corepack, scripts, frameworks, or
+native module compilation. Railpack installs Node.js automatically when it is
+needed.
+
+Bun applications otherwise use the same framework, monorepo, and SPA detection
+described in the [Node.js documentation](/languages/node).

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -34,29 +34,6 @@ Node.js GPG verification is disabled by default; see the [GPG verification
 recommendation](/architecture/recommendations#gpg-verification)
 to enable it in your project.
 
-### Bun
-
-The Bun version is determined in the following order:
-
-- Set via the `RAILPACK_BUN_VERSION` environment variable
-- Read from the `.bun-version` file
-- Read from the `engines.bun` field in `package.json`
-- Read from `mise.toml` or `.tool-versions` files
-- Defaults to `latest`
-
-If Bun is used as the package manager, Node.js will still be installed in the
-following cases:
-
-- If you define a `packageManager` field in your `package.json` (for Corepack
-  support)
-- If any script in your `package.json` contains `node`
-- If you're using Astro or Vite
-- During installation for native module compilation (node-gyp)
-
-When Node.js isn't required in the final image but is needed during installation
-(for native modules), Node.js will be installed via Mise and will respect
-[version specifications](#versions).
-
 ## Runtime Variables
 
 These variables are available at runtime:
@@ -92,7 +69,6 @@ Railpack determines the start command in the following order:
 | Variable                         | Description                             | Example                                 |
 | -------------------------------- | --------------------------------------- | --------------------------------------- |
 | `RAILPACK_NODE_VERSION`          | Override the Node.js version            | `22`                                    |
-| `RAILPACK_BUN_VERSION`           | Override the Bun version                | `1.2`                                   |
 | `RAILPACK_NO_SPA`                | Disable SPA mode                        | `true`                                  |
 | `RAILPACK_SPA_OUTPUT_DIR`        | Directory containing built static files | `dist`                                  |
 | `RAILPACK_PRUNE_DEPS`            | Remove development dependencies         | `true`                                  |


### PR DESCRIPTION
## Motivation

Bun-specific guidance was embedded in the Node documentation, making it harder to find and maintain independently.

## Description

- Adds a dedicated Bun language documentation page.
- Removes Bun-specific content from the Node page and adds Bun to the documentation navigation.