### PR TITLE
fix: support empty environment variable values

### DIFF
--- a/core/app/environment.go
+++ b/core/app/environment.go
@@ -33,12 +33,10 @@ func FromEnvs(envs []string) (*Environment, error) {
 		name := matches[1]
 		value := matches[2]
 
-		if value == "" {
-			// A bare NAME inherits from the process env; NAME= is skipped.
-			if !strings.Contains(e, "=") {
-				if v, ok := os.LookupEnv(name); ok {
-					env.SetVariable(name, v)
-				}
+		// A name-only entry inherits, while NAME= explicitly assigns an empty value.
+		if value == "" && !strings.Contains(e, "=") {
+			if v, ok := os.LookupEnv(name); ok {
+				env.SetVariable(name, v)
 			}
 		} else {
 			env.SetVariable(name, value)

--- a/core/app/environment_test.go
+++ b/core/app/environment_test.go
@@ -31,6 +31,7 @@ func TestFromEnvs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{
 		"PLAIN":          "value",
+		"EMPTY":          "",
 		"INHERITED":      "from the process environment",
 		"LEADING_EQUALS": "=value",
 		"EQUALS":         "value=with=equals==",


### PR DESCRIPTION
## Motivation

Explicitly empty environment variables should remain empty instead of being dropped or inheriting values from the build process.

## Description

Treat `NAME=` as an explicit empty assignment while retaining process-environment inheritance for bare `NAME` entries.

## TODO

- [ ] confirm with railpack before merging