### PR TITLE
fix(node): infer npm from package-lock.json

### DIFF
--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -581,7 +581,15 @@ func (p *NodeProvider) getPackageManager(ctx *generate.GenerateContext) PackageM
 		}
 	}
 
-	ctx.Logger.LogWarn("No node package manager detected, using npm")
+	if app.HasFile("package-lock.json") {
+		ctx.Logger.LogWarn("package-lock.json detected, assuming npm")
+	} else {
+		ctx.Logger.LogWarn("No node package manager detected, using npm")
+	}
+	ctx.Logger.LogSuggestion(
+		"Specify the package manager and version explicitly",
+		"/config/recommendations#specify-the-node-package-manager-version",
+	)
 
 	return PackageManagerNpm
 }

--- a/docs/src/content/docs/config/recommendations.md
+++ b/docs/src/content/docs/config/recommendations.md
@@ -79,6 +79,43 @@ jq = "1.7.1"
 See [Mise Configuration](/config/mise) for how Railpack detects and applies
 mise config during builds.
 
+## Specify the Node and Package Manager Version Explicitly
+
+By default, Railpack will infer the node and package manager version for you.
+However, it's much better to explicitly define this in your project, both for your
+team and Railpack. This keeps local development, CI, and production builds perfectly aligned.
+
+Package managers supported by mise can be pinned in `mise.toml`:
+
+```toml
+[tools]
+node = "22.14.0"
+pnpm = "10.15.1"
+```
+
+Mise is the recommended path, but you can use `package.json` configuration as well.
+
+```json
+{
+  "packageManager": "npm@11.4.2"
+}
+```
+
+The `devEngines` field can also document the required package manager and
+instruct supporting tooling to reject a different version:
+
+```json
+{
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "11.4.2",
+      "onFail": "error"
+    }
+  }
+}
+```
+
 ## Prefer Mise Over Apt, pipx, and Other Installers
 
 When you need a CLI tool or utility, prefer installing it with mise over Apt,

--- a/examples/node-npm/test.json
+++ b/examples/node-npm/test.json
@@ -1,5 +1,7 @@
 [
   {
+    // this project does not define the npm package manager explicitly, so we are assuming that
+    // that railpack infers it via package-lock.json
     "expectedOutput": "hello from Node v23.5.0",
     // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
     // Currently causes: npm warn config production Use `--omit=dev` instead.


### PR DESCRIPTION
## Motivation

Projects with a `package-lock.json` but no explicit package-manager configuration should reliably use npm. Users should also be guided toward pinning Node and package-manager versions for reproducible builds.

## Description

- Infer npm when `package-lock.json` is present and provide a targeted configuration recommendation.
- Document supported ways to pin Node and package-manager versions.
- Update the Node npm integration example to reflect this behavior.