### PR TITLE
feat: upgrade builder and runtime images to Debian 13

### DIFF
--- a/.claude/commands/update-debian.md
+++ b/.claude/commands/update-debian.md
@@ -1,0 +1,103 @@
+Update Railpack's builder and runtime images to a new Debian stable release. Focus on code changes and tests. If `$ARGUMENTS` is a Debian codename (e.g. `forky`), use that; otherwise pick the current Debian stable.
+
+Do not commit, push, or open a PR unless asked.
+
+## 1. Pick the target
+
+Confirm the current stable Debian version and codename (wiki.debian.org/DebianReleases). Note the **old** and **new** codenames from:
+
+- `images/debian/build/Dockerfile` (`FROM buildpack-deps:<codename>-scm`)
+- `images/debian/runtime/Dockerfile` (`FROM debian:<codename>-slim`)
+- `.github/workflows/release.yml` (`debian-<codename>` tags)
+
+## 2. Image and tag changes
+
+Update all three to the new codename. Keep the `-scm` / `-slim` suffixes.
+
+CI only rebuilds and pushes `ghcr.io/railwayapp/railpack-{builder,runtime}:mise-*` when `core/mise/version.txt` is **newer than origin/main**. Dockerfile `FROM` changes do nothing in production until that happens. **Never overwrite an existing `mise-*` tag.**
+
+- If `version.txt` already differs from origin/main, the Debian change can ride that bump.
+- Otherwise set `core/mise/version.txt` to the latest mise release (`gh release view --repo jdx/mise --json tagName --jq .tagName`, strip a leading `v`).
+
+Leave the comment in `.github/workflows/integration-tests.yml` that explains this coupling.
+
+## 3. Companion code
+
+Search the repo for the old codename and for hardcoded apt names. Typical call sites:
+
+| Area | Files |
+| --- | --- |
+| FrankenPHP image tag | `core/providers/php/php.go` (`dunglas/frankenphp:php%s-<codename>`) |
+| Node Chromium deps | `core/providers/node/node.go` (puppeteer + playwright lists) |
+| Python native / Playwright deps | `core/providers/python/python.go` |
+| Other provider apt | `core/providers/{ruby,golang,dotnet,shell}` |
+| Builder apt packages | `images/debian/build/Dockerfile` |
+| Example apt packages | `examples/**/railpack*.json` |
+| Docs | `docs/src/content/docs/architecture/overview.md` |
+
+Do **not** change `core/generate/context_test.go` deploy-base fixtures unless they are asserting Railpack's default image; those tests use a user-configured `debian:*-slim`.
+
+Do **not** edit the generated changelog.
+
+### FrankenPHP
+
+`getPhpImage` bakes the Debian codename into the tag. Confirm Docker Hub has `dunglas/frankenphp:php<version>-<new-codename>` for the PHP versions used in `examples/php-*` (the provider also probes Hub at plan time). Update the tag format **and** the nearby comments.
+
+### Apt packages
+
+Debian often removes packages, adds `t64` names, or replaces transitional packages that `apt-cache` still lists but `apt-get install` rejects.
+
+Collect every package from the Dockerfiles, provider lists, and example `aptPackages` / `buildAptPackages`. Install them for real on both new bases (not `apt-cache policy`):
+
+```bash
+docker run --rm debian:<new>-slim bash -lc 'apt-get update && apt-get install -y --no-install-recommends <pkgs>'
+docker run --rm buildpack-deps:<new>-scm bash -lc 'apt-get update && apt-get install -y --no-install-recommends <pkgs>'
+```
+
+Use names that `apt-get install` accepts on the **new** distro. If a package is gone (e.g. `neofetch` on Trixie), replace it in examples with something that still exists and update `test.json` expected output.
+
+Do not add comments that explain what the previous Debian release dropped or renamed. Keep that for the PR description.
+
+## 4. Local images for CLI / integration tests
+
+`mise run cli` and integration tests pull `ghcr.io/railwayapp/railpack-{builder,runtime}:mise-$(cat core/mise/version.txt)`, not `:local`. Build, then retag so those refs resolve to the new Dockerfiles:
+
+```bash
+mise run image-builder-build
+mise run image-runtime-build
+ver=$(cat core/mise/version.txt)
+docker tag railpack-builder:local "ghcr.io/railwayapp/railpack-builder:mise-${ver}"
+docker tag railpack-runtime:local "ghcr.io/railwayapp/railpack-runtime:mise-${ver}"
+```
+
+Confirm `/etc/os-release` on the runtime image shows the new `VERSION_CODENAME`.
+
+## 5. Tests
+
+After code changes:
+
+```bash
+mise run check
+mise run test-update-snapshots
+# review snapshot diffs (FrankenPHP tags, apt install command strings)
+mise run test
+```
+
+Then build **and run** examples that install apt packages or use FrankenPHP. Prefer `mise run test-integration -- -run 'TestExamplesIntegration/<example>'` (Playwright `test.json` envs are applied automatically). Minimum set:
+
+- `shell-script` — new runtime base
+- `config-file` — user apt packages
+- `python-system-deps` — cairo / poppler / ffmpeg
+- `rust-system-deps` — OpenSSL on the builder
+- `node-lts-npm-native-deps` — native modules on the builder
+- `node-puppeteer` (including the custom-apt `test.json` case)
+- `node-playwright` / `python-playwright`
+- `php-vanilla`, `php-vanilla-82`, `php-laravel-12-react`
+
+Fix install failures (`Unable to locate package`, `has no installation candidate`) in code, not by skipping the example.
+
+## 6. Report
+
+Old → new Debian. Whether mise was bumped and to which version. Companion package / FrankenPHP / example changes. Which integration tests ran and what failed.
+
+Include PR-description context for package churn (removed, renamed, or transitional), for example: Debian 13 dropped `gconf-service` / `libgconf-2-4` / `libappindicator1`, renamed `libgdk-pixbuf2.0-0` to `libgdk-pixbuf-2.0-0`, and removed `neofetch` from the archive. Do not put that prose in source comments.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           images: ${{ env.PRODUCTION_BUILDER_IMAGE_NAME }}
           # latest tag is automatically generated
           tags: |
