### PR TITLE
feat(mise): support pnpm idiomatic version files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,11 @@
 
 ## Test
 
-<!-- how is this change tested? Do not indicate that snapshots were updated -->
+<!--
+- Describe only targeted validation that specifically exercises this change.
+- Do not state or imply that all unit tests were run.
+- Do not indicate that snapshots were updated.
+-->
 
 ## Links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,9 @@ There are normal unit tests, snapshot tests, and integration tests. The integrat
 - Markdown files in @docs/src/content/docs/ should be limited to 80 columns
 - Do not fix indentation or formatting manually. This is corrected automatically using `mise run check`
 - NEVER commit language-specific cache or build artifacts (e.g. Python `__pycache__/`, `*.pyc`, `*.pyo` files). If you encounter build artifacts that are not excluded by .gitignore, add appropriate patterns to .gitignore to exclude them
+
+# Mise Functionality
+
+If work requires deep knowledge of mise internals, clone the project into `tmp/mise` and investigate the source code.
+
+https://github.com/jdx/mise

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,6 @@ There are normal unit tests, snapshot tests, and integration tests. The integrat
 
 # File Conventions
 
-- Markdown files in @docs/src/content/docs/ should be limited to 80 columns
 - Do not fix indentation or formatting manually. This is corrected automatically using `mise run check`
 - NEVER commit language-specific cache or build artifacts (e.g. Python `__pycache__/`, `*.pyc`, `*.pyo` files). If you encounter build artifacts that are not excluded by .gitignore, add appropriate patterns to .gitignore to exclude them
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,7 @@ There are normal unit tests, snapshot tests, and integration tests. The integrat
 If work requires deep knowledge of mise internals, clone the project into `tmp/mise` and investigate the source code.
 
 https://github.com/jdx/mise
+
+## Pull Requests
+
+When writing a pull request add a "---\nPlease remove this to indicate you've reviewed and deslopped your PR description"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-corepack_1.snap.json
@@ -45,10 +45,7 @@
     ],
     "include": [
      "/root/.cache",
-     ".",
-     "/opt/corepack",
-     "/mise/installs",
-     "/mise/shims"
+     "."
     ],
     "step": "build"
    }
@@ -80,7 +77,7 @@
     },
     {
      "cmd": "mise install",
-     "customName": "install mise packages: node"
+     "customName": "install mise packages: node, pnpm"
     }
    ],
    "inputs": [
@@ -106,14 +103,6 @@
      "path": "/app/node_modules/.bin"
     },
     {
-     "dest": "package.json",
-     "src": "package.json"
-    },
-    {
-     "cmd": "sh -c 'npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate'",
-     "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
-    },
-    {
      "cmd": "mkdir -p /app/node_modules/.cache"
     },
     {
@@ -123,6 +112,12 @@
     {
      "dest": "pnpm-lock.yaml",
      "src": "pnpm-lock.yaml"
+    },
+    {
+     "path": "/opt/pnpm"
+    },
+    {
+     "cmd": "pnpm add -g node-gyp"
     },
     {
      "cmd": "pnpm install --frozen-lockfile --prefer-offline"
@@ -136,7 +131,6 @@
    "name": "install",
    "variables": {
     "CI": "true",
-    "COREPACK_HOME": "/opt/corepack",
     "NODE_ENV": "production",
     "NPM_CONFIG_FETCH_RETRIES": "5",
     "NPM_CONFIG_FUND": "false",

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-dev-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-dev-engines_1.snap.json
@@ -82,7 +82,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.5"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.6"
     }
    ],
    "name": "packages:mise",
@@ -169,7 +169,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.5"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.6"
     }
    ],
    "name": "packages:apt:runtime"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-dev-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-dev-engines_1.snap.json
