### PR TITLE
docs: document remote Docker host for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ examples/**/.claude
 ### Mise ###
 # Local mise env selector (enables mise.dev.toml tools when present)
 .miserc.toml
+# Local env overrides (DOCKER_HOST, etc.)
+mise.local.toml

--- a/docs/src/content/docs/config/environment-variables.md
+++ b/docs/src/content/docs/config/environment-variables.md
@@ -16,7 +16,6 @@ often prefixed with `RAILPACK_`.
 | `RAILPACK_PACKAGES`            | Install additional Mise packages. In the format `pkg[@version]`. The version is optional; if not provided, the latest version is used. Allows list.                             |
 | `RAILPACK_BUILD_APT_PACKAGES`  | Install additional Apt packages during build. Allows list.                                                                                                                      |
 | `RAILPACK_DEPLOY_APT_PACKAGES` | Install additional Apt packages in the final image. Allows list.                                                                                                                |
-| `RAILPACK_DISABLE_CACHES`      | Specify specific BuildKit cache keys to disable, or `*` to disable all caches. Allows list.                                                                                     |
 
 Variables which allow a list use space-separated values. For example:
 
@@ -30,7 +29,11 @@ To configure more parts of the build, it is recommended to use a [config file](/
 
 These environment variables affect the behavior of Railpack:
 
-| Name              | Description                                 |
-| :---------------- | :------------------------------------------ |
-| `FORCE_COLOR`     | Force colored output even when not in a TTY |
-| `RAILPACK_VERBOSE` | Enable verbose logging (equivalent to `--verbose` flag) |
+They are read directly from Railpack's process environment; do not pass them
+with `--env`.
+
+| Name                      | Description                                                                 |
+| :------------------------ | :-------------------------------------------------------------------------- |
+| `FORCE_COLOR`             | Force colored output even when not in a TTY                                 |
+| `RAILPACK_VERBOSE`        | Enable verbose logging (equivalent to the `--verbose` flag)                 |
+| `RAILPACK_DISABLE_CACHES` | Disable specific BuildKit cache keys, or `*` to disable all caches. Allows list. |

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -56,7 +56,8 @@ through the `BUILDKIT_HOST` environment variable. The easiest way to do this is
 to run a BuildKit instance as a container:
 
 ```bash
-mise run setup
+docker run --rm --privileged -d --name buildkit moby/buildkit
+export BUILDKIT_HOST='docker-container://buildkit'
 ```
 
 Now you can build your image using Railpack:

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -28,6 +28,33 @@ mise run setup
 This command starts a BuildKit container (check out `mise.toml` in the root
 directory for more information).
 
+### Remote Docker host
+
+`BUILDKIT_HOST=docker-container://buildkit` uses the Docker CLI, so a
+remote Docker daemon is also the remote BuildKit. Set this in an
+untracked `mise.local.toml`:
+
+```toml
+[env]
+DOCKER_HOST = "ssh://user@host"
+```
+
+Leave `BUILDKIT_HOST` unset unless the remote container is not named
+`buildkit`. Use key/agent SSH auth. The remote host needs a running
+privileged `buildkit` container; `mise run setup` bind-mounts a local
+path that Docker-over-SSH looks up on the remote filesystem.
+
+Confirm the engine with `docker info` (`Name` is the hostname):
+
+```bash
+docker info -f '{{.Name}} {{.OperatingSystem}}'
+docker context inspect -f '{{.Endpoints.docker.Host}}'
+```
+
+`docker context inspect` reports the context URL, which is ignored when
+`DOCKER_HOST` is set. Use `DOCKER_CONTEXT` if you want that inspect
+command to match the live connection.
+
 Use the `cli` task to run the Railpack CLI (this is like `railpack --help`)
 
 ```bash
@@ -60,8 +87,9 @@ Pro-tip: point your agent at this guide.
 
 ## Building directly with BuildKit
 
-**👋 Requirement**: an instance of BuildKit must be running locally.
-Run `mise run setup` to start a BuildKit container.
+**👋 Requirement**: an instance of BuildKit must be reachable from the
+Docker CLI. Run `mise run setup` to start a local BuildKit container, or
+point Docker at a remote host (see [Remote Docker host](#remote-docker-host)).
 
 Railpack will instantiate a BuildKit client and communicate over GRPC in
 order to build the generated LLB.

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -32,11 +32,9 @@ directory for more information).
 
 Integration tests and local builds store images and BuildKit cache on
 the Docker host. Point Docker at another machine to keep tens of
-gigabytes of that data off your laptop.
+gigabytes of that data off your laptop if you are actively working on Railpack.
 
-`BUILDKIT_HOST=docker-container://buildkit` uses the Docker CLI, so a
-remote Docker daemon is also the remote BuildKit. Set this in an
-untracked `mise.local.toml`:
+Set this in a `mise.local.toml`:
 
 ```toml
 [env]
@@ -45,8 +43,7 @@ DOCKER_HOST = "ssh://user@host"
 
 Leave `BUILDKIT_HOST` unset unless the remote container is not named
 `buildkit`. Use key/agent SSH auth. The remote host needs a running
-privileged `buildkit` container; `mise run setup` bind-mounts a local
-path that Docker-over-SSH looks up on the remote filesystem.
+privileged `buildkit` container.
 
 Confirm the engine with `docker info` (`Name` is the hostname):
 
@@ -54,10 +51,6 @@ Confirm the engine with `docker info` (`Name` is the hostname):
 docker info -f '{{.Name}} {{.OperatingSystem}}'
 docker context inspect -f '{{.Endpoints.docker.Host}}'
 ```
-
-`docker context inspect` reports the context URL, which is ignored when
-`DOCKER_HOST` is set. Use `DOCKER_CONTEXT` if you want that inspect
-command to match the live connection.
 
 Use the `cli` task to run the Railpack CLI (this is like `railpack --help`)
 

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -30,6 +30,10 @@ directory for more information).
 
 ### Remote Docker host
 
+Integration tests and local builds store images and BuildKit cache on
+the Docker host. Point Docker at another machine to keep tens of
+gigabytes of that data off your laptop.
+
 `BUILDKIT_HOST=docker-container://buildkit` uses the Docker CLI, so a
 remote Docker daemon is also the remote BuildKit. Set this in an
 untracked `mise.local.toml`:


### PR DESCRIPTION
## Motivation

Integration tests and local builds store tens of gigabytes of images and BuildKit cache on the Docker host. Pointing Docker at another machine keeps that data off the laptop, but nothing explained which env vars to set or how to confirm the CLI is talking to that host.

## Description

- Document setting `DOCKER_HOST` (or `DOCKER_CONTEXT`) in an untracked `mise.local.toml` so the existing BuildKit container helper talks to a remote daemon.
- Include the SSH/setup caveats and `docker info` / `docker context inspect` commands to see which host is live.
- Ignore `mise.local.toml` so local host overrides are not committed.