### PR TITLE
fix(build): require --env for RAILPACK_DISABLE_CACHES

### DIFF
--- a/buildkit/build_llb/build_graph.go
+++ b/buildkit/build_llb/build_graph.go
@@ -399,21 +399,11 @@ func (g *BuildGraph) getSecretInvalidationMountOptions(node *StepNode, secretOpt
 	return opts
 }
 
-func isCacheDisabled(key string) bool {
-	// TODO: Thread Environment-derived config into BuildGraph instead of reading process envs here.
-	disabled := os.Getenv("RAILPACK_DISABLE_CACHES")
-	return disabled == "*" || slices.Contains(strings.Split(disabled, " "), key)
-}
-
 // returns the llb.RunOption slice for the given cache keys
 func (g *BuildGraph) getCacheMountOptions(cacheKeys []string) ([]llb.RunOption, error) {
 	var opts []llb.RunOption
 
 	for _, cacheKey := range cacheKeys {
-		if isCacheDisabled(cacheKey) {
-			continue
-		}
-
 		if planCache, ok := g.Plan.Caches[cacheKey]; ok {
 			cache := g.CacheStore.GetCache(cacheKey, planCache)
 			cacheType := llb.CacheMountShared

--- a/buildkit/build_llb/build_graph_test.go
+++ b/buildkit/build_llb/build_graph_test.go
@@ -32,7 +32,6 @@ func TestBuildGraphNoCache(t *testing.T) {
 		g, err := NewBuildGraph(p, &localState, cacheStore, "", &platform, "", false)
 		require.NoError(t, err)
 		require.False(t, g.NoCache)
-		require.False(t, isCacheDisabled("test-cache"))
 	})
 
 	t.Run("with NoCache=true", func(t *testing.T) {
@@ -40,8 +39,6 @@ func TestBuildGraphNoCache(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, g.NoCache)
 		// NoCache should NOT affect if caches are enabled or not, it just affects the layer cache
-		require.False(t, isCacheDisabled("test-cache"))
-
 		opts, err := g.getCacheMountOptions([]string{"test-cache"})
 		require.NoError(t, err)
 		require.Len(t, opts, 1)

--- a/core/core.go
+++ b/core/core.go
@@ -127,6 +127,14 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 		providerToUse.CleansePlan(buildPlan)
 	}
 
+	if env != nil {
+		disabledCaches, _ := env.GetConfigVariableList("DISABLE_CACHES")
+		if len(disabledCaches) > 1 && slices.Contains(disabledCaches, "*") {
+			logger.LogWarn("RAILPACK_DISABLE_CACHES contains `*`; all other cache keys will be ignored.")
+		}
+		disablePlanCaches(buildPlan, disabledCaches)
+	}
+
 	if !ValidatePlan(buildPlan, app, logger, &ValidatePlanOptions{
 		ErrorMissingStartCommand: options.ErrorMissingStartCommand,
 		ProviderToUse:            providerToUse,
@@ -145,6 +153,40 @@ func GenerateBuildPlan(app *app.App, env *app.Environment, options *GenerateBuil
 	}
 
 	return buildResult, nil
+}
+
+// Removes disabled cache mounts from the generated plan.
+func disablePlanCaches(buildPlan *plan.BuildPlan, disabledCaches []string) {
+	if len(disabledCaches) == 0 {
+		return
+	}
+
+	// A wildcard removes every cache definition and all step references.
+	if slices.Contains(disabledCaches, "*") {
+		clear(buildPlan.Caches)
+		for i := range buildPlan.Steps {
+			buildPlan.Steps[i].Caches = nil
+		}
+		return
+	}
+
+	// Remove named caches from their definitions and from every step that uses them.
+	disabled := make(map[string]struct{}, len(disabledCaches))
+	for _, cache := range disabledCaches {
+		disabled[cache] = struct{}{}
+		delete(buildPlan.Caches, cache)
+	}
+
+	for i := range buildPlan.Steps {
+		caches := slices.DeleteFunc(buildPlan.Steps[i].Caches, func(cache string) bool {
+			_, ok := disabled[cache]
+			return ok
+		})
+		if len(caches) == 0 {
+			caches = nil
+		}
+		buildPlan.Steps[i].Caches = caches
+	}
 }
 
 // records a planning failure in the build result. Transient failures are also returned

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -3,14 +3,17 @@ package core
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/railwayapp/railpack/core/app"
 	"github.com/railwayapp/railpack/core/logger"
 	"github.com/railwayapp/railpack/core/mise"
+	"github.com/railwayapp/railpack/core/plan"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,6 +82,80 @@ func TestFailedBuildResult(t *testing.T) {
 	require.NoError(t, err, "deterministic failures are reported in the build result only")
 	require.False(t, result.Success)
 	require.NotEmpty(t, result.Logs)
+}
+
+func TestDisablePlanCaches(t *testing.T) {
+	newPlan := func() *plan.BuildPlan {
+		return &plan.BuildPlan{
+			Caches: map[string]*plan.Cache{
+				"gradle":      {Directory: "/root/.gradle"},
+				"maven":       {Directory: "/root/.m2/repository"},
+				"npm-install": {Directory: "/root/.npm"},
+			},
+			Steps: []plan.Step{
+				{Caches: []string{"gradle", "maven"}},
+				{Caches: []string{"npm-install"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		disabledCaches []string
+		expectedCaches []string
+		expectedSteps  [][]string
+	}{
+		{
+			name:           "named caches",
+			disabledCaches: []string{"gradle", "npm-install"},
+			expectedCaches: []string{"maven"},
+			expectedSteps:  [][]string{{"maven"}, nil},
+		},
+		{
+			name:           "all caches with redundant named cache",
+			disabledCaches: []string{"*", "gradle"},
+			expectedCaches: nil,
+			expectedSteps:  [][]string{nil, nil},
+		},
+		{
+			name:           "unknown cache",
+			disabledCaches: []string{"unknown"},
+			expectedCaches: []string{"gradle", "maven", "npm-install"},
+			expectedSteps:  [][]string{{"gradle", "maven"}, {"npm-install"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildPlan := newPlan()
+			disablePlanCaches(buildPlan, tt.disabledCaches)
+
+			require.Equal(t, tt.expectedCaches, slices.Sorted(maps.Keys(buildPlan.Caches)))
+			for i, expected := range tt.expectedSteps {
+				require.Equal(t, expected, buildPlan.Steps[i].Caches)
+			}
+		})
+	}
+}
+
+func TestGenerateBuildPlan_DisableCachesRequiresEnvironmentArgument(t *testing.T) {
+	userApp, err := app.NewApp("../examples/java-gradle")
+	require.NoError(t, err)
+
+	t.Setenv("RAILPACK_DISABLE_CACHES", "gradle")
+	buildResult, err := GenerateBuildPlan(userApp, app.NewEnvironment(nil), &GenerateBuildPlanOptions{})
+	require.NoError(t, err)
+	require.True(t, buildResult.Success)
+	require.Contains(t, buildResult.Plan.Caches, "gradle")
+
+	envVars := map[string]string{"RAILPACK_DISABLE_CACHES": "gradle"}
+	buildResult, err = GenerateBuildPlan(userApp, app.NewEnvironment(&envVars), &GenerateBuildPlanOptions{})
+	require.NoError(t, err)
+	require.True(t, buildResult.Success)
+	require.NotContains(t, buildResult.Plan.Caches, "gradle")
+	for _, step := range buildResult.Plan.Steps {
+		require.NotContains(t, step.Caches, "gradle")
+	}
 }
 
 func TestGenerateConfigFromFile_NotFound(t *testing.T) {

--- a/docs/src/content/docs/config/environment-variables.md
+++ b/docs/src/content/docs/config/environment-variables.md
@@ -8,6 +8,10 @@ often prefixed with `RAILPACK_`.
 
 ## Build Configuration
 
+Variables that impact build configuration are *not* read from the process
+environment and must be specified explicitly with `--env` when using the
+Railpack CLI.
+
 | Name                           | Description                                                                                                                                                                     |
 | :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `RAILPACK_BUILD_CMD`           | Set the command to run for the build step. This overwrites any commands that come from providers                                                                                |
@@ -16,11 +20,13 @@ often prefixed with `RAILPACK_`.
 | `RAILPACK_PACKAGES`            | Install additional Mise packages. In the format `pkg[@version]`. The version is optional; if not provided, the latest version is used. Allows list.                             |
 | `RAILPACK_BUILD_APT_PACKAGES`  | Install additional Apt packages during build. Allows list.                                                                                                                      |
 | `RAILPACK_DEPLOY_APT_PACKAGES` | Install additional Apt packages in the final image. Allows list.                                                                                                                |
+| `RAILPACK_DISABLE_CACHES`      | Disable cache mounts defined in the top-level [`caches`](/config/file#caches) map, or `*` for all. Allows list. Layer caching is unaffected.                                     |
 
 Variables which allow a list use space-separated values. For example:
 
 ```sh
-RAILPACK_PACKAGES="pipx:httpie jq@latest"
+railpack build --env 'RAILPACK_PACKAGES=pipx:httpie jq@latest' .
+railpack build --env 'RAILPACK_DISABLE_CACHES=gradle maven' .
 ```
 
 To configure more parts of the build, it is recommended to use a [config file](/config/file).
@@ -36,4 +42,3 @@ with `--env`.
 | :------------------------ | :-------------------------------------------------------------------------- |
 | `FORCE_COLOR`             | Force colored output even when not in a TTY                                 |
 | `RAILPACK_VERBOSE`        | Enable verbose logging (equivalent to the `--verbose` flag)                 |
-| `RAILPACK_DISABLE_CACHES` | Disable specific BuildKit cache keys, or `*` to disable all caches. Allows list. |


### PR DESCRIPTION
## Motivation

`RAILPACK_DISABLE_CACHES` modifies the generated build, but was read directly from the Railpack process environment during LLB generation. This differed from other build configuration variables and meant values passed through `--env` were ignored.

It also made prepared build plans dependent on the environment of the process that later converted them to LLB.

## Description

Read `RAILPACK_DISABLE_CACHES` from the build environment supplied through `--env` and apply it during build plan generation.

Named cache mounts are removed from the top-level cache definitions and every step that references them. `*` removes all cache mounts. A warning is emitted when `*` is combined with redundant named cache mounts.

BuildKit conversion no longer reads `RAILPACK_DISABLE_CACHES` from the process environment, making conversion deterministic from the generated plan.

The environment variable documentation now distinguishes build configuration variables from process-level options and clarifies that this option does not disable layer caching.

## Breaking Changes

`RAILPACK_DISABLE_CACHES` is no longer read automatically from the Railpack process environment.

Existing usage such as:

```sh
RAILPACK_DISABLE_CACHES=gradle railpack build .
```

must be changed to:

```sh
railpack build --env RAILPACK_DISABLE_CACHES=gradle .
```

Alternatively, an exported value can be inherited explicitly:

```sh
export RAILPACK_DISABLE_CACHES=gradle
railpack build --env RAILPACK_DISABLE_CACHES .
```

Prepared plans now encode disabled cache mounts by omitting their definitions and step references. Downstream tooling that expects those entries to remain in `railpack-plan.json` may need to account for their absence.

BuildKit frontend processes can no longer influence cache mounts through their ambient `RAILPACK_DISABLE_CACHES` value. The variable must be supplied when generating the plan.

Builds that do not use `RAILPACK_DISABLE_CACHES` are unaffected.
