### PR TITLE
fix(buildkit): deduplicate inherited PATH entries

### DIFF
--- a/buildkit/build_llb/build_env.go
+++ b/buildkit/build_llb/build_env.go
@@ -19,8 +19,21 @@ func NewGraphEnvironment() BuildEnvironment {
 
 // Merges the other environment into the current environment
 func (e *BuildEnvironment) Merge(other BuildEnvironment) {
-	e.PathList = append(e.PathList, other.PathList...)
+	e.PathList = appendUniquePaths(e.PathList, other.PathList...)
 	maps.Copy(e.EnvVars, other.EnvVars)
+}
+
+func appendUniquePaths(existing []string, additions ...string) []string {
+	// Steps with shared ancestors inherit the same paths, so merging their outputs can
+	// otherwise duplicate entries in downstream steps and the final image PATH. Keep
+	// the first occurrence to preserve path precedence.
+	for _, path := range additions {
+		if slices.Contains(existing, path) {
+			continue
+		}
+		existing = append(existing, path)
+	}
+	return existing
 }
 
 func (e *BuildEnvironment) PushPath(path string) {

--- a/buildkit/build_llb/build_env_test.go
+++ b/buildkit/build_llb/build_env_test.go
@@ -1,0 +1,23 @@
+package build_llb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEnvironmentMergeDeduplicatesPaths(t *testing.T) {
+	env := BuildEnvironment{
+		PathList: []string{"/first", "/shared"},
+		EnvVars:  map[string]string{},
+	}
+	other := BuildEnvironment{
+		PathList: []string{"/shared", "/last"},
+		EnvVars:  map[string]string{},
+	}
+
+	env.Merge(other)
+
+	// Keeping /shared in its original position verifies that the first occurrence retains precedence.
+	require.Equal(t, []string{"/first", "/shared", "/last"}, env.PathList)
+}

--- a/buildkit/convert_test.go
+++ b/buildkit/convert_test.go
@@ -2,6 +2,7 @@ package buildkit
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -10,6 +11,8 @@ import (
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/railwayapp/railpack/buildkit/build_llb"
+	"github.com/railwayapp/railpack/core"
+	"github.com/railwayapp/railpack/core/app"
 	"github.com/railwayapp/railpack/core/plan"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +41,47 @@ func TestGetImageEnvIncludesBuiltAt(t *testing.T) {
 	require.GreaterOrEqual(t, timestamp, before)
 	require.LessOrEqual(t, timestamp, after)
 	require.True(t, slices.IsSorted(env))
+}
+
+func TestImagePathHasNoDuplicateEntries(t *testing.T) {
+	userApp, err := app.NewApp(filepath.Join("..", "examples", "ruby-with-node"))
+	require.NoError(t, err)
+
+	buildResult, err := core.GenerateBuildPlan(userApp, app.NewEnvironment(nil), &core.GenerateBuildPlanOptions{})
+	require.NoError(t, err)
+	require.True(t, buildResult.Success)
+
+	_, image, err := ConvertPlanToLLB(buildResult.Plan, ConvertPlanOptions{
+		BuildPlatform: specs.Platform{OS: "linux", Architecture: "amd64"},
+	})
+	require.NoError(t, err)
+
+	path := pathFromEnv(t, image.Config.Env)
+	require.Empty(t, duplicatePathEntries(path))
+}
+
+func pathFromEnv(t *testing.T, env []string) string {
+	t.Helper()
+
+	for _, envVar := range env {
+		if value, ok := strings.CutPrefix(envVar, "PATH="); ok {
+			return value
+		}
+	}
+	t.Fatal("PATH not found in image environment")
+	return ""
+}
+
+func duplicatePathEntries(path string) []string {
+	seen := map[string]bool{}
+	duplicates := []string{}
+	for _, entry := range strings.Split(path, ":") {
+		if seen[entry] {
+			duplicates = append(duplicates, entry)
+		}
+		seen[entry] = true
+	}
+	return duplicates
 }
 
 func TestDeployVariablesDoNotAffectLLB(t *testing.T) {

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -66,6 +66,9 @@ Now you can build your image using Railpack:
 railpack build ./path/to/project
 ```
 
+For a remote BuildKit host on a different CPU architecture, set `--platform`
+to an architecture supported by the remote builder.
+
 _(there are many examples in the [Railpack
 repo](https://github.com/railwayapp/railpack/tree/main/examples) that you can
 test with)_

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -52,6 +52,14 @@ docker info -f '{{.Name}} {{.OperatingSystem}}'
 docker context inspect -f '{{.Endpoints.docker.Host}}'
 ```
 
+If you use a remote Docker host with a different CPU architecture, specify
+the target platform explicitly. Without `--platform`, the CLI selects the
+architecture of the machine running Railpack, not the remote Docker host;
+`DOCKER_HOST` only changes where the build executes. Use a flag such as
+`--platform linux/amd64` for CLI builds, or set `"platform": "linux/amd64"`
+in an example's `test.json`, matching a platform supported by the remote
+BuildKit worker.
+
 Use the `cli` task to run the Railpack CLI (this is like `railpack --help`)
 
 ```bash

--- a/examples/ruby-with-node/app.rb
+++ b/examples/ruby-with-node/app.rb
@@ -1,1 +1,8 @@
-puts "Hello from Ruby with Node"
+# The Ruby and Node deploy steps overlap, which currently duplicates inherited PATH entries.
+# Assert the runtime value so this example reproduces the image configuration bug.
+paths = ENV.fetch("PATH").split(":")
+duplicates = paths.tally.filter_map { |path, count| path if count > 1 }
+
+abort "Duplicate PATH entries: #{duplicates.join(", ")}" unless duplicates.empty?
+
+puts "PATH contains no duplicate entries"

--- a/examples/ruby-with-node/test.json
+++ b/examples/ruby-with-node/test.json
@@ -1,5 +1,5 @@
 [
   {
-    "expectedOutput": "Hello from Ruby with Node"
+    "expectedOutput": "PATH contains no duplicate entries"
   }
 ]


### PR DESCRIPTION
## Motivation

Build steps inherit PATH entries from their ancestors. When deploy inputs shared ancestors, merging their environments appended those inherited paths repeatedly and produced duplicate entries in the final image PATH.

## Description

Treat build environment paths as an ordered set during merges, retaining the first occurrence to preserve path precedence. Add direct merge coverage, verify the generated image environment using an example project, and assert PATH uniqueness at runtime.

## Test
- Added regression tests for path deduplication, precedence, and generated image configuration
- Added runtime coverage to the Ruby-with-Node example