### PR TITLE
feat(mise): support .NET idiomatic version files

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-api_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_dotnet-api_1.snap.json
@@ -46,6 +46,10 @@
      "path": "/mise/shims"
     },
     {
+     "dest": "global.json",
+     "src": "global.json"
+    },
+    {
      "customName": "create mise config",
      "name": "generated-mise-toml",
      "path": "/etc/mise/config.toml"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-latest_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-latest_1.snap.json
@@ -86,7 +86,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.7.18"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.0"
     }
    ],
    "name": "packages:mise",
@@ -175,7 +175,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.7.18"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.0"
     }
    ],
    "name": "packages:apt:runtime"

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -22,7 +22,7 @@
  "steps": [
   {
    "assets": {
-    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\", \"bun\", \"deno\"]\n  minimum_release_age = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
+    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\", \"bun\", \"deno\", \"dotnet\"]\n  minimum_release_age = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
    },
    "commands": [
     {

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -367,6 +367,7 @@ var miseIdiomaticFiles = []string{
 	// .bun-version is a community convention, not officially supported by Bun
 	".bun-version",
 	".yvmrc",
+	"global.json",
 }
 
 // https://mise.jdx.dev/configuration.html#configuration-hierarchy

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -21,7 +21,7 @@ import (
 const (
 	InstallDir                = "/tmp/railpack/mise"
 	TestInstallDir            = "/tmp/railpack/mise-test"
-	IdiomaticVersionFileTools = "python,node,ruby,elixir,go,java,yarn,bun,deno"
+	IdiomaticVersionFileTools = "python,node,ruby,elixir,go,java,yarn,bun,deno,dotnet"
 	// applied only to the first GetLatestVersion check to skip very recent releases
 	MinimumReleaseAge = "14d"
 )

--- a/docs/src/content/docs/config/mise.md
+++ b/docs/src/content/docs/config/mise.md
@@ -48,7 +48,7 @@ into the build. This includes:
   `.config/mise/conf.d/*.toml`
 - **Idiomatic version files**: `.ruby-version`, `.python-version`,
   `.python-versions`, `.node-version`, `.nvmrc`, `.go-version`,
-  `.java-version`, `.sdkmanrc`, `.bun-version`, `.yvmrc`
+  `.java-version`, `.sdkmanrc`, `.bun-version`, `.yvmrc`, `global.json`
 - **Lock files**: `mise.lock` files co-located with any detected
   `*.toml` config
 

--- a/docs/src/content/docs/languages/dotnet.md
+++ b/docs/src/content/docs/languages/dotnet.md
@@ -14,7 +14,7 @@ Your project will be detected as a Dotnet application if a `*.csproj` file exist
 The Dotnet version is determined in the following order:
 
 - Read `TargetFramework` from the first `*.csproj` file found in the project
-- Read `version` from the `global.json` file in the project root
+- Read `sdk.version` from the `global.json` file in the project root
 - Set via the `RAILPACK_DOTNET_VERSION` environment variable
 - Defaults to `6.0.428`
 


### PR DESCRIPTION
## Motivation

Projects using global.json should have .NET SDK selection handled consistently with other idiomatic version files.

## Description

Enable dotnet in the generated mise idiomatic-version setting and copy global.json into the mise setup step so sdk.version selects the SDK. Clarify the supported field in the .NET and mise documentation.

## Test

- mise run check
- mise run test
- mise run test-integration-cwd for examples/dotnet-api
- mise run test-integration-cwd for examples/dotnet-cli

## Links

- https://mise.jdx.dev/configuration.html#idiomatic-version-files