### PR TITLE
feat(cli): add show-plan flag to info command

### DIFF
--- a/buildkit/build.go
+++ b/buildkit/build.go
@@ -128,7 +128,7 @@ func BuildWithBuildkitClient(appDir string, plan *plan.BuildPlan, opts BuildWith
 		return nil
 	}
 
-	core.PrettyPrintSectionHeader("Starting Docker Build...")
+	core.PrettyPrintSectionHeader(os.Stdout, "Starting Docker Build...")
 
 	ch := make(chan *client.SolveStatus)
 

--- a/cli/build.go
+++ b/cli/build.go
@@ -95,7 +95,9 @@ var BuildCommand = &cli.Command{
 			if err != nil {
 				return cli.Exit(err, 1)
 			}
-			fmt.Println(string(serializedPlan))
+
+			core.PrettyPrintSectionHeader(os.Stdout, "Generated railpack-plan.json")
+			core.PrettyPrintJSON(os.Stdout, serializedPlan)
 		}
 
 		err = validateSecrets(buildResult.Plan, env)

--- a/cli/info.go
+++ b/cli/info.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -27,6 +29,10 @@ var InfoCommand = &cli.Command{
 			Name:  "out",
 			Usage: "output file name",
 		},
+		&cli.BoolFlag{
+			Name:  "show-plan",
+			Usage: "show the generated build plan",
+		},
 	}, commonPlanFlags()...),
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		buildResult, _, _, err := GenerateBuildResultForCommand(cmd)
@@ -36,32 +42,51 @@ var InfoCommand = &cli.Command{
 
 		format := cmd.String("format")
 
-		var buildResultString string
+		var rendered bytes.Buffer
 		if format == "pretty" {
-			buildResultString = core.FormatBuildResult(buildResult, core.PrintOptions{
+			rendered.WriteString(core.FormatBuildResult(buildResult, core.PrintOptions{
 				Metadata: true,
 				Version:  Version,
-			})
+			}))
+
+			if cmd.Bool("show-plan") {
+				planMap, err := addSchemaToPlanMap(buildResult.Plan)
+				if err != nil {
+					return cli.Exit(err, 1)
+				}
+				serializedPlan, err := json.MarshalIndent(planMap, "", "  ")
+				if err != nil {
+					return cli.Exit(err, 1)
+				}
+
+				core.PrettyPrintSectionHeader(&rendered, "Generated railpack-plan.json")
+				core.PrettyPrintJSON(&rendered, serializedPlan)
+			} else {
+				fmt.Fprintf(
+					&rendered,
+					"Use %s to view generated railpack-plan.json\n",
+					core.FormatHighlight("--show-plan"),
+				)
+			}
 		} else {
 			serializedResult, err := json.MarshalIndent(buildResult, "", "  ")
 			if err != nil {
 				return cli.Exit(err, 1)
 			}
-			buildResultString = string(serializedResult)
+			fmt.Fprintln(&rendered, string(serializedResult))
 		}
 
 		output := cmd.String("out")
 		if output == "" {
 			// Write to stdout if no output file specified
-			_, _ = os.Stdout.Write([]byte(buildResultString))
-			_, _ = os.Stdout.Write([]byte("\n"))
+			_, _ = os.Stdout.Write(rendered.Bytes())
 			return nil
 		} else {
 			if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 				return cli.Exit(err, 1)
 			}
 
-			err = os.WriteFile(output, []byte(buildResultString), 0644)
+			err = os.WriteFile(output, rendered.Bytes(), 0644)
 			if err != nil {
 				return cli.Exit(err, 1)
 			}

--- a/core/pretty_print.go
+++ b/core/pretty_print.go
@@ -2,14 +2,17 @@ package core
 
 import (
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/railwayapp/railpack/core/logger"
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/railwayapp/railpack/core/resolver"
 	"github.com/railwayapp/railpack/internal/utils"
+	"github.com/tidwall/pretty"
 )
 
 const (
@@ -126,11 +129,11 @@ func PrettyPrintBuildResult(buildResult *BuildResult, options ...PrintOptions) {
 	fmt.Print(output)
 }
 
-func PrettyPrintSectionHeader(title string) {
+func PrettyPrintSectionHeader(output io.Writer, title string) {
 	style := sectionHeaderStyle.
 		MarginTop(0).
 		Width(max(10, lipgloss.Width(title)))
-	fmt.Printf("%s\n\n", style.Render(title))
+	_, _ = fmt.Fprintf(output, "%s\n\n", style.Render(title))
 }
 
 func PrettyPrintBox(content string) {
@@ -139,6 +142,14 @@ func PrettyPrintBox(content string) {
 
 func FormatHighlight(content string) string {
 	return highlightedTextStyle.Render(content)
+}
+
+func PrettyPrintJSON(output io.Writer, content []byte) {
+	if lipgloss.ColorProfile() != termenv.Ascii {
+		content = pretty.Color(content, nil)
+	}
+
+	_, _ = fmt.Fprintln(output, string(content))
 }
 
 func FormatBuildResult(br *BuildResult, options ...PrintOptions) string {

--- a/core/pretty_print_test.go
+++ b/core/pretty_print_test.go
@@ -1,8 +1,11 @@
 package core
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/railwayapp/railpack/core/logger"
 	"github.com/stretchr/testify/require"
 )
@@ -14,6 +17,13 @@ func TestPrettyPrintStyles(t *testing.T) {
 	require.Contains(t, output, "Successfully built image in 1.08s")
 	require.Contains(t, output, "docker run -it shell-script")
 	require.NotContains(t, output, "✓")
+}
+
+func TestPrettyPrintSectionHeader(t *testing.T) {
+	var output bytes.Buffer
+	PrettyPrintSectionHeader(&output, "Generated railpack-plan.json")
+
+	require.Contains(t, output.String(), "Generated railpack-plan.json")
 }
 
 func TestPrettyPrintDeprecationLog(t *testing.T) {
@@ -46,4 +56,23 @@ func TestPrettyPrintSuggestionLog(t *testing.T) {
 
 	require.Contains(t, output, "→ Include `...` in `buildAptPackages`")
 	require.Contains(t, output, "https://railpack.com/guides/installing-packages")
+}
+
+func TestPrettyPrintJSON(t *testing.T) {
+	originalProfile := lipgloss.ColorProfile()
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(originalProfile)
+	})
+
+	json := []byte(`{"key":"value","enabled":true}`)
+
+	lipgloss.SetColorProfile(termenv.ANSI)
+	var colored bytes.Buffer
+	PrettyPrintJSON(&colored, json)
+	require.Contains(t, colored.String(), "\x1b[")
+
+	lipgloss.SetColorProfile(termenv.Ascii)
+	var plain bytes.Buffer
+	PrettyPrintJSON(&plain, json)
+	require.Equal(t, string(json)+"\n", plain.String())
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/objx v0.5.3
 	github.com/stretchr/testify v1.11.1
 	github.com/tailscale/hujson v0.0.0-20260727124030-b80ff77dac4f
+	github.com/tidwall/pretty v1.2.1
 	github.com/tonistiigi/fsutil v0.0.0-20260717003753-6d9dc2ebad62
 	github.com/urfave/cli/v3 v3.10.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -87,7 +88,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect


### PR DESCRIPTION
## Motivation

Users need a way to inspect the generated build plan without running a build.

## Description

- Add `--show-plan` to the `info` command to render the generated plan.
- Update pretty-printing and section output to accept an `io.Writer`, enabling consistent CLI and JSON output.

## Test

- Added coverage for text and JSON pretty-print output.