### PR TITLE
fix(build): correct configuration precedence order

### DIFF
--- a/buildkit/frontend.go
+++ b/buildkit/frontend.go
@@ -70,6 +70,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		return nil, err
 	}
 
+	// TODO why are we marshalling the plan here if we don't do anything with it?
 	_, err = json.MarshalIndent(plan, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling plan: %w", err)

--- a/cli/build.go
+++ b/cli/build.go
@@ -86,6 +86,7 @@ var BuildCommand = &cli.Command{
 		}
 
 		if cmd.Bool("show-plan") && !cmd.Bool("dump-llb") {
+			// Include $schema in the generated plan JSON for editor support
 			planMap, err := addSchemaToPlanMap(buildResult.Plan)
 			if err != nil {
 				return cli.Exit(err, ExitCodeFailure)

--- a/cli/plan.go
+++ b/cli/plan.go
@@ -34,11 +34,12 @@ var PlanCommand = &cli.Command{
 		if err != nil {
 			return cli.Exit(err, ExitCodeFailure)
 		}
-		serializedPlan, err := json.MarshalIndent(planMap, "", "  ")
+
+		// serialize the plan to a string to dump to the plan file
+		buildResultString, err := json.MarshalIndent(planMap, "", "  ")
 		if err != nil {
 			return cli.Exit(err, ExitCodeFailure)
 		}
-		buildResultString := serializedPlan
 
 		output := cmd.String("out")
 		if output == "" {

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-precedence_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-precedence_1.snap.json
@@ -1,0 +1,51 @@
+{
+ "deploy": {
+  "base": {
+   "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.5"
+  },
+  "inputs": [
+   {
+    "include": [
+     "."
+    ],
+    "step": "build"
+   }
+  ],
+  "startCommand": "echo from-file",
+  "variables": {
+   "RAILPACK_VERSION": "dev"
+  }
+ },
+ "steps": [
+  {
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.5"
+    }
+   ],
+   "name": "packages:mise"
+  },
+  {
+   "commands": [
+    {
+     "cmd": "chmod +x start.sh"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    },
+    {
+     "include": [
+      "."
+     ],
+     "local": true
+    }
+   ],
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
+  }
+ ]
+}

--- a/core/core.go
+++ b/core/core.go
@@ -160,18 +160,23 @@ func failedBuildResult(logger *logger.Logger, err error) (*BuildResult, error) {
 	return result, nil
 }
 
-// GetConfig merges the options, environment, and file config into a single config
+// merges the options, environment, and file config into a single config
+// note that this is not run in the frontend process, since the buildkit frontend consumed the "compiled" railpack-plan.json which this logic helps generate
 func GetConfig(app *app.App, env *app.Environment, options *GenerateBuildPlanOptions, logger *logger.Logger) (*c.Config, error) {
+	// cli options first, takes precedence over environment and file config
 	optionsConfig := GenerateConfigFromOptions(options)
 
+	// environment variables next, takes precedence over file config
 	envConfig := GenerateConfigFromEnvironment(env)
 
+	// file config last
 	fileConfig, err := GenerateConfigFromFile(app, env, options, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	mergedConfig := c.Merge(optionsConfig, envConfig, fileConfig)
+
 	// Environment-provided secrets must remain available when file configuration replaces slice values.
 	mergedConfig.Secrets = utils.RemoveDuplicates(slices.Concat(envConfig.Secrets, mergedConfig.Secrets))
 
@@ -254,12 +259,13 @@ func GenerateConfigFromEnvironment(env *app.Environment) *c.Config {
 		config.Deploy.AptPackages = aptPackages
 	}
 
+	// TODO why do we add all the environment variables to the secrets?
 	config.Secrets = append(config.Secrets, slices.Sorted(maps.Keys(env.Variables))...)
 
 	return config
 }
 
-// generates a config from the CLI options
+// generates a config from the CLI options, this takes precedence over the environment and file config
 func GenerateConfigFromOptions(options *GenerateBuildPlanOptions) *c.Config {
 	config := c.EmptyConfig()
 

--- a/core/core.go
+++ b/core/core.go
@@ -164,7 +164,7 @@ func failedBuildResult(logger *logger.Logger, err error) (*BuildResult, error) {
 // note that this is not run in the frontend process, since the buildkit frontend consumed the "compiled" railpack-plan.json which this logic helps generate
 func GetConfig(app *app.App, env *app.Environment, options *GenerateBuildPlanOptions, logger *logger.Logger) (*c.Config, error) {
 	// cli options first, takes precedence over environment and file config
-	optionsConfig := GenerateConfigFromOptions(options)
+	cliOptionsConfig := GenerateConfigFromOptions(options)
 
 	// environment variables next, takes precedence over file config
 	envConfig := GenerateConfigFromEnvironment(env)
@@ -175,10 +175,18 @@ func GetConfig(app *app.App, env *app.Environment, options *GenerateBuildPlanOpt
 		return nil, err
 	}
 
-	mergedConfig := c.Merge(optionsConfig, envConfig, fileConfig)
+	// NOTE incredibly important line! This defined the precedence order for most of the configuration (right to left)
+	mergedConfig := c.Merge(fileConfig, envConfig, cliOptionsConfig)
 
-	// Environment-provided secrets must remain available when file configuration replaces slice values.
-	mergedConfig.Secrets = utils.RemoveDuplicates(slices.Concat(envConfig.Secrets, mergedConfig.Secrets))
+	// Secrets are unique: the values are *not* part of the configuration/railpack plan, only the names are
+	// the values are only provided to the build system (either directly to the buildctl / docker build cmd, or to `railpack build`)
+	// Additionally, it would unintuitive for a CLI option to replace a file-provided secret instead of concatenating them.
+	// For this reason, we merge the list of secret names together and deduplicate them.
+	mergedConfig.Secrets = utils.RemoveDuplicates(slices.Concat(
+		fileConfig.Secrets,
+		envConfig.Secrets,
+		// cli options don't define secrets
+	))
 
 	return mergedConfig, nil
 }
@@ -187,12 +195,11 @@ func GenerateConfigFromFile(app *app.App, env *app.Environment, options *Generat
 	config := c.EmptyConfig()
 
 	configFileName := defaultConfigFileName
-	if options.ConfigFilePath != "" {
-		configFileName = options.ConfigFilePath
-	}
-
 	if envConfigFileName, _ := env.GetConfigVariable("CONFIG_FILE"); envConfigFileName != "" {
 		configFileName = envConfigFileName
+	}
+	if options.ConfigFilePath != "" {
+		configFileName = options.ConfigFilePath
 	}
 
 	// always assume config file path is relative to the app source directory

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -113,6 +113,7 @@ func TestGenerateConfigFromFile_Malformed(t *testing.T) {
 }
 
 func TestGetConfig_MergesEnvironmentAndFileSecrets(t *testing.T) {
+	// write a railpack.json file with some secrets
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, defaultConfigFileName)
 	err := os.WriteFile(configPath, []byte(`{"secrets":["VITE_APP_TITLE","FILE_ONLY_SECRET"]}`), 0644)
@@ -124,8 +125,9 @@ func TestGetConfig_MergesEnvironmentAndFileSecrets(t *testing.T) {
 	envVars := map[string]string{
 		"DATABASE_URL":      "postgres://localhost/mydb",
 		"SENTRY_AUTH_TOKEN": "sntrx_abc",
-		"VITE_APP_TITLE":    "MyApp",
-		"MY_SECRET":         "s3cret",
+		// this should win against the file config
+		"VITE_APP_TITLE": "MyApp",
+		"MY_SECRET":      "s3cret",
 	}
 
 	env := app.NewEnvironment(&envVars)

--- a/core/precedence_test.go
+++ b/core/precedence_test.go
@@ -1,0 +1,220 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/railwayapp/railpack/core/app"
+	c "github.com/railwayapp/railpack/core/config"
+	"github.com/railwayapp/railpack/core/logger"
+	"github.com/railwayapp/railpack/core/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConfig_StartCommandPrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		env     map[string]string
+		options *GenerateBuildPlanOptions
+		want    string
+	}{
+		{
+			name:    "cli overrides env and file",
+			file:    `{"deploy":{"startCommand":"from-file"}}`,
+			env:     map[string]string{"RAILPACK_START_CMD": "from-env"},
+			options: &GenerateBuildPlanOptions{StartCommand: "from-cli"},
+			want:    "from-cli",
+		},
+		{
+			name: "env overrides file",
+			file: `{"deploy":{"startCommand":"from-file"}}`,
+			env:  map[string]string{"RAILPACK_START_CMD": "from-env"},
+			want: "from-env",
+		},
+		{
+			name: "file used when cli and env are unset",
+			file: `{"deploy":{"startCommand":"from-file"}}`,
+			want: "from-file",
+		},
+		{
+			name: "empty env does not override file",
+			file: `{"deploy":{"startCommand":"from-file"}}`,
+			env:  map[string]string{"RAILPACK_START_CMD": ""},
+			want: "from-file",
+		},
+		{
+			name: "empty cli does not override env",
+			file: `{"deploy":{"startCommand":"from-file"}}`,
+			env:  map[string]string{"RAILPACK_START_CMD": "from-env"},
+			want: "from-env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := loadTestConfig(t, tt.file, tt.env, tt.options)
+			require.Equal(t, tt.want, cfg.Deploy.StartCmd)
+		})
+	}
+}
+
+func TestGetConfig_BuildCommandPrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		env     map[string]string
+		options *GenerateBuildPlanOptions
+		want    string
+	}{
+		{
+			name:    "cli overrides env and file",
+			file:    `{"steps":{"build":{"commands":["from-file"]}}}`,
+			env:     map[string]string{"RAILPACK_BUILD_CMD": "from-env"},
+			options: &GenerateBuildPlanOptions{BuildCommand: "from-cli"},
+			want:    "from-cli",
+		},
+		{
+			name: "env overrides file",
+			file: `{"steps":{"build":{"commands":["from-file"]}}}`,
+			env:  map[string]string{"RAILPACK_BUILD_CMD": "from-env"},
+			want: "from-env",
+		},
+		{
+			name: "file used when cli and env are unset",
+			file: `{"steps":{"build":{"commands":["from-file"]}}}`,
+			want: "from-file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := loadTestConfig(t, tt.file, tt.env, tt.options)
+			require.Equal(t, tt.want, lastBuildCommand(cfg))
+		})
+	}
+}
+
+func TestGetConfig_ConfigFilePathPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, defaultConfigFileName), []byte(`{"deploy":{"startCommand":"from-default-file"}}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "alt.json"), []byte(`{"deploy":{"startCommand":"from-cli-file"}}`), 0644))
+
+	userApp, err := app.NewApp(dir)
+	require.NoError(t, err)
+
+	env := app.NewEnvironment(&map[string]string{
+		"RAILPACK_CONFIG_FILE": defaultConfigFileName,
+	})
+	cfg, err := GetConfig(userApp, env, &GenerateBuildPlanOptions{ConfigFilePath: "alt.json"}, logger.NewLogger())
+	require.NoError(t, err)
+	require.Equal(t, "from-cli-file", cfg.Deploy.StartCmd)
+}
+
+func TestGenerateBuildPlan_StartCommandPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		procfile string
+		env      map[string]string
+		options  *GenerateBuildPlanOptions
+		want     string
+	}{
+		{
+			name:     "cli overrides env file and procfile",
+			file:     `{"provider":"shell","deploy":{"startCommand":"from-file"}}`,
+			procfile: "web: from-procfile\n",
+			env:      map[string]string{"RAILPACK_START_CMD": "from-env"},
+			options:  &GenerateBuildPlanOptions{StartCommand: "from-cli"},
+			want:     "from-cli",
+		},
+		{
+			name:     "env overrides file and procfile",
+			file:     `{"provider":"shell","deploy":{"startCommand":"from-file"}}`,
+			procfile: "web: from-procfile\n",
+			env:      map[string]string{"RAILPACK_START_CMD": "from-env"},
+			want:     "from-env",
+		},
+		{
+			name:     "file overrides procfile",
+			file:     `{"provider":"shell","deploy":{"startCommand":"from-file"}}`,
+			procfile: "web: from-procfile\n",
+			want:     "from-file",
+		},
+		{
+			name:     "procfile overrides provider default",
+			file:     `{"provider":"shell"}`,
+			procfile: "web: from-procfile\n",
+			want:     "from-procfile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "start.sh"), []byte("#!/bin/sh\necho from-provider\n"), 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, defaultConfigFileName), []byte(tt.file), 0644))
+			if tt.procfile != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "Procfile"), []byte(tt.procfile), 0644))
+			}
+
+			userApp, err := app.NewApp(dir)
+			require.NoError(t, err)
+
+			options := tt.options
+			if options == nil {
+				options = &GenerateBuildPlanOptions{}
+			}
+
+			result, err := GenerateBuildPlan(userApp, app.NewEnvironment(&tt.env), options)
+			require.NoError(t, err)
+			require.True(t, result.Success)
+			require.Equal(t, tt.want, result.Plan.Deploy.StartCmd)
+		})
+	}
+}
+
+func loadTestConfig(t *testing.T, fileJSON string, envVars map[string]string, options *GenerateBuildPlanOptions) *c.Config {
+	t.Helper()
+
+	dir := t.TempDir()
+	if fileJSON != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, defaultConfigFileName), []byte(fileJSON), 0644))
+	}
+
+	userApp, err := app.NewApp(dir)
+	require.NoError(t, err)
+
+	if options == nil {
+		options = &GenerateBuildPlanOptions{}
+	}
+
+	cfg, err := GetConfig(userApp, app.NewEnvironment(&envVars), options, logger.NewLogger())
+	require.NoError(t, err)
+	return cfg
+}
+
+func lastBuildCommand(cfg *c.Config) string {
+	step, ok := cfg.Steps["build"]
+	if !ok {
+		return ""
+	}
+
+	for i := len(step.Commands) - 1; i >= 0; i-- {
+		switch cmd := step.Commands[i].(type) {
+		case plan.ExecCommand:
+			if cmd.CustomName != "" {
+				return cmd.CustomName
+			}
+			return cmd.Cmd
+		case *plan.ExecCommand:
+			if cmd.CustomName != "" {
+				return cmd.CustomName
+			}
+			return cmd.Cmd
+		}
+	}
+
+	return ""
+}

--- a/docs/src/content/docs/config/options.md
+++ b/docs/src/content/docs/config/options.md
@@ -10,17 +10,39 @@ Users can configure Railpack in a few different ways:
 - [`railpack.json` config file](/config/file)
 - [Mise configuration](/config/mise)
 
-CLI flags, environment variables, and `railpack.json` are merged and then
-applied to the generate context. Mise configuration files, such as
-`mise.toml`, are also detected and used to configure tool versions, install
-additional tools, set environment variables, and customize Mise behavior in
-the generated image.
+CLI flags, environment variables, and `railpack.json` are merged in
+precedence order and then applied to the generate context. Mise configuration
+files are used to configure tool versions, install additional tools, set environment variables, and customize Mise behavior in the generated image.
 
 Everything that affects a part of the build plan _should_ be configurable.
 Config affects the generate context rather than the plan itself as it allows
 Railpack to perform optimizations after the config is applied. It also allows
 the user config format to be abstracted at a higher level compared to the
 relatively low level build plan schema.
+
+## Configuration Precedence
+
+There are many configuration options which can be defined in multiple places. Here is the order of precedence (highest wins):
+
+1. CLI flags (`--build-cmd`, `--start-cmd`, etc)
+2. Environment variables passed with `--env` (`RAILPACK)
+3. [`railpack.json`](/config/file)
+4. [Procfile](/config/procfile) (only for the start command)
+5. Provider and detected defaults
+
+A couple things to note:
+
+- An unset or empty value does not override a lower source.
+- Build configuration from the environment must be passed with `--env`. Exported shell variables are not imported automatically.
+- Array values from a higher source replace lower ones unless the value
+includes `"..."` to extend the generated list. See [Array
+Extending](/config/file#array-extending).
+- Language versions (for example `RAILPACK_NODE_VERSION` versus `.nvmrc`) use a
+per-language order documented on each language page.
+
+### Mise Configuration Precedence
+
+The Railpack build process ends up generated system-level (`/etc/mise/config.toml`). You can override these settings with a project-level `mise.toml` file.
 
 ## Configuration and Build Plans
 

--- a/docs/src/content/docs/config/options.md
+++ b/docs/src/content/docs/config/options.md
@@ -24,8 +24,8 @@ relatively low level build plan schema.
 
 There are many configuration options which can be defined in multiple places. Here is the order of precedence (highest wins):
 
-1. CLI flags (`--build-cmd`, `--start-cmd`, etc)
-2. Environment variables passed with `--env` (`RAILPACK)
+1. CLI flags (`--start-cmd`, etc)
+2. Environment variables passed with `--env` (`RAILPACK_START_CMD`, etc)
 3. [`railpack.json`](/config/file)
 4. [Procfile](/config/procfile) (only for the start command)
 5. Provider and detected defaults

--- a/examples/config-precedence/Procfile
+++ b/examples/config-precedence/Procfile
@@ -1,0 +1,1 @@
+web: echo from-procfile

--- a/examples/config-precedence/railpack.json
+++ b/examples/config-precedence/railpack.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "provider": "shell",
+  "deploy": {
+    "startCommand": "echo from-file"
+  }
+}

--- a/examples/config-precedence/start.sh
+++ b/examples/config-precedence/start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo from-provider

--- a/examples/config-precedence/test.json
+++ b/examples/config-precedence/test.json
@@ -1,0 +1,13 @@
+[
+  {
+    // railpack.json startCommand beats Procfile
+    "expectedOutput": "from-file"
+  },
+  {
+    // RAILPACK_START_CMD beats railpack.json
+    "expectedOutput": "from-env",
+    "envs": {
+      "RAILPACK_START_CMD": "echo from-env"
+    }
+  }
+]


### PR DESCRIPTION
## Motivation

Configuration sources were merged in reverse priority, allowing `railpack.json` to unexpectedly override environment and CLI settings.

## Description

- Apply configuration precedence in this order: CLI options, environment variables, then `railpack.json`.
- Apply the same precedence when selecting a configuration file.
- Combine and deduplicate secret names across configuration sources.
- Document precedence rules for commands, arrays, packages, Procfiles, and provider defaults.

## Breaking Changes

Projects that define the same option in multiple configuration sources may produce different build plans.

- `--build-cmd` and `--start-cmd` now override corresponding environment and file settings.
- `RAILPACK_INSTALL_CMD`, `RAILPACK_BUILD_CMD`, and `RAILPACK_START_CMD` now override commands in `railpack.json`.
- `RAILPACK_PACKAGES` now determines the version when the same package is declared in `railpack.json`; packages unique to either source remain included.
- `RAILPACK_BUILD_APT_PACKAGES` and `RAILPACK_DEPLOY_APT_PACKAGES` replace corresponding file lists. Include all desired packages—and `...` where applicable—in the higher-priority environment value.
- `--config-file` now overrides `RAILPACK_CONFIG_FILE` when both are provided, which may select a different file or surface a missing-file error.

Projects that configure each option in only one source are unaffected. Empty CLI and environment values remain ignored; remove stale higher-priority settings to fall back to `railpack.json`.

## Test

- Added unit coverage for CLI, environment, file, Procfile, and provider-default precedence.
- Added coverage for configuration-file selection and empty values.
- Validated precedence through the `config-precedence` integration example.