-            type=raw,value=debian-bookworm
+            type=raw,value=debian-trixie
             type=semver,pattern={{version}}
             type=raw,value=${{ env.PRODUCTION_MISE_TAG }}
             type=sha,format=long
@@ -86,7 +86,7 @@ jobs:
           images: ${{ env.PRODUCTION_RUNTIME_IMAGE_NAME }}
           # latest tag is automatically generated
           tags: |
-            type=raw,value=debian-bookworm
+            type=raw,value=debian-trixie
             type=semver,pattern={{version}}
             type=raw,value=${{ env.PRODUCTION_MISE_TAG }}
             type=sha,format=long

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_config-file_1.snap.json
@@ -50,7 +50,7 @@
     "step": "build"
    }
   ],
-  "startCommand": "python --version \u0026\u0026 neofetch $HELLO",
+  "startCommand": "python --version \u0026\u0026 lsb_release -d",
   "variables": {
    "CI": "true",
    "NODE_ENV": "production",
@@ -69,8 +69,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y neofetch'",
-     "customName": "install apt packages: neofetch"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y lsb-release'",
+     "customName": "install apt packages: lsb-release"
     }
    ],
    "inputs": [
@@ -156,8 +156,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'neofetch'",
-     "customName": "neofetch"
+     "cmd": "sh -c 'lsb_release -a'",
+     "customName": "lsb_release -a"
     }
    ],
    "inputs": [
@@ -186,8 +186,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y neofetch'",
-     "customName": "install apt packages: neofetch"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y lsb-release'",
+     "customName": "install apt packages: lsb-release"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-puppeteer_1.snap.json
@@ -159,8 +159,8 @@
    ],
    "commands": [
     {
-     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y ca-certificates fonts-liberation gconf-service libappindicator1 libasound2 libatk1.0-0 libatomic1 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils xvfb'",
-     "customName": "install apt packages: ca-certificates fonts-liberation gconf-service libappindicator1 libasound2 libatk1.0-0 libatomic1 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils xvfb"
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y ca-certificates fonts-liberation libasound2 libatk1.0-0 libatomic1 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgdk-pixbuf-2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils xvfb'",
+     "customName": "install apt packages: ca-certificates fonts-liberation libasound2 libatk1.0-0 libatomic1 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgdk-pixbuf-2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils xvfb"
     }
    ],
    "inputs": [

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-11-react_1.snap.json
@@ -103,7 +103,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.2.33-bookworm"
+     "image": "dunglas/frankenphp:php8.2.33-trixie"
     }
    ],
    "name": "packages:image"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-laravel-12-react_1.snap.json
