### PR TITLE
fix(mise): enable safe mode when reading app config

### DIFF
--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -192,6 +192,9 @@ func (m *Mise) GetCurrentList(appDir string) (string, error) {
 		enabledIdiomaticEnv,
 		// MISE_PARANOID enables stricter security validation
 		"MISE_PARANOID=1",
+		// This is the only path that loads the app's own mise config. Safe mode keeps that
+		// config inert (no code execution, no host environment mutation) while still reporting versions.
+		"MISE_SAFE=1",
 	}, "--cd", appDir, "list", "--current", "--json")
 }
 

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -192,8 +192,7 @@ func (m *Mise) GetCurrentList(appDir string) (string, error) {
 		enabledIdiomaticEnv,
 		// MISE_PARANOID enables stricter security validation
 		"MISE_PARANOID=1",
-		// This is the only path that loads the app's own mise config. Safe mode keeps that
-		// config inert (no code execution, no host environment mutation) while still reporting versions.
+		// Safe mode keeps the app's own mise config inert (no code execution or host env mutation) while still reporting versions
 		"MISE_SAFE=1",
 	}, "--cd", appDir, "list", "--current", "--json")
 }


### PR DESCRIPTION
Run the app's mise config in mise safe mode when resolving tool versions during analysis, so the config stays inert while we read it. Version resolution and reporting are unchanged.
