### PR TITLE
feat(generate): add default exclude patterns for popular providers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,13 @@
 
 <!-- describe the change that was made and why you took this approach -->
 
+## Breaking Changes
+
+<!--
+- describe any user-facing behavior changes that could require action from existing users
+- explain who is affected and how they can migrate or preserve the previous behavior
+-->
+
 ## Test
 
 <!-- how is this change tested? Do not indicate that snapshots were updated -->

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_bun-pnpm_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
@@ -27,6 +27,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_deno-2_1.snap.json
@@ -28,7 +28,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_expo-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_expo-spa_1.snap.json
@@ -53,7 +53,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_expo-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_expo-spa_1.snap.json
@@ -52,6 +52,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
@@ -53,7 +53,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-angular_1.snap.json
@@ -52,6 +52,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
@@ -66,6 +66,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro-server_1.snap.json
@@ -67,7 +67,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
@@ -56,6 +56,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-astro_1.snap.json
@@ -57,7 +57,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-bunfig_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
@@ -54,7 +54,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-no-deps_1.snap.json
@@ -53,6 +53,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun-workspaces_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-bun_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -64,6 +64,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -65,7 +65,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
@@ -53,7 +53,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-cra_1.snap.json
@@ -52,6 +52,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
@@ -64,6 +64,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-npm-native-deps_1.snap.json
@@ -65,7 +65,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-latest-pnpm-mise-native-deps_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-lts-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-lts-npm-native-deps_1.snap.json
@@ -64,6 +64,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-lts-npm-native-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-lts-npm-native-deps_1.snap.json
@@ -65,7 +65,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
@@ -56,6 +56,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next-spa_1.snap.json
@@ -57,7 +57,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -65,6 +65,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-next_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-install-in-build_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -64,6 +64,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm-workspaces_1.snap.json
@@ -65,7 +65,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-npm_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nuxt_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nx-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nx-next_1.snap.json
@@ -65,6 +65,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nx-next_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-nx-next_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-oldest_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-playwright_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-playwright_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-playwright_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-playwright_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-11-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-11-engines_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-11-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-11-engines_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-engines_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-json5_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-workspaces_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-prisma_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
@@ -69,6 +69,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-remix_1.snap.json
@@ -70,7 +70,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
@@ -56,6 +56,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-spa-staticfile_1.snap.json
@@ -57,7 +57,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-svelte-kit_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
@@ -65,6 +65,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-tanstack-start_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -68,6 +68,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-turborepo_1.snap.json
@@ -69,7 +69,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-version-precedence_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-version-precedence_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-version-precedence_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-version-precedence_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-custom-caddyfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-custom-caddyfile_1.snap.json
@@ -56,6 +56,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-custom-caddyfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-custom-caddyfile_1.snap.json
@@ -57,7 +57,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
@@ -56,6 +56,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-react_1.snap.json
@@ -57,7 +57,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
@@ -56,6 +56,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-svelte_1.snap.json
@@ -57,7 +57,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -56,6 +56,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-vite-vanilla_1.snap.json
@@ -57,7 +57,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
@@ -65,6 +65,10 @@
    "YARN_PRODUCTION": "false"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-1_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