@@ -103,7 +103,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.2.33-bookworm"
+     "image": "dunglas/frankenphp:php8.2.33-trixie"
     }
    ],
    "name": "packages:image"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla-82_1.snap.json
@@ -24,7 +24,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.2.33-bookworm"
+     "image": "dunglas/frankenphp:php8.2.33-trixie"
     }
    ],
    "name": "packages:image"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_php-vanilla_1.snap.json
@@ -18,7 +18,7 @@
    ],
    "inputs": [
     {
-     "image": "dunglas/frankenphp:php8.4.24-bookworm"
+     "image": "dunglas/frankenphp:php8.4.24-trixie"
     }
    ],
    "name": "packages:image"

--- a/core/generate/context_test.go
+++ b/core/generate/context_test.go
@@ -172,18 +172,18 @@ func TestGenerateContextAppliesConfiguredDeployBase(t *testing.T) {
 	t.Run("direct deploy base", func(t *testing.T) {
 		ctx := CreateTestContext(t, "../../examples/node-npm")
 		cfg := config.EmptyConfig()
-		cfg.Deploy.Base = &plan.Layer{Image: "debian:bookworm-slim"}
+		cfg.Deploy.Base = &plan.Layer{Image: "debian:trixie-slim"}
 		ctx.Config = cfg
 
 		buildPlan, _, err := ctx.Generate()
 		require.NoError(t, err)
-		require.Equal(t, plan.NewImageLayer("debian:bookworm-slim"), buildPlan.Deploy.Base)
+		require.Equal(t, plan.NewImageLayer("debian:trixie-slim"), buildPlan.Deploy.Base)
 	})
 
 	t.Run("runtime apt step uses configured deploy base", func(t *testing.T) {
 		ctx := CreateTestContext(t, "../../examples/node-npm")
 		cfg := config.EmptyConfig()
-		cfg.Deploy.Base = &plan.Layer{Image: "debian:bookworm-slim"}
+		cfg.Deploy.Base = &plan.Layer{Image: "debian:trixie-slim"}
 		cfg.Deploy.AptPackages = []string{"curl"}
 		ctx.Config = cfg
 
@@ -200,7 +200,7 @@ func TestGenerateContextAppliesConfiguredDeployBase(t *testing.T) {
 		}
 
 		require.NotNil(t, runtimeAptStep)
-		require.Equal(t, []plan.Layer{plan.NewImageLayer("debian:bookworm-slim")}, runtimeAptStep.Inputs)
+		require.Equal(t, []plan.Layer{plan.NewImageLayer("debian:trixie-slim")}, runtimeAptStep.Inputs)
 	})
 }
 

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -28,11 +28,11 @@ const (
 )
 
 var nodeRuntimeDepRequirements = map[string][]string{
-	// To find the latest list: run `npx puppeteer@latest install --help` and inspect docs
-	"puppeteer": {"xvfb", "gconf-service", "libasound2", "libatk1.0-0", "libc6", "libcairo2", "libcups2", "libdbus-1-3", "libexpat1", "libfontconfig1", "libgbm1", "libgcc1", "libgconf-2-4", "libgdk-pixbuf2.0-0", "libglib2.0-0", "libgtk-3-0", "libnspr4", "libpango-1.0-0", "libpangocairo-1.0-0", "libstdc++6", "libx11-6", "libx11-xcb1", "libxcb1", "libxcomposite1", "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6", "libxrandr2", "libxrender1", "libxss1", "libxtst6", "ca-certificates", "fonts-liberation", "libappindicator1", "libnss3", "lsb-release", "xdg-utils", "wget"},
+	// To find the latest list: run `npx puppeteer@latest install --help` and inspect docs.
+	"puppeteer": {"xvfb", "libasound2", "libatk1.0-0", "libc6", "libcairo2", "libcups2", "libdbus-1-3", "libexpat1", "libfontconfig1", "libgbm1", "libgcc1", "libgdk-pixbuf-2.0-0", "libglib2.0-0", "libgtk-3-0", "libnspr4", "libpango-1.0-0", "libpangocairo-1.0-0", "libstdc++6", "libx11-6", "libx11-xcb1", "libxcb1", "libxcomposite1", "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6", "libxrandr2", "libxrender1", "libxss1", "libxtst6", "ca-certificates", "fonts-liberation", "libnss3", "lsb-release", "xdg-utils", "wget"},
 }
 