@@ -1,0 +1,178 @@
+{
+ "caches": {
+  "apt": {
+   "directory": "/var/cache/apt",
+   "type": "locked"
+  },
+  "apt-lists": {
+   "directory": "/var/lib/apt/lists",
+   "type": "locked"
+  },
+  "node-modules": {
+   "directory": "/app/node_modules/.cache",
+   "type": "shared"
+  },
+  "pnpm-install": {
+   "directory": "/opt/pnpm/store",
+   "type": "shared"
+  }
+ },
+ "deploy": {
+  "base": {
+   "step": "packages:apt:runtime"
+  },
+  "inputs": [
+   {
+    "include": [
+     "/mise/shims",
+     "/mise/installs",
+     "/usr/local/bin/mise",
+     "/etc/mise/config.toml",
+     "/root/.local/state/mise"
+    ],
+    "step": "packages:mise"
+   },
+   {
+    "include": [
+     "/app/node_modules"
+    ],
+    "step": "build"
+   },
+   {
+    "exclude": [
+     "node_modules",
+     ".yarn"
+    ],
+    "include": [
+     "/root/.cache",
+     "."
+    ],
+    "step": "build"
+   }
+  ],
+  "startCommand": "pnpm run start",
+  "variables": {
+   "CI": "true",
+   "NODE_ENV": "production",
+   "NPM_CONFIG_FETCH_RETRIES": "5",
+   "NPM_CONFIG_FUND": "false",
+   "NPM_CONFIG_PRODUCTION": "false",
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
+  }
+ },
+ "steps": [
+  {
+   "assets": {
+    "generated-mise-toml": "[generated-mise-toml]"
+   },
+   "commands": [
+    {
+     "path": "/mise/shims"
+    },
+    {
+     "customName": "create mise config",
+     "name": "generated-mise-toml",
+     "path": "/etc/mise/config.toml"
+    },
+    {
+     "cmd": "mise install",
+     "customName": "install mise packages: node, pnpm"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.5"
+    }
+   ],
+   "name": "packages:mise",
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
+  },
+  {
+   "caches": [
+    "pnpm-install"
+   ],
+   "commands": [
+    {
+     "path": "/app/node_modules/.bin"
+    },
+    {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
+     "dest": "package.json",
+     "src": "package.json"
+    },
+    {
+     "path": "/opt/pnpm"
+    },
+    {
+     "cmd": "pnpm add -g node-gyp"
+    },
+    {
+     "cmd": "pnpm install"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    }
+   ],
+   "name": "install",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_FETCH_RETRIES": "5",
+    "NPM_CONFIG_FUND": "false",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
+   }
+  },
+  {
+   "caches": [
+    "node-modules"
+   ],
+   "inputs": [
+    {
+     "step": "install"
+    },
+    {
+     "include": [
+      "."
+     ],
+     "local": true
+    }
+   ],
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
+  },
+  {
+   "caches": [
+    "apt",
+    "apt-lists"
+   ],
+   "commands": [
+    {
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libatomic1'",
+     "customName": "install apt packages: libatomic1"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.5"
+    }
+   ],
+   "name": "packages:apt:runtime"
+  }
+ ]
+}

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_pnpm-corepack-runtime-usage_1.snap.json
@@ -45,10 +45,7 @@
     ],
     "include": [
      "/root/.cache",
-     ".",
-     "/opt/corepack",
-     "/mise/installs",
-     "/mise/shims"
+     "."
     ],
     "step": "build"
    }
