### PR TITLE
fix: drop empty env entries instead of keeping explicit empty values

### DIFF
--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -33,10 +33,17 @@ func FromEnvs(envs []string) (*Environment, error) {
 		name := matches[1]
 		value := matches[2]
 
-		// A name-only entry inherits, while NAME= explicitly assigns an empty value.
-		if value == "" && !strings.Contains(e, "=") {
-			if v, ok := os.LookupEnv(name); ok {
-				env.SetVariable(name, v)
+		if value == "" {
+			// A name-only entry inherits from the process environment.
+			// NAME= is dropped entirely: hosted builders pass every variable
+			// this way, and BuildKit cannot mount an empty env secret, so
+			// keeping it produces plans that reference unresolvable secrets.
+			// It must never inherit — user-controlled names would read from
+			// the build daemon's environment.
+			if !strings.Contains(e, "=") {
+				if v, ok := os.LookupEnv(name); ok {
+					env.SetVariable(name, v)
+				}
 			}
 		} else {
 			// Use provided name, value pair

--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -34,9 +34,7 @@ func FromEnvs(envs []string) (*Environment, error) {
 		value := matches[2]
 
 		if value == "" {
-			// A bare NAME (no "=") inherits its value from the current
-			// process environment. An explicit NAME= is treated as unset
-			// and skipped.
+			// A bare NAME inherits from the process env; NAME= is skipped.
 			if !strings.Contains(e, "=") {
 				if v, ok := os.LookupEnv(name); ok {
 					env.SetVariable(name, v)

--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -34,9 +34,9 @@ func FromEnvs(envs []string) (*Environment, error) {
 		value := matches[2]
 
 		if value == "" {
-			// A bare NAME inherits from the process env; NAME= is dropped.
-			// Never inherit for NAME= — names are user-controlled and would
-			// leak the build daemon's environment.
+			// A bare NAME (no "=") inherits its value from the current
+			// process environment. An explicit NAME= is treated as unset
+			// and skipped.
 			if !strings.Contains(e, "=") {
 				if v, ok := os.LookupEnv(name); ok {
 					env.SetVariable(name, v)

--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -34,19 +34,15 @@ func FromEnvs(envs []string) (*Environment, error) {
 		value := matches[2]
 
 		if value == "" {
-			// A name-only entry inherits from the process environment.
-			// NAME= is dropped entirely: hosted builders pass every variable
-			// this way, and BuildKit cannot mount an empty env secret, so
-			// keeping it produces plans that reference unresolvable secrets.
-			// It must never inherit — user-controlled names would read from
-			// the build daemon's environment.
+			// A bare NAME inherits from the process env; NAME= is dropped.
+			// Never inherit for NAME= — names are user-controlled and would
+			// leak the build daemon's environment.
 			if !strings.Contains(e, "=") {
 				if v, ok := os.LookupEnv(name); ok {
 					env.SetVariable(name, v)
 				}
 			}
 		} else {
-			// Use provided name, value pair
 			env.SetVariable(name, value)
 		}
 	}

--- a/core/app/environment_test.go
+++ b/core/app/environment_test.go
@@ -8,8 +8,6 @@ import (
 
 func TestFromEnvs(t *testing.T) {
 	t.Setenv("INHERITED", "from the process environment")
-	// EMPTY= entries are dropped, never inherited: user-controlled names must
-	// not read values out of the build daemon's environment.
 	t.Setenv("EMPTY", "this must not be inherited")
 
 	env, err := FromEnvs([]string{

--- a/core/app/environment_test.go
+++ b/core/app/environment_test.go
@@ -8,6 +8,8 @@ import (
 
 func TestFromEnvs(t *testing.T) {
 	t.Setenv("INHERITED", "from the process environment")
+	// EMPTY= entries are dropped, never inherited: user-controlled names must
+	// not read values out of the build daemon's environment.
 	t.Setenv("EMPTY", "this must not be inherited")
 
 	env, err := FromEnvs([]string{
@@ -31,7 +33,6 @@ func TestFromEnvs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{
 		"PLAIN":          "value",
-		"EMPTY":          "",
 		"INHERITED":      "from the process environment",
 		"LEADING_EQUALS": "=value",
 		"EQUALS":         "value=with=equals==",


### PR DESCRIPTION
Fixes the v0.36.1 regression where every build with an empty-valued variable fails with `failed to solve: secret <NAME> not found`.

#685 changed `NAME=` from "inherit from process env" to "explicit empty variable". Hosted builders pass every variable as `--env NAME=value` including empties, but exclude empty values from BuildKit secrets (BuildKit cannot mount an empty env secret). Pre-#685 the empty var was dropped on railpack's side so the two filters agreed; post-#685 the plan declares a secret the builder never registers.

- `NAME=` entries are now dropped entirely, restoring the pre-v0.36.1 effective behavior
- The security tightening from #685 is preserved: `NAME=` never inherits from the process environment (names are user-controlled and the railpack process inherits the build daemon's env)
- Bare `NAME` inheritance and the multiline value support are unchanged