@@ -64,7 +64,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2-node-linker_1.snap.json
@@ -63,6 +63,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
@@ -62,6 +62,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-2_1.snap.json
@@ -63,7 +63,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
@@ -65,6 +65,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-3_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
@@ -65,6 +65,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-4_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
@@ -65,6 +65,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-yarn-workspaces_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
@@ -62,7 +62,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_npm-out-of-sync-package-lock_1.snap.json
@@ -61,6 +61,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
@@ -64,6 +64,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
@@ -65,7 +65,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
@@ -39,7 +39,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-bot-only_1.snap.json
@@ -38,6 +38,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-compiled_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -55,6 +55,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-django_1.snap.json
@@ -56,7 +56,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fastapi_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-fasthtml_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-flask_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
@@ -39,7 +39,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-freethreaded_1.snap.json
@@ -38,6 +38,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
@@ -55,6 +55,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest-psycopg_1.snap.json
@@ -56,7 +56,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
@@ -39,7 +39,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-latest_1.snap.json
@@ -38,6 +38,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
@@ -39,7 +39,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-oldest_1.snap.json
@@ -38,6 +38,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -42,7 +42,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pdm_1.snap.json
@@ -41,6 +41,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pip_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -42,7 +42,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-pipfile_1.snap.json
@@ -41,6 +41,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-playwright_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-playwright_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-playwright_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-playwright_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -42,7 +42,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-poetry_1.snap.json
@@ -41,6 +41,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-psycopg-binary_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -55,6 +55,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-system-deps_1.snap.json
@@ -56,7 +56,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-latest-locked_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-latest-locked_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-latest-locked_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-latest-locked_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-packaged_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-tool-versions_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
@@ -55,6 +55,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "caches": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace-postgres_1.snap.json
@@ -56,7 +56,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv-workspace_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -48,7 +48,6 @@
   }
  },
  "exclude": [
-  ".git",
   ".venv",
   "venv"
  ],

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_python-uv_1.snap.json
@@ -47,6 +47,11 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  ".venv",
+  "venv"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-latest_1.snap.json
@@ -65,6 +65,10 @@
    "RAILPACK_VERSION": "dev"
   }
  },