@@ -80,7 +77,7 @@
     },
     {
      "cmd": "mise install",
-     "customName": "install mise packages: node"
+     "customName": "install mise packages: node, pnpm"
     }
    ],
    "inputs": [
@@ -106,14 +103,6 @@
      "path": "/app/node_modules/.bin"
     },
     {
-     "dest": "package.json",
-     "src": "package.json"
-    },
-    {
-     "cmd": "sh -c 'npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate'",
-     "customName": "npm i -g corepack@latest \u0026\u0026 corepack enable \u0026\u0026 corepack prepare --activate"
-    },
-    {
      "cmd": "mkdir -p /app/node_modules/.cache"
     },
     {
@@ -123,6 +112,12 @@
     {
      "dest": "pnpm-workspace.yaml",
      "src": "pnpm-workspace.yaml"
+    },
+    {
+     "path": "/opt/pnpm/bin"
+    },
+    {
+     "cmd": "pnpm add -g node-gyp"
     },
     {
      "cmd": "pnpm install"
@@ -136,7 +131,6 @@
    "name": "install",
    "variables": {
     "CI": "true",
-    "COREPACK_HOME": "/opt/corepack",
     "NODE_ENV": "production",
     "NPM_CONFIG_FETCH_RETRIES": "5",
     "NPM_CONFIG_FUND": "false",

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -22,7 +22,7 @@
  "steps": [
   {
    "assets": {
-    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\", \"bun\", \"deno\", \"dotnet\", \"rust\"]\n  minimum_release_age = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
+    "generated-mise-toml": "[tools]\n  go = \"1.23.5\"\n  node = \"20.18.2\"\n  python = \"3.13.1\"\n\n[settings]\n  idiomatic_version_file_enable_tools = [\"python\", \"node\", \"ruby\", \"elixir\", \"go\", \"java\", \"yarn\", \"pnpm\", \"bun\", \"deno\", \"dotnet\", \"rust\"]\n  minimum_release_age = \"14d\"\n  paranoid = true\n  trusted_config_paths = [\"/app\"]\n  [settings.node]\n    verify = false\n"
    },
    "commands": [
     {

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -21,7 +21,7 @@ import (
 const (
 	InstallDir                = "/tmp/railpack/mise"
 	TestInstallDir            = "/tmp/railpack/mise-test"
-	IdiomaticVersionFileTools = "python,node,ruby,elixir,go,java,yarn,bun,deno,dotnet,rust"
+	IdiomaticVersionFileTools = "python,node,ruby,elixir,go,java,yarn,pnpm,bun,deno,dotnet,rust"
 	// applied only to the first GetLatestVersion check to skip very recent releases
 	MinimumReleaseAge = "14d"
 )

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -526,6 +526,38 @@ func (p *NodeProvider) usesProductionPlaywright() bool {
 	return p.workspace.HasProductionDependency("playwright")
 }
 
+// Mise already parsed package.json (devEngines / packageManager). Use that when it names exactly one manager.
+func packageManagerFromIdiomaticMise(ctx *generate.GenerateContext) (PackageManager, bool) {
+	versions, err := ctx.GetMiseStepBuilder().GetMisePackageVersions(ctx)
+	if err != nil {
+		ctx.Logger.LogWarn("Failed to get package versions from mise: %s", err.Error())
+		return "", false
+	}
+
+	var found []string
+	for _, name := range []string{"pnpm", "yarn", "bun", "npm"} {
+		if pkg := versions[name]; pkg != nil && pkg.Source == "idiomatic-version-file" {
+			found = append(found, name)
+		}
+	}
+	if len(found) != 1 {
+		return "", false
+	}
+
+	switch found[0] {
+	case "pnpm":
+		return PackageManagerPnpm, true
+	case "npm":
+		return PackageManagerNpm, true
+	case "bun":
+		return PackageManagerBun, true
+	case "yarn":
+		return parseYarnPackageManager(versions["yarn"].Version), true
+	default:
+		return "", false
+	}
+}
+
 // determine the major version of yarn from a version string. These major versions are installed and managed quite
 // differently which is why we need to distinguish them here.
 func parseYarnPackageManager(pmVersion string) PackageManager {
@@ -557,6 +589,10 @@ func (p *NodeProvider) getPackageManager(ctx *generate.GenerateContext) PackageM
 		} else {
 			log.Warnf("Unknown package manager `%s` specified in package.json, defaulting to npm", pmName)
 		}
+	}
+
+	if pm, ok := packageManagerFromIdiomaticMise(ctx); ok {
+		return pm
 	}
 
 	// Fall back to file-based detection

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -510,9 +510,12 @@ func (p *NodeProvider) hasDependency(dependency string) bool {
 	return p.packageJson.hasDependency(dependency)
 }
 
-// if 'packageManager' field exists in package.json, then assume corepack unless using bun
+// Use Corepack for package managers that are not installed directly through mise.
 func (p *NodeProvider) usesCorepack() bool {
-	return p.packageJson != nil && p.packageJson.PackageManager != nil && p.packageManager != PackageManagerBun
+	return p.packageJson != nil &&
+		p.packageJson.PackageManager != nil &&
+		p.packageManager != PackageManagerBun &&
+		p.packageManager != PackageManagerPnpm
 }
 
 func (p *NodeProvider) usesPuppeteer() bool {

--- a/core/providers/node/node_test.go
+++ b/core/providers/node/node_test.go
@@ -76,6 +76,15 @@ func TestNode(t *testing.T) {
 			envVars:        map[string]string{"RAILPACK_NODE_VERSION": "22"},
 		},
 		{
+			name:           "pnpm from devEngines via mise idiomatic files",
+			path:           "../../../examples/node-pnpm-dev-engines",
+			detected:       true,
+			packageManager: PackageManagerPnpm,
+			nodeVersion:    "22.11.0",
+			pnpmVersion:    "10.4.1",
+			pnpmSource:     "idiomatic-version-file",
+		},
+		{
 			name:     "golang",
 			path:     "../../../examples/go-mod",
 			detected: false,

--- a/core/providers/node/node_test.go
+++ b/core/providers/node/node_test.go
@@ -19,6 +19,7 @@ func TestNode(t *testing.T) {
 		packageManager PackageManager
 		nodeVersion    string
 		pnpmVersion    string
+		pnpmSource     string
 		envVars        map[string]string
 	}{
 		{
@@ -41,6 +42,7 @@ func TestNode(t *testing.T) {
 			packageManager: PackageManagerPnpm,
 			nodeVersion:    "20",
 			pnpmVersion:    "10.4.1",
+			pnpmSource:     "idiomatic-version-file",
 		},
 		{
 			name:           "pnpm",
@@ -48,6 +50,8 @@ func TestNode(t *testing.T) {
 			detected:       true,
 			packageManager: PackageManagerPnpm,
 			nodeVersion:    "22.2.0",
+			pnpmVersion:    "10.4.1",
+			pnpmSource:     "idiomatic-version-file",
 		},
 		{
 			name:           "pnpm from mise.toml",
@@ -117,6 +121,9 @@ func TestNode(t *testing.T) {
 					} else {
 						require.Equal(t, tt.pnpmVersion, pnpmVersion.Version)
 					}
+					if tt.pnpmSource != "" {
+						require.Equal(t, tt.pnpmSource, pnpmVersion.Source)
+					}
 				}
 			}
 		})
@@ -130,8 +137,13 @@ func TestNodeCorepack(t *testing.T) {
 		wantCorepack bool
 	}{
 		{
-			name:         "corepack project",
+			name:         "pnpm project",
 			path:         "../../../examples/node-corepack",
+			wantCorepack: false,
+		},
+		{
+			name:         "yarn project",
+			path:         "../../../examples/node-yarn-3",
 			wantCorepack: true,
 		},
 		{

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -182,11 +182,7 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 
 			// pnpm 11+ installs global bins under PNPM_HOME/bin.
 			//
-			// We compare against the mise-resolved version rather than the requested one solely to handle
-			// the Node ecosystem's "x-range" engines notation (e.g. `engines.pnpm: "11.5.x"`), which is not
-			// valid semver and so cannot be parsed directly. Mise resolves it to a concrete version
-			// (e.g. "11.5.1") that we can compare. For any other source (exact version, mise.toml, etc.)
-			// resolving vs. using the requested string would yield the same result.
+			// Use the mise-resolved version so every supported source has a concrete semver here.
 			if usesPnpmBinSubdir(resolvePnpmVersion(ctx)) {
 				pnpmBinPath = PNPM_HOME + "/bin"
 			}
@@ -278,18 +274,13 @@ func (p PackageManager) PruneDeps(ctx *generate.GenerateContext, prune *generate
 }
 
 func (p PackageManager) prunePnpm(ctx *generate.GenerateContext, prune *generate.CommandStepBuilder) {
-	if packageJson, err := p.getPackageJsonFromContext(ctx); err == nil {
-		_, pnpmVersion := packageJson.GetPackageManagerInfo()
-		if pnpmVersion != "" {
-			pnpmVersion, err := semver.NewVersion(pnpmVersion)
+	pnpmVersion, err := semver.NewVersion(resolvePnpmVersion(ctx))
 
-			// pnpm 8.15.6 added the --ignore-scripts flag to the prune command
-			// https://github.com/pnpm/pnpm/releases/tag/v8.15.6
-			if err == nil && pnpmVersion.Compare(semver.MustParse("8.15.6")) == -1 {
-				prune.AddCommand(plan.NewExecCommand("pnpm prune --prod"))
-				return
-			}
-		}
+	// pnpm 8.15.6 added the --ignore-scripts flag to the prune command
+	// https://github.com/pnpm/pnpm/releases/tag/v8.15.6
+	if err == nil && pnpmVersion.Compare(semver.MustParse("8.15.6")) == -1 {
+		prune.AddCommand(plan.NewExecCommand("pnpm prune --prod"))
+		return
 	}
 
 	prune.AddCommand(plan.NewExecCommand("pnpm prune --prod --ignore-scripts"))
@@ -405,13 +396,6 @@ func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext,
 			packages.Version(pnpm, packageJson.Engines["pnpm"], "package.json > engines > pnpm")
 		}
 
-		if pmName == "pnpm" && pmVersion != "" {
-			packages.Version(pnpm, pmVersion, "package.json > packageManager")
-
-			// skip installing via Mise and install with corepack instead
-			// https://github.com/railwayapp/railpack/issues/201
-			packages.SkipMiseInstall(pnpm)
-		}
 	}
 
 	// Yarn

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -182,7 +182,12 @@ func (p PackageManager) installDeps(ctx *generate.GenerateContext, install *gene
 
 			// pnpm 11+ installs global bins under PNPM_HOME/bin.
 			//
-			// Use the mise-resolved version so every supported source has a concrete semver here.
+			// Compare against the mise-resolved version rather than the requested one. The Node ecosystem
+			// permits x-ranges such as `engines.pnpm: "11.5.x"`, which are not valid semver and cannot be
+			// compared directly. Mise resolves them to a concrete version (e.g. "11.5.1"). Mise's idiomatic
+			// package.json parsing may also override Railpack's requested engines or lockfile fallback via
+			// `devEngines.packageManager` or `packageManager` (including values with a hash suffix), so the
+			// resolved version is the authoritative version that will actually be installed.
 			if usesPnpmBinSubdir(resolvePnpmVersion(ctx)) {
 				pnpmBinPath = PNPM_HOME + "/bin"
 			}

--- a/core/providers/node/package_manager_test.go
+++ b/core/providers/node/package_manager_test.go
@@ -128,7 +128,7 @@ func TestGetPackageManagerPackages_PnpmVersionPrecedence(t *testing.T) {
 		require.Equal(t, "package.json > engines > pnpm", pnpm.Source)
 	})
 
-	t.Run("packageManager version is delegated to mise", func(t *testing.T) {
+	t.Run("packageManager is not parsed before mise resolution", func(t *testing.T) {
 		ctx := testingUtils.CreateGenerateContext(t, tmpDir)
 		miseStep := ctx.NewMiseStepBuilder("test")
 		pm := "pnpm@10.4.1"
@@ -140,6 +140,20 @@ func TestGetPackageManagerPackages_PnpmVersionPrecedence(t *testing.T) {
 		require.NotNil(t, pnpm)
 		require.Equal(t, "8", pnpm.Version)
 		require.Equal(t, "pnpm-lock.yaml", pnpm.Source)
+		require.False(t, pnpm.SkipMiseInstall)
+	})
+
+	t.Run("mise idiomatic version overrides lockfile", func(t *testing.T) {
+		ctx := testingUtils.CreateGenerateContext(t, "../../../examples/node-corepack")
+		provider := NodeProvider{}
+
+		require.NoError(t, provider.Initialize(ctx))
+		require.NoError(t, provider.Plan(ctx))
+
+		pnpm := ctx.Resolver.Get("pnpm")
+		require.NotNil(t, pnpm)
+		require.Equal(t, "10.4.1", pnpm.Version)
+		require.Equal(t, "idiomatic-version-file", pnpm.Source)
 		require.False(t, pnpm.SkipMiseInstall)
 	})
 }

--- a/core/providers/node/package_manager_test.go
+++ b/core/providers/node/package_manager_test.go
@@ -128,7 +128,7 @@ func TestGetPackageManagerPackages_PnpmVersionPrecedence(t *testing.T) {
 		require.Equal(t, "package.json > engines > pnpm", pnpm.Source)
 	})
 
-	t.Run("packageManager overrides lockfile", func(t *testing.T) {
+	t.Run("packageManager version is delegated to mise", func(t *testing.T) {
 		ctx := testingUtils.CreateGenerateContext(t, tmpDir)
 		miseStep := ctx.NewMiseStepBuilder("test")
 		pm := "pnpm@10.4.1"
@@ -138,8 +138,8 @@ func TestGetPackageManagerPackages_PnpmVersionPrecedence(t *testing.T) {
 
 		pnpm := ctx.Resolver.Get("pnpm")
 		require.NotNil(t, pnpm)
-		require.Equal(t, "10.4.1", pnpm.Version)
-		require.Equal(t, "package.json > packageManager", pnpm.Source)
-		require.True(t, pnpm.SkipMiseInstall)
+		require.Equal(t, "8", pnpm.Version)
+		require.Equal(t, "pnpm-lock.yaml", pnpm.Source)
+		require.False(t, pnpm.SkipMiseInstall)
 	})
 }

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -13,14 +13,18 @@ exists in the root directory.
 
 ## Versions
 
+### Node.js
+
 The Node.js version is determined in the following order of priority:
 
 1. Set via the `RAILPACK_NODE_VERSION` environment variable
-2. Read from the `engines.node` field in `package.json`
-3. Read from the `.nvmrc` file
-4. Read from the `.node-version` file
-5. Read from `mise.toml` or `.tool-versions` files
-6. Defaults to `lts`
+2. Read from `devEngines.runtime` in `package.json` through
+   [Mise's idiomatic file parsing](#mise-idiomatic-file-parsing)
+3. Read from the `engines.node` field in `package.json`
+4. Read from the `.nvmrc` file
+5. Read from the `.node-version` file
+6. Read from `mise.toml` or `.tool-versions` files
+7. Defaults to `lts`
 
 This version resolution logic is applied consistently across all scenarios where
 Node is needed, including when Bun is the primary package manager but Node is
@@ -33,6 +37,33 @@ Node.js will likely still work but are not officially supported.
 Node.js GPG verification is disabled by default; see the [GPG verification
 recommendation](/config/recommendations#enable-gpg-verification) to enable it in
 your project.
+
+### Package Manager Versions
+
+The detected package manager's version is determined in the following order:
+
+1. `package.json`, through Mise's idiomatic file parsing described below.
+2. The package manager's `engines` field, such as `engines.pnpm`.
+3. The detected lock file, when its format identifies a compatible version.
+4. The default version for the detected package manager.
+
+### Mise Idiomatic File Parsing
+
+For Node.js, npm, Yarn, pnpm, and Bun, Mise parses `package.json` as an
+[idiomatic version file](https://mise.jdx.dev/configuration.html#idiomatic-version-files).
+For Node.js, Mise reads `devEngines.runtime.version` when
+`devEngines.runtime.name` is `node`.
+
+For package managers, Mise checks these fields in order:
+
+1. `devEngines.packageManager`: Uses `version` when `name` matches the detected
+   package manager. The value may be an object or an array, in which case Mise
+   reads the first entry.
+2. `packageManager`: Parses `<package-manager>@<version>` and removes an optional
+   `+hash` suffix.
+
+Railpack parses additional package manager version sources as described in
+[Versions](#package-manager-versions).
 
 ## Runtime Variables
 
@@ -110,20 +141,7 @@ Railpack detects your package manager in the following order:
    - Defaults to npm if no package manager is detected
 
 When the `packageManager` field selects npm or Yarn, Corepack installs its
-specified version. pnpm is installed through Mise instead.
-
-For pnpm, Mise only parses `package.json` and checks these fields in order:
-
-1. `devEngines.packageManager`: Uses `version` when `name` is `pnpm`. The value
-   may be an object or an array, in which case Mise reads the first entry.
-2. `packageManager`: Parses `pnpm@<version>` and removes an optional `+hash`
-   suffix.
-
-Mise does not parse `engines.pnpm`, `.pnpm-version`, or `pnpm-workspace.yaml` as
-pnpm idiomatic version sources. `devEngines.packageManager` only selects a
-version, not the package manager itself. When neither idiomatic field provides
-a pnpm version, the Node provider retains its `engines.pnpm` and lockfile
-version fallbacks.
+specified version.
 
 Railpack supports building native modules and automatically configures `node-gyp`.
 

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -128,12 +128,16 @@ Railpack detects your package manager in the following order:
 
 1. **packageManager field**: Reads the `packageManager` field from
    `package.json`
-2. **Lock files**: Falls back to detecting based on lock files:
+2. **Mise idiomatic version files**: If Mise resolves exactly one of
+   pnpm, Yarn, Bun, or npm from `package.json` (`devEngines.packageManager`
+   or `packageManager`), that manager is used. A tool listed only in
+   `mise.toml` or `.tool-versions` does not select the package manager.
+3. **Lock files**: Falls back to detecting based on lock files:
    - `pnpm-lock.yaml` for pnpm
    - `bun.lockb` or `bun.lock` for Bun
    - `.yarnrc.yml` or `.yarnrc.yaml` for Yarn Berry (2+)
    - `yarn.lock` for Yarn 1
-3. **engines field**: As a fallback, checks the `engines` field in
+4. **engines field**: As a fallback, checks the `engines` field in
    `package.json` for package manager versions:
    - `engines.pnpm` for pnpm version
    - `engines.bun` for Bun version

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -96,7 +96,7 @@ available during the build.
 Railpack detects your package manager in the following order:
 
 1. **packageManager field**: Reads the `packageManager` field from
-   `package.json` (uses Corepack to install the specified version)
+   `package.json`
 2. **Lock files**: Falls back to detecting based on lock files:
    - `pnpm-lock.yaml` for pnpm
    - `bun.lockb` or `bun.lock` for Bun
@@ -109,16 +109,21 @@ Railpack detects your package manager in the following order:
    - `engines.yarn` for Yarn version
    - Defaults to npm if no package manager is detected
 
-When the `packageManager` field is present, Railpack will use Corepack to
-install the specified package manager version. When a package manager is
-detected via the `engines` field, the specified version constraint will be
-used.
+When the `packageManager` field selects npm or Yarn, Corepack installs its
+specified version. pnpm is installed through Mise instead.
 
-For a pnpm project, `devEngines.packageManager` can also specify the pnpm
-version through Mise's idiomatic `package.json` support. Mise gives this field
-precedence over `packageManager`, but it does not use `devEngines` to select the
-package manager. A `pnpm-lock.yaml` file or `engines.pnpm` value is still needed
-when `packageManager` does not select pnpm.
+For pnpm, Mise only parses `package.json` and checks these fields in order:
+
+1. `devEngines.packageManager`: Uses `version` when `name` is `pnpm`. The value
+   may be an object or an array, in which case Mise reads the first entry.
+2. `packageManager`: Parses `pnpm@<version>` and removes an optional `+hash`
+   suffix.
+
+Mise does not parse `engines.pnpm`, `.pnpm-version`, or `pnpm-workspace.yaml` as
+pnpm idiomatic version sources. `devEngines.packageManager` only selects a
+version, not the package manager itself. When neither idiomatic field provides
+a pnpm version, the Node provider retains its `engines.pnpm` and lockfile
+version fallbacks.
 
 Railpack supports building native modules and automatically configures `node-gyp`.
 

--- a/docs/src/content/docs/languages/node.md
+++ b/docs/src/content/docs/languages/node.md
@@ -114,6 +114,12 @@ install the specified package manager version. When a package manager is
 detected via the `engines` field, the specified version constraint will be
 used.
 
+For a pnpm project, `devEngines.packageManager` can also specify the pnpm
+version through Mise's idiomatic `package.json` support. Mise gives this field
+precedence over `packageManager`, but it does not use `devEngines` to select the
+package manager. A `pnpm-lock.yaml` file or `engines.pnpm` value is still needed
+when `packageManager` does not select pnpm.
+
 Railpack supports building native modules and automatically configures `node-gyp`.
 
 ### Monorepo Support

--- a/examples/node-corepack/package.json
+++ b/examples/node-corepack/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js"
   },
-  "packageManager": "pnpm@10.4.1",
+  "packageManager": "pnpm@10.4.1+sha256.abc",
   "engines": {
     "node": "20"
   },

--- a/examples/node-pnpm-dev-engines/README.md
+++ b/examples/node-pnpm-dev-engines/README.md
@@ -1,0 +1,4 @@
+`package.json` declares Node and pnpm only through `devEngines`. There is
+no `packageManager` field and no lockfile.
+
+Detection should still select pnpm 10.4.1.

--- a/examples/node-pnpm-dev-engines/main.js
+++ b/examples/node-pnpm-dev-engines/main.js
@@ -1,0 +1,23 @@
+const { execSync } = require('child_process');
+
+function getPnpmVersion() {
+  const ua = process.env.npm_config_user_agent || "";
+  return /\bpnpm\/([^\s]+)/.exec(ua)?.[1] ?? null;
+}
+
+const nodeVersion = process.version;
+console.log(`Node.js version: ${nodeVersion}`);
+
+const pnpmVersionFromUA = getPnpmVersion();
+if (pnpmVersionFromUA) {
+  console.log(`PNPM version (from user agent): v${pnpmVersionFromUA}`);
+} else {
+  console.log('PNPM version (from user agent): not detected');
+}
+
+try {
+  const pnpmVersion = execSync('pnpm --version', { encoding: 'utf8' }).trim();
+  console.log(`PNPM version (from CLI): v${pnpmVersion}`);
+} catch (error) {
+  console.log('PNPM version (from CLI): not available');
+}

--- a/examples/node-pnpm-dev-engines/package.json
+++ b/examples/node-pnpm-dev-engines/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "node-pnpm-dev-engines",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Package manager is declared only via object-form devEngines.packageManager",
+  "main": "main.js",
+  "scripts": {
+    "start": "node main.js"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "22.11.0"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.4.1"
+    }
+  }
+}

--- a/examples/node-pnpm-dev-engines/test.json
+++ b/examples/node-pnpm-dev-engines/test.json
@@ -1,0 +1,11 @@
+[
+  {
+    // No packageManager field or lockfile: the package manager is declared
+    // only in object-form devEngines.packageManager (#678 / #616).
+    "expectedOutput": [
+      "Node.js version: v22.11.0",
+      "PNPM version (from user agent): v10.4.1",
+      "PNPM version (from CLI): v10.4.1"
+    ]
+  }
+]

--- a/examples/node-pnpm-workspaces/package.json
+++ b/examples/node-pnpm-workspaces/package.json
@@ -9,6 +9,14 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js"
   },
+  "devEngines": {
+    "packageManager": [
+      {
+        "name": "pnpm",
+        "version": "10.4.1"
+      }
+    ]
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/examples/node-pnpm-workspaces/test.json
+++ b/examples/node-pnpm-workspaces/test.json
@@ -2,8 +2,8 @@
   {
     "expectedOutput": [
       "Node v: v22.2.0",
-      "PNPM version (from user agent): v9.",
-      "PNPM version (from CLI): v9.",
+      "PNPM version (from user agent): v10.4.1",
+      "PNPM version (from CLI): v10.4.1",
       "Hello from pnpm workspaces",
       "pkg-a loaded",
       "pkg-b loaded",


### PR DESCRIPTION
## Motivation

Mise can resolve pnpm versions from `package.json`, including `devEngines.packageManager`, but Railpack did not enable pnpm idiomatic version files. Railpack also duplicated part of this parsing and installed pnpm through Corepack when `packageManager` was present.

## Description

- Enable pnpm idiomatic version-file parsing alongside existing tools.
- **Add support for `devEngines.packageManager`**, including the array format (`[{ "name": "pnpm", "version": "..." }]`) and object format, which were previously unsupported.
- Stop installing pnpm through Corepack. Pnpm is now always installed through Mise, including when `package.json` contains `packageManager`.
- Delegate `devEngines.packageManager` and `packageManager` pnpm version parsing to Mise, replacing Railpack's duplicate custom string splitting and `+hash` suffix handling.
- Retain Railpack's package-manager detection along with `engines.pnpm` and lockfile version fallbacks since Mise does not parse those sources.
- Document the exact pnpm version precedence and supported fields.

Corepack remains in use for npm and Yarn projects selected through `packageManager`; this change only moves pnpm installation to Mise.

## Breaking Changes

* **Node.js Version Precedence:** `devEngines.runtime` (when `name` is `"node"`) is now parsed by Mise and takes priority over `engines.node`, `.nvmrc`, `.node-version`, and `mise.toml`. If your `package.json` specifies a `devEngines.runtime` version that differs from `engines.node` or `.nvmrc`, Railpack will now build using the `devEngines.runtime` version.
* **pnpm Version Precedence & Detection:** `devEngines.packageManager` (both object and array formats) is now resolved before `engines.pnpm` or lockfile fallbacks. If defined, it will also select `pnpm` as the package manager before inspecting lockfiles.
* **Corepack Removed for pnpm:** pnpm is now provisioned directly via Mise (`mise install`). Railpack no longer executes Corepack activation commands or sets `COREPACK_HOME` for pnpm builds.

## Test

- Verified array-form `devEngines.packageManager` selects and installs the requested pnpm version in a workspace application.
- Verified object-form `devEngines.packageManager` selects and installs the requested pnpm and node versions.
- Verified a `packageManager` pnpm version with a `+hash` suffix is installed by Mise at the stripped version and the resulting application builds and runs.
- Verified a runtime native-module application works with its Mise-installed pnpm version without Corepack.

## Links

- [Mise idiomatic version files](https://mise.jdx.dev/configuration.html#idiomatic-version-files)
