### PR TITLE
docs(resolving-errors): document resolving Playwright errors

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -135,6 +135,10 @@ export default defineConfig({
           link: "/faq",
         },
         {
+          label: "Resolving Errors",
+          link: "/resolving-errors",
+        },
+        {
           label: "Installation",
           link: "/installation",
         },

--- a/docs/src/content/docs/resolving-errors.md
+++ b/docs/src/content/docs/resolving-errors.md
@@ -1,0 +1,16 @@
+---
+title: Resolving Errors
+description: Solutions to common build and deployment errors
+---
+
+## Playwright
+
+### Why does the Playwright installation hang or fail?
+
+Outdated versions of Playwright can cause browser installation to hang, fail,
+or behave unexpectedly. Update Playwright and regenerate your lock file with
+your package manager so the lock file pins the latest version.
+
+Browser installation is opt-in. Follow the setup instructions for
+[Node.js](/languages/node#playwright) or
+[Python](/languages/python#playwright) to enable it.


### PR DESCRIPTION
## Motivation

Users need clear guidance for diagnosing and resolving Playwright-related errors.

## Description

Adds a Playwright error-resolution guide and registers it in the documentation site configuration so it is discoverable.