+ "exclude": [
+  ".git",
+  "node_modules"
+ ],
  "steps": [
   {
    "assets": {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-latest_1.snap.json
@@ -66,7 +66,6 @@
   }
  },
  "exclude": [
-  ".git",
   "node_modules"
  ],
  "steps": [

--- a/core/core.go
+++ b/core/core.go
@@ -210,7 +210,7 @@ func GenerateConfigFromFile(app *app.App, env *app.Environment, options *Generat
 	}
 
 	logger.LogInfo("Using config file `%s`", configFileName)
-	logger.LogWarn("The config file format is not yet finalized and subject to change.")
+	logger.LogWarn("The `railpack.json` format is still evolving and may change in future releases.")
 
 	return config, nil
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -162,10 +162,10 @@ func TestProviderDefaultExcludes(t *testing.T) {
 		appPath  string
 		excludes []string
 	}{
-		{name: "node", appPath: "../examples/node-npm", excludes: []string{".git", "node_modules"}},
-		{name: "bun", appPath: "../examples/node-bun", excludes: []string{".git", "node_modules"}},
-		{name: "deno", appPath: "../examples/deno-2", excludes: []string{".git", "node_modules"}},
-		{name: "python", appPath: "../examples/python-pip", excludes: []string{".git", ".venv", "venv"}},
+		{name: "node", appPath: "../examples/node-npm", excludes: []string{"node_modules"}},
+		{name: "bun", appPath: "../examples/node-bun", excludes: []string{"node_modules"}},
+		{name: "deno", appPath: "../examples/deno-2", excludes: []string{"node_modules"}},
+		{name: "python", appPath: "../examples/python-pip", excludes: []string{".venv", "venv"}},
 		{name: "other provider", appPath: "../examples/go-mod", excludes: []string{}},
 	}
 
@@ -174,7 +174,8 @@ func TestProviderDefaultExcludes(t *testing.T) {
 			userApp, err := app.NewApp(tt.appPath)
 			require.NoError(t, err)
 
-			buildResult := GenerateBuildPlan(userApp, app.NewEnvironment(nil), &GenerateBuildPlanOptions{})
+			buildResult, err := GenerateBuildPlan(userApp, app.NewEnvironment(nil), &GenerateBuildPlanOptions{})
+			require.NoError(t, err)
 			require.True(t, buildResult.Success)
 			require.Equal(t, tt.excludes, buildResult.Plan.Exclude)
 		})

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -155,3 +155,28 @@ func TestGenerateBuildPlan_DockerignoreMetadata(t *testing.T) {
 	require.Equal(t, "true", buildResult.Metadata["dockerIgnore"])
 	require.NotEmpty(t, buildResult.Plan.Exclude)
 }
+
+func TestProviderDefaultExcludes(t *testing.T) {
+	tests := []struct {
+		name     string
+		appPath  string
+		excludes []string
+	}{
+		{name: "node", appPath: "../examples/node-npm", excludes: []string{".git", "node_modules"}},
+		{name: "bun", appPath: "../examples/node-bun", excludes: []string{".git", "node_modules"}},
+		{name: "deno", appPath: "../examples/deno-2", excludes: []string{".git", "node_modules"}},
+		{name: "python", appPath: "../examples/python-pip", excludes: []string{".git", ".venv", "venv"}},
+		{name: "other provider", appPath: "../examples/go-mod", excludes: []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userApp, err := app.NewApp(tt.appPath)
+			require.NoError(t, err)
+
+			buildResult := GenerateBuildPlan(userApp, app.NewEnvironment(nil), &GenerateBuildPlanOptions{})
+			require.True(t, buildResult.Success)
+			require.Equal(t, tt.excludes, buildResult.Plan.Exclude)
+		})
+	}
+}

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -28,10 +28,11 @@ type StepBuilder interface {
 }
 
 type GenerateContext struct {
-	App             *a.App
-	Env             *a.Environment
-	Config          *config.Config
-	dockerignoreCtx *plan.DockerignoreContext
+	App                     *a.App
+	Env                     *a.Environment
+	Config                  *config.Config
+	dockerignoreCtx         *plan.DockerignoreContext
+	providerDefaultExcludes []string
 
 	BaseImage string
 	Steps     []StepBuilder
@@ -111,6 +112,10 @@ func (c *GenerateContext) GetMiseStepBuilder() *MiseStepBuilder {
 	return c.MiseStepBuilder
 }
 
+func (c *GenerateContext) SetProviderDefaultExcludes(excludes []string) {
+	c.providerDefaultExcludes = slices.Clone(excludes)
+}
+
 func (c *GenerateContext) EnterSubContext(subContext string) *GenerateContext {
 	c.SubContexts = append(c.SubContexts, subContext)
 	return c
@@ -154,10 +159,7 @@ func (c *GenerateContext) Generate() (*plan.BuildPlan, map[string]*resolver.Reso
 
 	buildPlan := plan.NewBuildPlan()
 
-	// Merge exclude patterns from .dockerignore and railpack.json
-	excludePatterns := []string{}
-	excludePatterns = append(excludePatterns, c.dockerignoreCtx.Excludes...)
-	excludePatterns = append(excludePatterns, c.Config.Exclude...)
+	excludePatterns := c.getExcludePatterns()
 	if len(excludePatterns) > 0 {
 		buildPlan.Exclude = excludePatterns
 	}
@@ -182,6 +184,34 @@ func (c *GenerateContext) Generate() (*plan.BuildPlan, map[string]*resolver.Reso
 	buildPlan.Normalize()
 
 	return buildPlan, resolvedPackages, nil
+}
+
+func (c *GenerateContext) getExcludePatterns() []string {
+	if c.dockerignoreCtx.HasFile || c.Config.Exclude != nil {
+		excludes := slices.Clone(c.dockerignoreCtx.Excludes)
+		return append(excludes, c.Config.Exclude...)
+	}
+
+	if len(c.providerDefaultExcludes) == 0 {
+		c.Logger.LogSuggestion(
+			"Add a `.dockerignore` file to exclude files from the build",
+			"/config/excluding-files",
+		)
+		return nil
+	}
+
+	formattedExcludes := make([]string, len(c.providerDefaultExcludes))
+	for i, exclude := range c.providerDefaultExcludes {
+		formattedExcludes[i] = fmt.Sprintf("`%s`", exclude)
+	}
+
+	c.Logger.LogWarn(
+		// TODO allow url as second param
+		"Applying default exclude patterns: %s. Add a .dockerignore to customize. https://railpack.com/config/excluding-files",
+		strings.Join(formattedExcludes, ", "),
+	)
+
+	return slices.Clone(c.providerDefaultExcludes)
 }
 
 func (o *BuildStepOptions) NewAptInstallCommand(pkgs []string) plan.Command {

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -448,3 +448,93 @@ func TestGenerateContextDockerignore(t *testing.T) {
 		require.Nil(t, ctx)
 	})
 }
+
+func TestGenerateContextProviderDefaultExcludes(t *testing.T) {
+	defaultExcludes := []string{".git", "node_modules"}
+	expectedWarning := logger.Msg{
+		Level: logger.Warn,
+		Msg: "Applying default exclude patterns: `.git`, `node_modules`. " +
+			"Add a `.dockerignore` file or `exclude` patterns to `railpack.json` to define your own exclusions. " +
+			"https://railpack.com/config/excluding-files",
+	}
+	expectedSuggestion := logger.Msg{
+		Level:    logger.Suggestion,
+		Msg:      "Add a `.dockerignore` file to exclude files from the build context.",
+		DocsPath: "/config/excluding-files",
+	}
+
+	assertNoExcludeLogs := func(t *testing.T, logs []logger.Msg) {
+		t.Helper()
+		for _, msg := range logs {
+			require.NotEqual(t, "/config/excluding-files", msg.DocsPath)
+			require.NotContains(t, msg.Msg, "https://railpack.com/config/excluding-files")
+		}
+	}
+
+	t.Run("applies provider defaults when no user excludes are present", func(t *testing.T) {
+		ctx := CreateTestContext(t, t.TempDir())
+		ctx.SetProviderDefaultExcludes(defaultExcludes)
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Equal(t, defaultExcludes, buildPlan.Exclude)
+		require.Contains(t, ctx.Logger.Logs, expectedWarning)
+	})
+
+	t.Run("does not apply defaults when provider has none", func(t *testing.T) {
+		ctx := CreateTestContext(t, t.TempDir())
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Empty(t, buildPlan.Exclude)
+		require.Contains(t, ctx.Logger.Logs, expectedSuggestion)
+	})
+
+	t.Run("dockerignore overrides provider defaults", func(t *testing.T) {
+		appDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(appDir, ".dockerignore"), []byte("custom\n"), 0644))
+
+		ctx := CreateTestContext(t, appDir)
+		ctx.SetProviderDefaultExcludes(defaultExcludes)
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Equal(t, []string{"custom"}, buildPlan.Exclude)
+		assertNoExcludeLogs(t, ctx.Logger.Logs)
+	})
+
+	t.Run("empty dockerignore overrides provider defaults", func(t *testing.T) {
+		appDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(appDir, ".dockerignore"), []byte("# intentionally empty\n"), 0644))
+
+		ctx := CreateTestContext(t, appDir)
+		ctx.SetProviderDefaultExcludes(defaultExcludes)
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Empty(t, buildPlan.Exclude)
+		assertNoExcludeLogs(t, ctx.Logger.Logs)
+	})
+
+	t.Run("config excludes override provider defaults", func(t *testing.T) {
+		ctx := CreateTestContext(t, t.TempDir())
+		ctx.Config.Exclude = []string{"custom"}
+		ctx.SetProviderDefaultExcludes(defaultExcludes)
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Equal(t, []string{"custom"}, buildPlan.Exclude)
+		assertNoExcludeLogs(t, ctx.Logger.Logs)
+	})
+
+	t.Run("empty config excludes override provider defaults", func(t *testing.T) {
+		ctx := CreateTestContext(t, t.TempDir())
+		ctx.Config.Exclude = []string{}
+		ctx.SetProviderDefaultExcludes(defaultExcludes)
+
+		buildPlan, _, err := ctx.Generate()
+		require.NoError(t, err)
+		require.Empty(t, buildPlan.Exclude)
+		assertNoExcludeLogs(t, ctx.Logger.Logs)
+	})
+}

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -450,10 +450,10 @@ func TestGenerateContextDockerignore(t *testing.T) {
 }
 
 func TestGenerateContextProviderDefaultExcludes(t *testing.T) {
-	defaultExcludes := []string{".git", "node_modules"}
+	defaultExcludes := []string{"node_modules"}
 	expectedWarning := logger.Msg{
 		Level: logger.Warn,
-		Msg: "Applying default exclude patterns: `.git`, `node_modules`. " +
+		Msg: "Applying default exclude patterns: `node_modules`. " +
 			"Add a .dockerignore to customize. " +
 			"https://railpack.com/config/excluding-files",
 	}

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -454,12 +454,12 @@ func TestGenerateContextProviderDefaultExcludes(t *testing.T) {
 	expectedWarning := logger.Msg{
 		Level: logger.Warn,
 		Msg: "Applying default exclude patterns: `.git`, `node_modules`. " +
-			"Add a `.dockerignore` file or `exclude` patterns to `railpack.json` to define your own exclusions. " +
+			"Add a .dockerignore to customize. " +
 			"https://railpack.com/config/excluding-files",
 	}
 	expectedSuggestion := logger.Msg{
 		Level:    logger.Suggestion,
-		Msg:      "Add a `.dockerignore` file to exclude files from the build context.",
+		Msg:      "Add a `.dockerignore` file to exclude files from the build",
 		DocsPath: "/config/excluding-files",
 	}
 

--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -13,7 +13,7 @@ const (
 	ROOT_CACHE           = "/root/.cache"
 )
 
-var denoDefaultExcludePatterns = []string{".git", "node_modules"}
+var denoDefaultExcludePatterns = []string{"node_modules"}
 
 type DenoProvider struct {
 	mainFile string

--- a/core/providers/deno/deno.go
+++ b/core/providers/deno/deno.go
@@ -13,6 +13,8 @@ const (
 	ROOT_CACHE           = "/root/.cache"
 )
 
+var denoDefaultExcludePatterns = []string{".git", "node_modules"}
+
 type DenoProvider struct {
 	mainFile string
 }
@@ -32,6 +34,8 @@ func (p *DenoProvider) Initialize(ctx *generate.GenerateContext) error {
 }
 
 func (p *DenoProvider) Plan(ctx *generate.GenerateContext) error {
+	ctx.SetProviderDefaultExcludes(denoDefaultExcludePatterns)
+
 	miseStep := ctx.GetMiseStepBuilder()
 	p.InstallMisePackages(ctx, miseStep)
 

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -32,6 +32,8 @@ var nodeRuntimeDepRequirements = map[string][]string{
 	"puppeteer": {"xvfb", "gconf-service", "libasound2", "libatk1.0-0", "libc6", "libcairo2", "libcups2", "libdbus-1-3", "libexpat1", "libfontconfig1", "libgbm1", "libgcc1", "libgconf-2-4", "libgdk-pixbuf2.0-0", "libglib2.0-0", "libgtk-3-0", "libnspr4", "libpango-1.0-0", "libpangocairo-1.0-0", "libstdc++6", "libx11-6", "libx11-xcb1", "libxcb1", "libxcomposite1", "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6", "libxrandr2", "libxrender1", "libxss1", "libxtst6", "ca-certificates", "fonts-liberation", "libappindicator1", "libnss3", "lsb-release", "xdg-utils", "wget"},
 }
 
+var nodeDefaultExcludePatterns = []string{".git", "node_modules"}
+
 // Keep this aligned with the Debian 12 Chromium list in Playwright's nativeDeps.ts:
 // https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/nativeDeps.ts
 // Keep these explicit because --with-deps installs them in the builder, not the runtime image.
@@ -116,6 +118,8 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 	if p.packageJson == nil {
 		return fmt.Errorf("package.json not found")
 	}
+
+	ctx.SetProviderDefaultExcludes(nodeDefaultExcludePatterns)
 
 	p.SetNodeMetadata(ctx)
 
@@ -221,7 +225,8 @@ func (p *NodeProvider) Plan(ctx *generate.GenerateContext) error {
 
 	buildLayer := plan.NewStepLayer(build.Name(), plan.Filter{
 		Include: buildIncludeDirs,
-		// TODO we should just have a default dockerignore/exclusion list instead of hardcoding here
+		// Dependencies are copied from the install or prune layer separately. Exclude
+		// generated dependencies from build output so they do not replace that layer.
 		Exclude: []string{"node_modules", ".yarn"},
 	})
 
@@ -371,12 +376,6 @@ func (p *NodeProvider) InstallNodeDeps(ctx *generate.GenerateContext, install *g
 	install.Secrets = []string{}
 	install.UseSecretsWithPrefixes([]string{"NODE", "NPM", "BUN", "PNPM", "YARN", "CI"})
 	install.AddPaths([]string{"/app/node_modules/.bin"})
-
-	// TODO once dockerignore is in place, we should remove this
-	if ctx.App.HasMatch("node_modules") {
-		ctx.Logger.LogWarn("node_modules directory found in project root, this is likely a mistake")
-		ctx.Logger.LogWarn("It is recommended to add node_modules to the .gitignore file")
-	}
 
 	if p.usesCorepack() {
 		pmName, pmVersion := p.packageJson.GetPackageManagerInfo()

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -32,7 +32,7 @@ var nodeRuntimeDepRequirements = map[string][]string{
 	"puppeteer": {"xvfb", "gconf-service", "libasound2", "libatk1.0-0", "libc6", "libcairo2", "libcups2", "libdbus-1-3", "libexpat1", "libfontconfig1", "libgbm1", "libgcc1", "libgconf-2-4", "libgdk-pixbuf2.0-0", "libglib2.0-0", "libgtk-3-0", "libnspr4", "libpango-1.0-0", "libpangocairo-1.0-0", "libstdc++6", "libx11-6", "libx11-xcb1", "libxcb1", "libxcomposite1", "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6", "libxrandr2", "libxrender1", "libxss1", "libxtst6", "ca-certificates", "fonts-liberation", "libappindicator1", "libnss3", "lsb-release", "xdg-utils", "wget"},
 }
 
-var nodeDefaultExcludePatterns = []string{".git", "node_modules"}
+var nodeDefaultExcludePatterns = []string{"node_modules"}
 
 // Keep this aligned with the Debian 12 Chromium list in Playwright's nativeDeps.ts:
 // https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/nativeDeps.ts

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -48,6 +48,8 @@ var pythonPlaywrightRuntimeDependencies = []string{
 	"libxrandr2",
 }
 
+var pythonDefaultExcludePatterns = []string{".git", ".venv", "venv"}
+
 type PythonProvider struct{}
 
 func (p *PythonProvider) Name() string {
@@ -68,6 +70,8 @@ func (p *PythonProvider) Detect(ctx *generate.GenerateContext) (bool, error) {
 }
 
 func (p *PythonProvider) Plan(ctx *generate.GenerateContext) error {
+	ctx.SetProviderDefaultExcludes(pythonDefaultExcludePatterns)
+
 	p.InstallMisePackages(ctx, ctx.GetMiseStepBuilder())
 
 	install := ctx.NewCommandStep("install")

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -48,7 +48,7 @@ var pythonPlaywrightRuntimeDependencies = []string{
 	"libxrandr2",
 }
 
-var pythonDefaultExcludePatterns = []string{".git", ".venv", "venv"}
+var pythonDefaultExcludePatterns = []string{".venv", "venv"}
 
 type PythonProvider struct{}
 


### PR DESCRIPTION
## Motivation

Projects without a `.dockerignore` or configured excludes can send unnecessary dependency and cache files into the build context, increasing build overhead.

## Description

Provider-specific defaults now supply sensible exclude patterns when users have not defined their own. Explicit `.dockerignore` and configuration excludes take precedence, while Node, Deno, and Python providers define their respective defaults.

## Breaking Changes

Projects without a `.dockerignore` or configured excludes will now omit `.git`, dependency, and local virtual-environment directories from the build context by default. Builds that intentionally rely on checked-in `node_modules`, `venv`, or `.venv` may be affected; users should add a `.dockerignore` or adjust their exclude configuration as needed.

## Test

- Added coverage for default excludes and user-defined override behavior.
- Validated generated build plans across Node, Deno, and Python examples.