-// Keep this aligned with the Debian 12 Chromium list in Playwright's nativeDeps.ts:
+// Keep this aligned with Playwright's Chromium deps in nativeDeps.ts:
 // https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/nativeDeps.ts
 // Keep these explicit because --with-deps installs them in the builder, not the runtime image.
 var nodePlaywrightRuntimeDependencies = []string{

--- a/core/providers/php/php.go
+++ b/core/providers/php/php.go
@@ -429,10 +429,10 @@ func (p *PhpProvider) phpImagePackage(ctx *generate.GenerateContext) (*generate.
 	imageStep.SetVersionAvailable(php, func(version string) bool {
 		image := getPhpImage(version)
 
-		// dunglas/frankenphp:php8.4.3-bookworm -> [dunglas, frankenphp, php8.4.3-bookworm]
+		// dunglas/frankenphp:php8.4.3-trixie -> [dunglas, frankenphp, php8.4.3-trixie]
 		parts := strings.Split(image, ":")
 		repository := parts[0] // dunglas/frankenphp
-		tag := parts[1]        // php8.4.3-bookworm
+		tag := parts[1]        // php8.4.3-trixie
 
 		url := fmt.Sprintf("https://registry.hub.docker.com/v2/repositories/%s/tags/%s", repository, tag)
 		resp, err := http.Get(url)
@@ -447,7 +447,7 @@ func (p *PhpProvider) phpImagePackage(ctx *generate.GenerateContext) (*generate.
 }
 
 func getPhpImage(phpVersion string) string {
-	return fmt.Sprintf("dunglas/frankenphp:php%s-bookworm", phpVersion)
+	return fmt.Sprintf("dunglas/frankenphp:php%s-trixie", phpVersion)
 }
 
 func (p *PhpProvider) readComposerJson(ctx *generate.GenerateContext) (map[string]any, error) {

--- a/core/providers/python/python.go
+++ b/core/providers/python/python.go
@@ -22,7 +22,7 @@ const (
 	PLAYWRIGHT_INSTALL_VAR = "PYTHON_PLAYWRIGHT_INSTALL"
 )
 
-// Keep this aligned with the Debian 12 Chromium list in Playwright's nativeDeps.ts:
+// Keep this aligned with Playwright's Chromium deps in nativeDeps.ts:
 // https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/nativeDeps.ts
 var pythonPlaywrightRuntimeDependencies = []string{
 	"libasound2",

--- a/examples/config-file/railpack.json
+++ b/examples/config-file/railpack.json
@@ -4,10 +4,10 @@
   "packages": {
     "python": "latest"
   },
-  "buildAptPackages": ["neofetch"],
+  "buildAptPackages": ["lsb-release"],
   "steps": {
     "build": {
-      "commands": ["neofetch"],
+      "commands": ["lsb_release -a"],
       "variables": {
         "HELLO": "world"
       }
@@ -15,7 +15,7 @@
   },
   "deploy": {
     "inputs": ["..."],
-    "aptPackages": ["neofetch"],
-    "startCommand": "python --version && neofetch $HELLO"
+    "aptPackages": ["lsb-release"],
+    "startCommand": "python --version && lsb_release -d"
   }
 }

--- a/examples/config-file/test.json
+++ b/examples/config-file/test.json
@@ -1,6 +1,6 @@
 [
   {
-    "expectedOutput": "Kernel"
+    "expectedOutput": "Debian"
   },
   {
     "expectedOutput": "custom start",

--- a/images/debian/build/Dockerfile
+++ b/images/debian/build/Dockerfile
@@ -1,6 +1,6 @@
 # Image used by railpack during the build process, but not as the base image of the final runtime image
 # scm = fat image containing a lot of build tools
-FROM buildpack-deps:bookworm-scm
+FROM buildpack-deps:trixie-scm
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/images/debian/runtime/Dockerfile
+++ b/images/debian/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # Base image for the final runtime image created by railpack
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Motivation

Debian 12 (Bookworm) regular support ended 2026-07-11. Builder and runtime images still use Bookworm (`buildpack-deps:bookworm-scm` / `debian:bookworm-slim`), so new deploys are based on a distro that is no longer the current stable.

## Description

Move both images to Debian 13 (Trixie):

- Builder: `buildpack-deps:trixie-scm`
- Runtime: `debian:trixie-slim`
- GHCR convenience tags: `debian-bookworm` → `debian-trixie`
- PHP: FrankenPHP tags `dunglas/frankenphp:php%s-bookworm` → `php%s-trixie`

Railpack-managed Apt lists that broke on Trixie are updated (Puppeteer Chromium deps). The `config-file` example no longer installs `neofetch` from Apt; that package is gone from Debian 13.

CI only publishes new `mise-*` builder/runtime tags when `core/mise/version.txt` is newer than origin/main. This change must ship with a mise bump so existing `mise-*` tags are not overwritten. That bump is still outstanding (`2026.8.5` matches main).

## Test

Built local Trixie builder/runtime images and ran example builds against them:

- Baseline: `shell-script`, `go-mod`, `python-uv-tool-versions`
- Apt / native: `config-file`, `python-system-deps`, `rust-system-deps`, `node-lts-npm-native-deps`
- Browsers: `node-puppeteer` (default + custom apt), `node-playwright`, `python-playwright`
- PHP: `php-vanilla`, `php-vanilla-82`, `php-laravel-12-react` (FrankenPHP 8.2.33, HTTP 200)

## Breaking Changes

After this Railpack version is released, **new builds** use Debian 13. Existing images are unchanged until rebuilt.

### Custom Apt packages

`buildAptPackages`, `deploy.aptPackages`, `RAILPACK_BUILD_APT_PACKAGES`, and `RAILPACK_DEPLOY_APT_PACKAGES` install from Trixie, not Bookworm. A Bookworm package name that was removed or renamed will fail the build (`Unable to locate package` / `has no installation candidate`).

Update the names to whatever Trixie provides ([packages.debian.org](https://packages.debian.org/trixie/)). Examples we hit:

| Bookworm | Trixie |
| --- | --- |
| `neofetch` | removed (use `fastfetch`, or another package you actually need) |
| `libgdk-pixbuf2.0-0` | `libgdk-pixbuf-2.0-0` |
| `gconf-service`, `libgconf-2-4`, `libappindicator1` | removed |

If you omit `...` and replace Railpack's Apt list, include Trixie-valid Chromium libraries for Puppeteer/Playwright yourself.

### Pinned Debian / FrankenPHP images

If `deploy.base` (or a copied-in image) is still `debian:bookworm-slim` / `dunglas/frankenphp:php*-bookworm`, the **builder** will be Trixie while runtime stays Bookworm. Native modules compiled in the builder can fail to load at runtime. Point those pins at Trixie, or drop them and use the defaults.

### Native addons and prebuilt binaries

Next deploy recompiles native addons on Trixie (newer glibc). Bookworm-built binaries usually still run. Binaries or scripts that assume Bookworm paths, `.so` names, or `/etc/os-release` may need a rebuild or a package-name change.

## Links

- https://wiki.debian.org/DebianTrixie
- https://wiki.debian.org/LTS
- https://packages.debian.org/trixie/
- https://hub.docker.com/r/dunglas/frankenphp/tags
- Apt config: https://railpack.com/guides/installing-packages#apt

Made with [Cursor](https://cursor.com)