### PR TITLE
feat(mise): support Rust idiomatic version files

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_rust-custom-toolchain_1.snap.json
@@ -44,6 +44,10 @@
      "path": "/mise/shims"
     },
     {
+     "dest": "rust-toolchain.toml",
+     "src": "rust-toolchain.toml"
+    },
+    {
      "customName": "create mise config",
      "name": "generated-mise-toml",
      "path": "/etc/mise/config.toml"

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -22,7 +22,7 @@
  "steps": [
   {
    "assets": {
-    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\", \"bun\", \"deno\", \"dotnet\"]\n  minimum_release_age = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
+    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\", \"bun\", \"deno\", \"dotnet\", \"rust\"]\n  minimum_release_age = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
    },
    "commands": [
     {

--- a/core/generate/mise_step_builder.go
+++ b/core/generate/mise_step_builder.go
@@ -364,6 +364,7 @@ var miseIdiomaticFiles = []string{
 	".sdkmanrc",
 	".exenv-version",
 	".deno-version",
+	"rust-toolchain.toml",
 	// .bun-version is a community convention, not officially supported by Bun
 	".bun-version",
 	".yvmrc",

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -21,7 +21,7 @@ import (
 const (
 	InstallDir                = "/tmp/railpack/mise"
 	TestInstallDir            = "/tmp/railpack/mise-test"
-	IdiomaticVersionFileTools = "python,node,ruby,elixir,go,java,yarn,bun,deno,dotnet"
+	IdiomaticVersionFileTools = "python,node,ruby,elixir,go,java,yarn,bun,deno,dotnet,rust"
 	// applied only to the first GetLatestVersion check to skip very recent releases
 	MinimumReleaseAge = "14d"
 )

--- a/docs/src/content/docs/config/mise.md
+++ b/docs/src/content/docs/config/mise.md
@@ -48,7 +48,8 @@ into the build. This includes:
   `.config/mise/conf.d/*.toml`
 - **Idiomatic version files**: `.ruby-version`, `.python-version`,
   `.python-versions`, `.node-version`, `.nvmrc`, `.go-version`,
-  `.java-version`, `.sdkmanrc`, `.bun-version`, `.yvmrc`, `global.json`
+  `.java-version`, `.sdkmanrc`, `.deno-version`, `rust-toolchain.toml`,
+  `.bun-version`, `.yvmrc`, `global.json`
 - **Lock files**: `mise.lock` files co-located with any detected
   `*.toml` config
 

--- a/docs/src/content/docs/languages/rust.md
+++ b/docs/src/content/docs/languages/rust.md
@@ -16,12 +16,15 @@ Your project will be detected as a Rust application if any of these conditions a
 The Rust version is determined in the following order:
 
 - Any mise-supported version file (`mise.toml`, `.tool-versions`, etc).
-- Read from the `toolchain.channel` field in the `rust-toolchain.toml` file
 - Read from the `package.rust-version` field in the `Cargo.toml` file
 - Read from the `.rust-version` or `rust-version.txt` file
 - Set via the `RAILPACK_RUST_VERSION` environment variable
 - Set via the `package.edition` field in the `Cargo.toml` file
 - Defaults to `1.89`
+
+Mise treats `rust-toolchain.toml` as an idiomatic version file. Its
+`toolchain.channel` field selects the Rust version, while `profile`,
+`components`, and `targets` are passed to rustup as installation options.
 
 ## Runtime Variables
 


### PR DESCRIPTION
## Motivation

Rust projects using `rust-toolchain.toml` should have their requested toolchain and rustup installation options honored through mise.

## Description

- Enable Rust idiomatic version-file discovery in mise.
- Copy `rust-toolchain.toml` into the mise install step so `channel`, `profile`, `components`, and `targets` are applied.
- Document Rust toolchain parsing and the supported configuration file.

## Test

- Built `examples/rust-custom-toolchain` and verified `rust-toolchain.toml` resolves Rust 1.59 through the idiomatic version-file path.
- Built `examples/rust-custom-version` and verified the `Cargo.toml` `rust-version` fallback remains unchanged.

## Links

- https://mise.jdx.dev/configuration.html#idiomatic-version-files