### PR TITLE
test: mount plan-declared secrets during frontend smoke tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -143,8 +143,17 @@ jobs:
         env:
           EXAMPLE: ${{ steps.example.outputs.name }}
         run: |
+          # This smoke test does not load test.json, so provide non-sensitive values
+          # for every plan-declared secret through BuildKit's secret mount interface.
+          secret_args=()
+          while IFS= read -r secret; do
+            export "$secret=frontend-e2e"
+            secret_args+=(--secret "id=$secret,env=$secret")
+          done < <(jq -r '.secrets[]?' tmp/frontend-plan/railpack-plan.json)
+
           docker buildx build \
             --build-arg BUILDKIT_SYNTAX="railpack-frontend:local" \
+            "${secret_args[@]}" \
             -f tmp/frontend-plan/railpack-plan.json \
             "examples/$EXAMPLE"
 


### PR DESCRIPTION
## Motivation

Frontend smoke tests can fail when applications require secrets declared in their build plan.

## Description

Mounts plan-declared secrets into the frontend smoke-test environment so tests run with the required secret inputs.

## Test

Covered by the frontend integration smoke-test workflow.
