### PR TITLE
Windows mise support

### DIFF
--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -33,13 +34,6 @@ import (
 )
 
 const (
-	buildkitHostNotSetError = `BUILDKIT_HOST environment variable is not set.
-
-To start a local BuildKit daemon and set the environment variable run:
-
-	docker run --rm --privileged -d --name buildkit moby/buildkit
-	export BUILDKIT_HOST='docker-container://buildkit'`
-
 	buildkitInfoError = `failed to get buildkit information.
 
 Most likely the $BUILDKIT_HOST is not running. Here's an example of how to start the build container:
@@ -48,6 +42,22 @@ Most likely the $BUILDKIT_HOST is not running. Here's an example of how to start
 
 Use 'railpack --verbose' to view more error details`
 )
+
+// returns platform-specific instructions for starting BuildKit and setting BUILDKIT_HOST.
+// PowerShell uses $env:VAR and ; separators, while bash/zsh use export and newlines.
+func buildkitHostNotSetError() string {
+	setEnvLine := "export BUILDKIT_HOST='docker-container://buildkit'"
+	if runtime.GOOS == "windows" {
+		setEnvLine = "$env:BUILDKIT_HOST = 'docker-container://buildkit'"
+	}
+
+	return fmt.Sprintf(`BUILDKIT_HOST environment variable is not set.
+
+To start a local BuildKit daemon and set the environment variable run:
+
+	docker run --rm --privileged -d --name buildkit moby/buildkit
+	%s`, setEnvLine)
+}
 
 type BuildWithBuildkitClientOptions struct {
 	ImageName    string
@@ -74,7 +84,7 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 
 	buildkitHost := os.Getenv("BUILDKIT_HOST")
 	if buildkitHost == "" {
-		return errors.New(buildkitHostNotSetError)
+		return errors.New(buildkitHostNotSetError())
 	}
 
 	log.Debugf("Connecting to buildkit host: %s", buildkitHost)

--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -338,8 +337,16 @@ func (g *BuildGraph) convertFileCommandToLLB(cmd plan.FileCommand, state llb.Sta
 		return state, fmt.Errorf("asset %q not found", cmd.Name)
 	}
 
-	// Create parent directories for the file
-	parentDir := filepath.Dir(cmd.Path)
+	// Create parent directories for the file. The container always runs Linux, so
+	// container paths must stay POSIX-style. filepath.Dir is host-OS dependent and
+	// would convert to backslashes on Windows (e.g. /etc/mise -> \etc\mise), so
+	// derive the parent dir with forward-slash splitting instead.
+	parentDir := cmd.Path
+	if idx := strings.LastIndex(parentDir, "/"); idx > 0 {
+		parentDir = parentDir[:idx]
+	} else {
+		parentDir = "/"
+	}
 	if parentDir != "/" {
 		s := state.File(llb.Mkdir(parentDir, 0755, llb.WithParents(true)))
 		state = s

--- a/buildkit/build_llb/layers.go
+++ b/buildkit/build_llb/layers.go
@@ -3,7 +3,6 @@ package build_llb
 import (
 	"fmt"
 	"path"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -263,15 +262,15 @@ func hasPathOverlap(paths1, paths2 []string) bool {
 func resolvePaths(include string, isLocal bool) (srcPath, destPath string) {
 	if isLocal {
 		// convert a local path reference to fully qualified container path
-		return include, filepath.Join("/app", filepath.Base(include))
+		return include, path.Join("/app", path.Base(include))
 	}
 
 	switch {
 	case include == "." || include == "/app" || include == "/app/":
 		return "/app", "/app"
-	case filepath.IsAbs(include):
+	case path.IsAbs(include):
 		return include, include
 	default:
-		return filepath.Join("/app", include), filepath.Join("/app", include)
+		return path.Join("/app", include), path.Join("/app", include)
 	}
 }

--- a/core/mise/install.go
+++ b/core/mise/install.go
@@ -248,21 +248,32 @@ func extractZip(archivePath, binaryPath string) error {
 	}
 	defer cleanup()
 
-	binaryName := getBinaryName()
+	// On Windows the release archive contains `mise/bin/mise.exe` (unversioned), while
+	// getBinaryName() returns the versioned output filename used on disk. Match either
+	// the versioned output name or the plain archive name so both layouts are handled.
+	var archiveNames []string
+	if runtime.GOOS == "windows" {
+		archiveNames = []string{getBinaryName(), "mise.exe"}
+	} else {
+		archiveNames = []string{getBinaryName()}
+	}
+
 	for _, f := range r.File {
-		if strings.HasSuffix(f.Name, binaryName) {
-			rc, err := f.Open()
-			if err != nil {
+		for _, archiveName := range archiveNames {
+			if strings.HasSuffix(f.Name, archiveName) {
+				rc, err := f.Open()
+				if err != nil {
+					return err
+				}
+
+				err = writeAndMove(func(tempFile *os.File) error {
+					_, err := io.Copy(tempFile, rc)
+					_ = rc.Close()
+					return err
+				})
+
 				return err
 			}
-
-			err = writeAndMove(func(tempFile *os.File) error {
-				_, err := io.Copy(tempFile, rc)
-				_ = rc.Close()
-				return err
-			})
-
-			return err
 		}
 	}
 


### PR DESCRIPTION
<!-- feel free to drop this template into your agent, but make sure you edit the resulting PR description to be concise and de-slopped -->

## Motivation

Context - https://github.com/railwayapp/railpack/issues/404

Support `mise`  for Windows 11 OS



## Problem before

```
PS C:\Users\dealenx\dev\my-app> mise -V
              _                                        __
   ____ ___  (_)_______        ___  ____        ____  / /___ _________
  / __ `__ \/ / ___/ _ \______/ _ \/ __ \______/ __ \/ / __ `/ ___/ _ \
 / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
/_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                            /_/                 by @jdx
2026.7.11 windows-x64 (2026-07-20)
mise WARN  mise version 2026.8.1 available
mise WARN  To update, run mise self-update
PS C:\Users\dealenx\dev\my-app> railpack build .

╭─────────────────╮
│ Railpack 0.35.0 │
╰─────────────────╯

  ✖ Failed to ensure mise is installed: failed to download and install: failed to extract archive: binary not found in archive
```


## Demo

<img width="1904" height="1005" alt="image" src="https://github.com/user-attachments/assets/ffecd969-442c-416c-93f7-269b29c3a2df" />


The releases to test: https://github.com/dealenx/railpack/releases/tag/v0.35.1

