### PR TITLE
test(core): update FrankenPHP image versions in snapshots

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -103,7 +103,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.2.32-bookworm"
+     "image": "dunglas/frankenphp:php8.2.33-bookworm"
     }
    ],
    "name": "packages:image"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -103,7 +103,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.2.32-bookworm"
+     "image": "dunglas/frankenphp:php8.2.33-bookworm"
     }
    ],
    "name": "packages:image"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
@@ -24,7 +24,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.2.32-bookworm"
+     "image": "dunglas/frankenphp:php8.2.33-bookworm"
     }
    ],
    "name": "packages:image"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
@@ -18,7 +18,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.4.23-bookworm"
+     "image": "dunglas/frankenphp:php8.4.24-bookworm"
     }
    ],
    "name": "packages:image"


### PR DESCRIPTION
## Motivation

FrankenPHP image versions changed, causing the generated build-plan expectations for PHP examples to become outdated.

## Description

Update the PHP build-plan expectations to reference the current FrankenPHP image versions.

## Test

- Verified the affected PHP example expectations against the updated image versions.