### PR TITLE
feat(secrets): promote step secrets into the build plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,9 @@ Follow these instructions carefully when writing code:
 - Use appropriate error handling with proper error wrapping
 - Do not write comments that are obvious from the code itself; focus on
   explaining why something is done, not what it does
+- Do not end one-line comments with a period
+- Do not preserve behavior or add complexity solely to avoid snapshot changes;
+  update and review snapshots when intended behavior changes
 - Seriously, do not write comments that are obvious from the code itself.
 - Do not write one-line functions
 - Always use the App abstraction for file system operations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,13 @@ it into a container image. It's built on BuildKit with support for Node, Python,
 
 Follow these instructions carefully when writing code:
 
-- When writing a comment describing a function, do not start the comment with the name of the function
+- Add a concise one-line comment above functions whose purpose is not
+  immediately obvious. Describe their role or why they exist without starting
+  the comment with the function name.
 - Assume the person reading this code is an expert software engineer, but is not familiar with the internals of every system. Include concise one-line comments explaining key hooks, API usage, blocks of logic, etc., to help the reader quickly understand the code you've written.
 - Follow Go conventions and existing patterns in the codebase
+- Prefer modern Go standard-library APIs and idioms supported by the Go version
+  pinned in `mise.toml` when they make the code clearer or simpler.
 - Prefer early `return`s or `continue`s to `if` nesting
 - Use appropriate error handling with proper error wrapping
 - Do not write comments that are obvious from the code itself; focus on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ There are normal unit tests, snapshot tests, and integration tests. The integrat
 
 - Assume the reader knows the documentation is about Railpack. Avoid
   redundantly naming Railpack when the subject is clear from context.
+- Always call a JSON array an "array". Do not use "list", "catalog", or other
+  terms for that concept.
 
 # File Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ Follow these instructions carefully when writing code:
 - Follow Go conventions and existing patterns in the codebase
 - Prefer modern Go standard-library APIs and idioms supported by the Go version
   pinned in `mise.toml` when they make the code clearer or simpler.
+- Assume no external Go applications consume this project as a library; exported
+  APIs only need compatibility with in-repository consumers unless stated otherwise.
 - Prefer early `return`s or `continue`s to `if` nesting
 - Use appropriate error handling with proper error wrapping
 - Do not write comments that are obvious from the code itself; focus on

--- a/buildkit/frontend.go
+++ b/buildkit/frontend.go
@@ -70,12 +70,6 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		return nil, err
 	}
 
-	// TODO why are we marshalling the plan here if we don't do anything with it?
-	_, err = json.MarshalIndent(plan, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("error marshalling plan: %w", err)
-	}
-
 	llbState, image, err := ConvertPlanToLLB(plan, ConvertPlanOptions{
 		BuildPlatform: buildPlatform,
 		SecretsHash:   secretsHash,

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_secrets_1.snap.json
@@ -17,15 +17,15 @@
     "step": "usesSecrets"
    }
   ],
-  "startCommand": "./run.sh",
+  "startCommand": "echo secrets-build-succeeded",
   "variables": {
    "RAILPACK_VERSION": "dev"
   }
  },
  "secrets": [
+  "HELLO_WORLD",
   "MY_SECRET",
-  "MY_OTHER_SECRET",
-  "HELLO_WORLD"
+  "MY_OTHER_SECRET"
  ],
  "steps": [
   {
@@ -43,8 +43,8 @@
      "src": "."
     },
     {
-     "cmd": "sh -c './run.sh'",
-     "customName": "./run.sh"
+     "cmd": "sh -c './run.sh HELLO_WORLD NOT_SECRET'",
+     "customName": "./run.sh HELLO_WORLD NOT_SECRET"
     }
    ],
    "inputs": [
@@ -54,7 +54,7 @@
    ],
    "name": "defaultsToUsing",
    "secrets": [
-    "*"
+    "HELLO_WORLD"
    ],
    "variables": {
     "NOT_SECRET": "not secret"
@@ -67,8 +67,8 @@
      "src": "."
     },
     {
-     "cmd": "sh -c './run.sh'",
-     "customName": "./run.sh"
+     "cmd": "sh -c './run.sh MY_SECRET MY_OTHER_SECRET NOT_SECRET'",
+     "customName": "./run.sh MY_SECRET MY_OTHER_SECRET NOT_SECRET"
     }
    ],
    "inputs": [

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	Deploy           *DeployConfig          `json:"deploy,omitempty" jsonschema:"description=Deploy configuration"`
 	Packages         map[string]string      `json:"packages,omitempty" jsonschema:"description=Map of package name to package version"`
 	Caches           map[string]*plan.Cache `json:"caches,omitempty" jsonschema:"description=Map of cache name to cache definitions. The cache key can be referenced in an exec command"`
-	Secrets          []string               `json:"secrets,omitempty" jsonschema:"description=Secrets that should be made available to commands that have useSecrets set to true"`
+	Secrets          []string               `json:"secrets,omitempty" jsonschema:"description=Secrets that should be made available to build commands"`
 	Exclude          []string               `json:"exclude,omitempty" jsonschema:"description=File patterns to exclude from the build context (alternative to .dockerignore). Supports negation patterns starting with ! to include files that would otherwise be excluded"`
 }
 

--- a/core/generate/__snapshots__/context_test.snap
+++ b/core/generate/__snapshots__/context_test.snap
@@ -86,7 +86,8 @@
    ],
    "name": "build",
    "secrets": [
-    "*"
+    "RAILWAY_SECRET_1",
+    "RAILWAY_SECRET_2"
    ]
   }
  ]

--- a/core/generate/context.go
+++ b/core/generate/context.go
@@ -37,8 +37,7 @@ type GenerateContext struct {
 	Steps     []StepBuilder
 	Deploy    *DeployBuilder
 
-	Caches  *CacheContext
-	Secrets []string
+	Caches *CacheContext
 
 	SubContexts []string
 
@@ -88,7 +87,6 @@ func NewGenerateContext(app *a.App, env *a.Environment, config *config.Config, l
 		Steps:           make([]StepBuilder, 0),
 		Deploy:          NewDeployBuilder(),
 		Caches:          NewCacheContext(),
-		Secrets:         []string{},
 		Metadata:        NewMetadata(),
 		Resolver:        resolver,
 		Logger:          logger,
@@ -176,10 +174,10 @@ func (c *GenerateContext) Generate() (*plan.BuildPlan, map[string]*resolver.Reso
 	}
 
 	buildPlan.Caches = c.Caches.Caches
-	buildPlan.Secrets = utils.RemoveDuplicates(c.Secrets)
 	c.Deploy.Build(buildPlan, buildStepOptions)
 
 	buildPlan.Normalize()
+	buildPlan.Secrets, buildPlan.Steps = resolveSecrets(c.Config, buildPlan.Steps)
 
 	return buildPlan, resolvedPackages, nil
 }
@@ -213,7 +211,6 @@ func (c *GenerateContext) applyConfig() {
 
 	// Apply the cache config to the context
 	maps.Copy(c.Caches.Caches, c.Config.Caches)
-	c.Secrets = plan.SpreadStrings(c.Config.Secrets, c.Secrets)
 
 	// Update deploy from config
 	if c.Config.Deploy != nil {

--- a/core/generate/secrets.go
+++ b/core/generate/secrets.go
@@ -1,0 +1,61 @@
+package generate
+
+import (
+	"slices"
+
+	"github.com/railwayapp/railpack/core/config"
+	"github.com/railwayapp/railpack/core/plan"
+	"github.com/railwayapp/railpack/internal/utils"
+)
+
+// Secret resolution from config declarations into build plans belongs in this file
+// Concrete secrets are named secrets rather than selectors such as "*" and "..."
+// The wildcard catalog contains concrete top-level config names, while the plan catalog
+// also contains concrete names inferred from individual steps
+
+// Resolves step selectors and builds the catalog of configured and inferred secrets
+func resolveSecrets(buildConfig *config.Config, buildPlan *plan.BuildPlan) {
+	configuredSecrets := concreteSecrets(buildConfig.Secrets)
+	buildPlan.Secrets = collectSecrets(configuredSecrets, buildPlan.Steps)
+
+	for i := range buildPlan.Steps {
+		buildPlan.Steps[i].Secrets = resolveStepSecrets(
+			buildPlan.Steps[i].Secrets,
+			configuredSecrets,
+		)
+	}
+}
+
+// Collects the concrete configured and step-level names in their original order
+func collectSecrets(configuredSecrets []string, steps []plan.Step) []string {
+	secrets := slices.Clone(configuredSecrets)
+	for _, step := range steps {
+		secrets = append(secrets, concreteSecrets(step.Secrets)...)
+	}
+
+	return utils.RemoveDuplicates(secrets)
+}
+
+// Expands wildcards from configured names without leaking secrets inferred from other steps
+func resolveStepSecrets(stepSecrets, configuredSecrets []string) []string {
+	resolvedSecrets := make([]string, 0, len(stepSecrets)+len(configuredSecrets))
+	for _, secret := range stepSecrets {
+		switch secret {
+		case "*":
+			resolvedSecrets = append(resolvedSecrets, configuredSecrets...)
+		case "...":
+			continue
+		default:
+			resolvedSecrets = append(resolvedSecrets, secret)
+		}
+	}
+
+	return utils.RemoveDuplicates(resolvedSecrets)
+}
+
+// Removes access selectors that are not concrete secret names
+func concreteSecrets(secrets []string) []string {
+	return slices.DeleteFunc(slices.Clone(secrets), func(secret string) bool {
+		return secret == "*" || secret == "..."
+	})
+}

--- a/core/generate/secrets.go
+++ b/core/generate/secrets.go
@@ -14,16 +14,21 @@ import (
 // also contains concrete names inferred from individual steps
 
 // Resolves step selectors and builds the catalog of configured and inferred secrets
-func resolveSecrets(buildConfig *config.Config, buildPlan *plan.BuildPlan) {
+func resolveSecrets(buildConfig *config.Config, steps []plan.Step) ([]string, []plan.Step) {
 	configuredSecrets := concreteSecrets(buildConfig.Secrets)
-	buildPlan.Secrets = collectSecrets(configuredSecrets, buildPlan.Steps)
+	secrets := collectSecrets(configuredSecrets, steps)
+	preserveWildcard := len(secrets) == 0
+	resolvedSteps := slices.Clone(steps)
 
-	for i := range buildPlan.Steps {
-		buildPlan.Steps[i].Secrets = resolveStepSecrets(
-			buildPlan.Steps[i].Secrets,
+	for i := range resolvedSteps {
+		resolvedSteps[i].Secrets = resolveStepSecrets(
+			resolvedSteps[i].Secrets,
 			configuredSecrets,
+			preserveWildcard,
 		)
 	}
+
+	return secrets, resolvedSteps
 }
 
 // Collects the concrete configured and step-level names in their original order
@@ -36,13 +41,17 @@ func collectSecrets(configuredSecrets []string, steps []plan.Step) []string {
 	return utils.RemoveDuplicates(secrets)
 }
 
-// Expands wildcards from configured names without leaking secrets inferred from other steps
-func resolveStepSecrets(stepSecrets, configuredSecrets []string) []string {
+// Expands wildcards unless an empty catalog requires preserving cache semantics
+func resolveStepSecrets(stepSecrets, configuredSecrets []string, preserveWildcard bool) []string {
 	resolvedSecrets := make([]string, 0, len(stepSecrets)+len(configuredSecrets))
 	for _, secret := range stepSecrets {
 		switch secret {
 		case "*":
-			resolvedSecrets = append(resolvedSecrets, configuredSecrets...)
+			if preserveWildcard {
+				resolvedSecrets = append(resolvedSecrets, secret)
+			} else {
+				resolvedSecrets = append(resolvedSecrets, configuredSecrets...)
+			}
 		case "...":
 			continue
 		default:

--- a/core/generate/secrets_test.go
+++ b/core/generate/secrets_test.go
@@ -79,10 +79,10 @@ func TestResolveSecrets(t *testing.T) {
 			expectedByStep: [][]string{{}, {}},
 		},
 		{
-			name:           "resolves wildcard to empty when no secrets exist",
+			name:           "preserves wildcard when no secrets exist",
 			steps:          []plan.Step{{Secrets: []string{"*"}}},
 			expected:       []string{},
-			expectedByStep: [][]string{{}},
+			expectedByStep: [][]string{{"*"}},
 		},
 	}
 
@@ -90,18 +90,28 @@ func TestResolveSecrets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buildConfig := config.EmptyConfig()
 			buildConfig.Secrets = tt.configuredSecrets
-			buildPlan := &plan.BuildPlan{Steps: tt.steps}
-			resolveSecrets(buildConfig, buildPlan)
+			secrets, steps := resolveSecrets(buildConfig, tt.steps)
 
-			require.ElementsMatch(t, tt.expected, buildPlan.Secrets)
-			require.Len(t, buildPlan.Secrets, len(tt.expected))
+			require.ElementsMatch(t, tt.expected, secrets)
+			require.Len(t, secrets, len(tt.expected))
 
 			for i, expected := range tt.expectedByStep {
-				require.ElementsMatch(t, expected, buildPlan.Steps[i].Secrets)
-				require.Len(t, buildPlan.Steps[i].Secrets, len(expected))
+				require.ElementsMatch(t, expected, steps[i].Secrets)
+				require.Len(t, steps[i].Secrets, len(expected))
 			}
 		})
 	}
+}
+
+func TestResolveSecretsDoesNotMutateSteps(t *testing.T) {
+	buildConfig := config.EmptyConfig()
+	buildConfig.Secrets = []string{"GLOBAL"}
+	steps := []plan.Step{{Secrets: []string{"*"}}}
+
+	_, resolvedSteps := resolveSecrets(buildConfig, steps)
+
+	require.Equal(t, []string{"*"}, steps[0].Secrets)
+	require.Equal(t, []string{"GLOBAL"}, resolvedSteps[0].Secrets)
 }
 
 func TestGenerateContextPromotesSecretsFromReferencedSteps(t *testing.T) {

--- a/core/generate/secrets_test.go
+++ b/core/generate/secrets_test.go
@@ -1,0 +1,137 @@
+package generate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/railwayapp/railpack/core/config"
+	"github.com/railwayapp/railpack/core/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSecrets(t *testing.T) {
+	tests := []struct {
+		name              string
+		configuredSecrets []string
+		steps             []plan.Step
+		expected          []string
+		expectedByStep    [][]string
+	}{
+		{
+			name:           "promotes a step secret",
+			steps:          []plan.Step{{Secrets: []string{"TOKEN"}}},
+			expected:       []string{"TOKEN"},
+			expectedByStep: [][]string{{"TOKEN"}},
+		},
+		{
+			name: "promotes secrets from multiple steps",
+			steps: []plan.Step{
+				{Secrets: []string{"TOKEN"}},
+				{Secrets: []string{"API_KEY"}},
+			},
+			expected:       []string{"TOKEN", "API_KEY"},
+			expectedByStep: [][]string{{"TOKEN"}, {"API_KEY"}},
+		},
+		{
+			name:              "deduplicates configured and step secrets",
+			configuredSecrets: []string{"TOKEN"},
+			steps: []plan.Step{
+				{Secrets: []string{"TOKEN"}},
+				{Secrets: []string{"TOKEN"}},
+			},
+			expected:       []string{"TOKEN"},
+			expectedByStep: [][]string{{"TOKEN"}, {"TOKEN"}},
+		},
+		{
+			name:              "expands selectors from configured secrets",
+			configuredSecrets: []string{"GLOBAL"},
+			steps: []plan.Step{
+				{Secrets: []string{"*"}},
+				{Secrets: []string{"...", "TOKEN"}},
+			},
+			expected:       []string{"GLOBAL", "TOKEN"},
+			expectedByStep: [][]string{{"GLOBAL"}, {"TOKEN"}},
+		},
+		{
+			name:              "wildcard excludes secrets inferred from other steps",
+			configuredSecrets: []string{"GLOBAL"},
+			steps: []plan.Step{
+				{Secrets: []string{"LOCAL"}},
+				{Secrets: []string{"*"}},
+			},
+			expected:       []string{"GLOBAL", "LOCAL"},
+			expectedByStep: [][]string{{"LOCAL"}, {"GLOBAL"}},
+		},
+		{
+			name:              "combines wildcard with an explicit step secret",
+			configuredSecrets: []string{"GLOBAL"},
+			steps:             []plan.Step{{Secrets: []string{"*", "LOCAL"}}},
+			expected:          []string{"GLOBAL", "LOCAL"},
+			expectedByStep:    [][]string{{"GLOBAL", "LOCAL"}},
+		},
+		{
+			name: "empty and omitted step secrets contribute nothing",
+			steps: []plan.Step{
+				{},
+				{Secrets: []string{}},
+			},
+			expected:       []string{},
+			expectedByStep: [][]string{{}, {}},
+		},
+		{
+			name:           "resolves wildcard to empty when no secrets exist",
+			steps:          []plan.Step{{Secrets: []string{"*"}}},
+			expected:       []string{},
+			expectedByStep: [][]string{{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildConfig := config.EmptyConfig()
+			buildConfig.Secrets = tt.configuredSecrets
+			buildPlan := &plan.BuildPlan{Steps: tt.steps}
+			resolveSecrets(buildConfig, buildPlan)
+
+			require.ElementsMatch(t, tt.expected, buildPlan.Secrets)
+			require.Len(t, buildPlan.Secrets, len(tt.expected))
+
+			for i, expected := range tt.expectedByStep {
+				require.ElementsMatch(t, expected, buildPlan.Steps[i].Secrets)
+				require.Len(t, buildPlan.Steps[i].Secrets, len(expected))
+			}
+		})
+	}
+}
+
+func TestGenerateContextPromotesSecretsFromReferencedSteps(t *testing.T) {
+	ctx := CreateTestContext(t, "../../examples/node-npm")
+	configJSON := `{
+		"steps": {
+			"included": {
+				"commands": ["echo included"],
+				"secrets": ["INCLUDED_SECRET"]
+			},
+			"removed": {
+				"commands": ["echo removed"],
+				"secrets": ["REMOVED_SECRET"]
+			}
+		},
+		"deploy": {
+			"inputs": [{"step": "included"}]
+		}
+	}`
+
+	var cfg config.Config
+	require.NoError(t, json.Unmarshal([]byte(configJSON), &cfg))
+	ctx.Config = &cfg
+
+	buildPlan, _, err := ctx.Generate()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"INCLUDED_SECRET"}, buildPlan.Secrets)
+	require.NotContains(t, buildPlan.Secrets, "REMOVED_SECRET")
+
+	for _, step := range buildPlan.Steps {
+		require.NotEqual(t, "removed", step.Name)
+	}
+}

--- a/core/plan/plan.go
+++ b/core/plan/plan.go
@@ -10,7 +10,7 @@ var (
 	RailpackRuntimeImage = fmt.Sprintf("ghcr.io/railwayapp/railpack-runtime:mise-%s", mise.Version)
 )
 
-// serialized to railpack.json
+// serialized to railpack-plan.json
 type BuildPlan struct {
 	Steps   []Step            `json:"steps,omitempty"`
 	Caches  map[string]*Cache `json:"caches,omitempty"`

--- a/core/plan/plan_test.go
+++ b/core/plan/plan_test.go
@@ -27,7 +27,6 @@ func TestSerialization(t *testing.T) {
 					{"cmd": "npm ci"},
 					{"cmd": "npm run build"}
 				],
-				"useSecrets": true,
 				"outputs": [
 					"dist",
 					"node_modules/.cache"
@@ -44,8 +43,7 @@ func TestSerialization(t *testing.T) {
 					{"cmd": "npm run test"},
 					{"path": "/usr/local/bin"},
 					{"name": "NODE_ENV", "value": "production"}
-				],
-				"useSecrets": false
+				]
 			}
 		],
 		"start": {

--- a/core/plan/step.go
+++ b/core/plan/step.go
@@ -10,7 +10,7 @@ type Step struct {
 	Name      string            `json:"name,omitempty" jsonschema:"description=The name of the step"`
 	Inputs    []Layer           `json:"inputs,omitempty" jsonschema:"description=The inputs for this step"`
 	Commands  []Command         `json:"commands,omitempty" jsonschema:"description=The commands to run in this step"`
-	Secrets   []string          `json:"secrets,omitempty" jsonschema:"description=The secrets that this step uses"`
+	Secrets   []string          `json:"secrets,omitempty" jsonschema:"description=Secret names whose values invalidate this step's layer cache"`
 	Assets    map[string]string `json:"assets,omitempty" jsonschema:"description=The assets available to this step. The key is the name of the asset that is referenced in a file command"`
 	Variables map[string]string `json:"variables,omitempty" jsonschema:"description=The variables available to this step. The key is the name of the variable that is referenced in a variable command"`
 	Caches    []string          `json:"caches,omitempty" jsonschema:"description=The caches available to all commands in this step. Each cache must refer to a cache at the top level of the plan"`
@@ -21,7 +21,7 @@ func NewStep(name string) *Step {
 		Name:      name,
 		Assets:    make(map[string]string),
 		Variables: make(map[string]string),
-		Secrets:   []string{"*"}, // default to using all secrets
+		Secrets:   []string{"*"}, // default to invalidating for root-configured secrets
 	}
 }
 

--- a/docs/src/content/docs/architecture/overview.md
+++ b/docs/src/content/docs/architecture/overview.md
@@ -30,7 +30,7 @@ generate an image. Things that it includes are:
 - Caches
   - Map of cache definitions that can be referenced by steps
 - Secrets
-  - Catalog of secret names mounted into build commands
+  - Array of secret names mounted into build commands
 - Deploy
   - Configuration for how the container runs, including:
     - Inputs: List of inputs for the deploy step

--- a/docs/src/content/docs/architecture/overview.md
+++ b/docs/src/content/docs/architecture/overview.md
@@ -30,7 +30,7 @@ generate an image. Things that it includes are:
 - Caches
   - Map of cache definitions that can be referenced by steps
 - Secrets
-  - List of secret names that are referenced by steps
+  - Catalog of secret names mounted into build commands
 - Deploy
   - Configuration for how the container runs, including:
     - Inputs: List of inputs for the deploy step
@@ -61,7 +61,7 @@ Steps contain:
     - Path command: Add a directory to the global PATH
     - File command: Create a new file with optional permissions
 - Secrets
-  - List of secret names that this step uses
+  - Secret names whose values invalidate this step's layer cache
 - Assets
   - Mapping of name to file contents referenced in file commands
 - Variables

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -62,21 +62,21 @@ deploy variables with the same name.
 
 ## Secrets
 
-The generated build plan has a top-level catalog containing the names of every
-secret that can be used during the build. You can define names in the root
-`secrets` array or directly in a step's `secrets` array. Explicit secrets on
-retained steps are automatically promoted into the generated plan's catalog
-and do not need to be repeated at the root.
+The generated build plan has a top-level `secrets` array containing the names
+of every secret that can be used during the build. You can define names in the
+root `secrets` array or directly in a step's `secrets` array. Explicit secrets
+on retained steps are automatically added to the generated plan's top-level
+array and do not need to be repeated at the root.
 
 Under the hood, Railpack uses [BuildKit secrets
 mounts](https://docs.docker.com/build/building/secrets/) to supply an exec
 command with the secret value as an environment variable.
 
-The frontend mounts every secret in the plan catalog into every exec command.
-A step's `secrets` array does not restrict access. It selects the values that
-invalidate that step's layer cache. An empty array disables secret-based cache
-invalidation for the step, but cataloged secrets remain available to its exec
-commands.
+The frontend mounts every secret in the plan's top-level `secrets` array into
+every exec command. A step's `secrets` array does not restrict access. It
+selects the values that invalidate that step's layer cache. An empty array
+disables secret-based cache invalidation for the step, but secrets in the
+top-level array remain available to its exec commands.
 
 ```json
 {
@@ -88,9 +88,9 @@ commands.
 }
 ```
 
-Use `"*"` in a step's `secrets` array to invalidate it when any root-configured
-secret changes. Secrets inferred from other steps are not included in this
-selection:
+Use `"*"` in a step's `secrets` array to invalidate it when any secret from the
+root `secrets` array in `railpack.json` changes. Secrets defined on another
+step are not included:
 
 ```json
 {
@@ -120,10 +120,11 @@ railpack build --env STRIPE_LIVE_KEY
 
 #### Custom Frontend
 
-If building with the [BuildKit frontend](/platforms/buildkit-frontend), secret
-names can come from `railpack.json` or `--env` during plan generation. You must
-then provide values for every name in the generated plan catalog to Docker or
-BuildKit with `--secret`.
+Before using the [BuildKit frontend](/platforms/buildkit-frontend), generate a
+`railpack-plan.json`. Secret names can come from `railpack.json` or `--env`
+during this generation step. The frontend consumes only the resulting
+`railpack-plan.json`, so you must provide Docker or BuildKit with a value for
+every name in that plan's top-level `secrets` array.
 
 ```bash
 # Generate a build plan
@@ -153,12 +154,13 @@ Railpack in Production](/platforms/running-railpack-in-production) guide.
 
 BuildKit does not make every secret passed on the command line automatically
 available to a frontend. The frontend requests values by ID using the names in
-the plan catalog:
+the plan's top-level `secrets` array:
 
-- A cataloged and supplied secret is mounted into every exec command.
-- A supplied secret absent from the catalog is never requested or mounted.
-- A cataloged secret that was not supplied causes the build to fail because
-  Railpack requests required secret mounts.
+- A secret present in the array and supplied to BuildKit is mounted into every
+  exec command.
+- A supplied secret absent from the array is never requested or mounted.
+- A secret present in the array but not supplied causes the build to fail
+  because the frontend requests required secret mounts.
 
 BuildKit's frontend API does not provide a way to enumerate every supplied
 secret ID. Railpack can request a known ID but cannot discover undeclared
@@ -177,20 +179,25 @@ this automatically. Frontend users must pass it with
 `--build-arg secrets-hash=<hash>` for Docker or
 `--opt build-arg:secrets-hash=<hash>` for `buildctl`.
 
-The compiled `secrets` list on each step determines how the hash is used:
+The compiled `secrets` array on each step determines how the hash is used:
 
-- An empty list adds no secret-based cache dependency.
+- An empty array adds no secret-based cache dependency.
 - Concrete names derive a hash from only those mounted values. Changes to other
   secrets do not invalidate the step's resulting layer.
 - `"*"` depends directly on the complete supplied `secrets-hash`.
 
-When compiling `railpack.json`, `"*"` normally expands to the concrete root
-secret names. This keeps secrets inferred from another step from invalidating
-the wildcard step. The selector is preserved only when the generated plan has
-no concrete secret catalog. A manually authored `railpack-plan.json` may also
-contain `"*"`; the frontend interprets it as the complete supplied hash.
+The frontend never reads `railpack.json`; it reads the compiled
+`railpack-plan.json`. During plan generation, a `"*"` from `railpack.json`
+normally becomes the concrete names from its root `secrets` array. It does not
+include names defined only on other steps, so those values do not invalidate
+the wildcard step.
+
+If the generated plan has no concrete secret names, `"*"` remains in that
+step's `secrets` array. A manually authored `railpack-plan.json` may also
+contain `"*"`. In either case, the frontend makes that step depend on the
+complete supplied `secrets-hash`.
 
 The value passed as `secrets-hash` can include values that are not present in
-the plan catalog. Those values are still not mounted. However, a preserved
-`"*"` will invalidate when that complete hash changes, including changes caused
-by such extra values.
+the plan's top-level `secrets` array. Those values are still not mounted.
+However, a `"*"` that reaches the frontend will invalidate when the complete
+hash changes, including changes caused by such extra values.

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -9,8 +9,11 @@ differences being:
 - Environment variables are saved in the final image and should not contain
   sensitive information. Since they are in the final image, providers can add
   variables that will be available to the app at runtime.
-- Secrets are never logged or saved in the build logs. They are also only
-  available at build time and not saved to the final image.
+- Secrets are available at build time and are not automatically saved to the
+  final image. Build commands can still print secrets or persist them in build
+  artifacts, and secret values are not automatically filtered from logs, so you
+  are responsible for preventing build commands and artifacts from exposing
+  them.
 
 ## Environment Variables
 
@@ -126,14 +129,21 @@ or BuildKit with the `--secret` flag.
 
 ```bash
 # Generate a build plan
-railpack plan --env STRIPE_LIVE_KEY=sk_live_asdf --out test/railpack-plan.json
+railpack plan --env STRIPE_LIVE_KEY=sk_live_123 --out test/railpack-plan.json
+
+# Hash the same value that will be supplied to BuildKit
+secrets_hash=$(
+  echo -n "STRIPE_LIVE_KEY=sk_live_123" |
+    sha256sum |
+    awk '{print $1}'
+)
 
 # Build with the custom frontend
-STRIPE_LIVE_KEY=asdf123456789 docker build \
-  --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack:railpack-frontend" \
+STRIPE_LIVE_KEY=sk_live_123 docker build \
+  --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend" \
   -f test/railpack-plan.json \
   --secret id=STRIPE_LIVE_KEY,env=STRIPE_LIVE_KEY \
-  --build-arg secrets-hash=asdfasdf \
+  --build-arg secrets-hash="$secrets_hash" \
   examples/node-bun
 ```
 

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -60,11 +60,14 @@ deploy variables with the same name.
 ## Secrets
 
 The names of all secrets that should be used during the build are added to the
-top of the build plan, and each step's `secrets` array specifies which secrets
-should invalidate that step's layer cache when their values change. While all
-secrets are available to every command as environment variables, only the ones
-listed in a step's `secrets` array will trigger a cache invalidation if
-modified.
+top of the build plan. You can define names in the top-level `secrets` array or
+directly in a step's `secrets` array. Explicit step secrets are automatically
+included in the generated build plan's top-level secret list.
+
+Each step's `secrets` array specifies which secrets should invalidate that
+step's layer cache when their values change. While all secrets are available to
+every command as environment variables, only the ones listed in a step's
+`secrets` array will trigger a cache invalidation if modified.
 
 Under the hood, Railpack uses [BuildKit secrets
 mounts](https://docs.docker.com/build/building/secrets/) to supply an exec
@@ -77,24 +80,24 @@ that step.
 
 ```json
 {
-  "secrets": ["DATABASE_URL", "API_KEY", "STRIPE_LIVE_KEY"],
   "steps": {
     "build": {
-      "secrets": ["DATABASE_URL", "API_KEY"] // Only these secrets are available to this step
+      "secrets": ["DATABASE_URL", "API_KEY"]
     }
   }
 }
 ```
 
 You can also use `"*"` in a step's secrets array to indicate that it should have
-access to all secrets defined in the build plan:
+access to all secrets explicitly defined in the top-level `secrets` array.
+Secrets inferred from other steps are not included:
 
 ```json
 {
   "secrets": ["DATABASE_URL", "API_KEY", "STRIPE_LIVE_KEY"],
   "steps": {
     "build": {
-      "secrets": ["*"] // This step has access to all secrets
+      "secrets": ["*"]
     }
   }
 }

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -62,24 +62,21 @@ deploy variables with the same name.
 
 ## Secrets
 
-The names of all secrets that should be used during the build are added to the
-top of the build plan. You can define names in the top-level `secrets` array or
-directly in a step's `secrets` array. Explicit step secrets are automatically
-included in the generated build plan's top-level secret list.
-
-Each step's `secrets` array specifies which secrets should invalidate that
-step's layer cache when their values change. While all secrets are available to
-every command as environment variables, only the ones listed in a step's
-`secrets` array will trigger a cache invalidation if modified.
+The generated build plan has a top-level catalog containing the names of every
+secret that can be used during the build. You can define names in the root
+`secrets` array or directly in a step's `secrets` array. Explicit secrets on
+retained steps are automatically promoted into the generated plan's catalog
+and do not need to be repeated at the root.
 
 Under the hood, Railpack uses [BuildKit secrets
 mounts](https://docs.docker.com/build/building/secrets/) to supply an exec
 command with the secret value as an environment variable.
 
-By default, all secrets defined in the build plan are available to each step.
-You can explicitly specify which secrets a step should have access to using the
-`secrets` array. An empty array indicates that no secrets should be available to
-that step.
+The frontend mounts every secret in the plan catalog into every exec command.
+A step's `secrets` array does not restrict access. It selects the values that
+invalidate that step's layer cache. An empty array disables secret-based cache
+invalidation for the step, but cataloged secrets remain available to its exec
+commands.
 
 ```json
 {
@@ -91,9 +88,9 @@ that step.
 }
 ```
 
-You can also use `"*"` in a step's secrets array to indicate that it should have
-access to all secrets explicitly defined in the top-level `secrets` array.
-Secrets inferred from other steps are not included:
+Use `"*"` in a step's `secrets` array to invalidate it when any root-configured
+secret changes. Secrets inferred from other steps are not included in this
+selection:
 
 ```json
 {
@@ -117,19 +114,21 @@ If building with [the CLI](/reference/cli/#build), Railpack will check that all
 the secrets defined in the build plan have variables.
 
 ```bash
-railpack build --env STRIPE_LIVE_KEY=sk_live_asdf
+export STRIPE_LIVE_KEY=sk_live_asdf
+railpack build --env STRIPE_LIVE_KEY
 ```
 
 #### Custom Frontend
 
-If building with the [BuildKit frontend](/platforms/buildkit-frontend),
-you should still provide the secrets when generating the plan with `--env`. This
-adds the secrets to the build plan. You then need to pass the secrets to Docker
-or BuildKit with the `--secret` flag.
+If building with the [BuildKit frontend](/platforms/buildkit-frontend), secret
+names can come from `railpack.json` or `--env` during plan generation. You must
+then provide values for every name in the generated plan catalog to Docker or
+BuildKit with `--secret`.
 
 ```bash
 # Generate a build plan
-railpack plan --env STRIPE_LIVE_KEY=sk_live_123 --out test/railpack-plan.json
+export STRIPE_LIVE_KEY=sk_live_123
+railpack plan --env STRIPE_LIVE_KEY --out test/railpack-plan.json
 
 # Hash the same value that will be supplied to BuildKit
 secrets_hash=$(
@@ -139,7 +138,7 @@ secrets_hash=$(
 )
 
 # Build with the custom frontend
-STRIPE_LIVE_KEY=sk_live_123 docker build \
+docker build \
   --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend" \
   -f test/railpack-plan.json \
   --secret id=STRIPE_LIVE_KEY,env=STRIPE_LIVE_KEY \
@@ -150,9 +149,48 @@ STRIPE_LIVE_KEY=sk_live_123 docker build \
 For more information about running Railpack in production, see the [Running
 Railpack in Production](/platforms/running-railpack-in-production) guide.
 
-### Layer Invalidation
+### BuildKit Secret Filtering
 
-By default, BuildKit will not invalidate a layer if a secret is changed. To get
-around this, Railpack uses a hash of the secret values and mounts this as a file
-in the layer. This will bust the layer cache if the secret is changed. Pass the
-secret hash to BuildKit with the `--build-arg secrets-hash=<hash>` flag.
+BuildKit does not make every secret passed on the command line automatically
+available to a frontend. The frontend requests values by ID using the names in
+the plan catalog:
+
+- A cataloged and supplied secret is mounted into every exec command.
+- A supplied secret absent from the catalog is never requested or mounted.
+- A cataloged secret that was not supplied causes the build to fail because
+  Railpack requests required secret mounts.
+
+BuildKit's frontend API does not provide a way to enumerate every supplied
+secret ID. Railpack can request a known ID but cannot discover undeclared
+secrets from the BuildKit session.
+
+## Secrets & Layer Invalidation
+
+BuildKit intentionally excludes secret contents from an exec operation's cache
+key. Without additional input, changing a mounted secret can reuse a layer
+created with its previous value.
+
+Railpack accepts an opaque hash through the `secrets-hash` build argument and
+uses it to create cache dependencies. The hash must be deterministic and must
+change whenever any supplied value represented by it changes. The CLI computes
+this automatically. Frontend users must pass it with
+`--build-arg secrets-hash=<hash>` for Docker or
+`--opt build-arg:secrets-hash=<hash>` for `buildctl`.
+
+The compiled `secrets` list on each step determines how the hash is used:
+
+- An empty list adds no secret-based cache dependency.
+- Concrete names derive a hash from only those mounted values. Changes to other
+  secrets do not invalidate the step's resulting layer.
+- `"*"` depends directly on the complete supplied `secrets-hash`.
+
+When compiling `railpack.json`, `"*"` normally expands to the concrete root
+secret names. This keeps secrets inferred from another step from invalidating
+the wildcard step. The selector is preserved only when the generated plan has
+no concrete secret catalog. A manually authored `railpack-plan.json` may also
+contain `"*"`; the frontend interprets it as the complete supplied hash.
+
+The value passed as `secrets-hash` can include values that are not present in
+the plan catalog. Those values are still not mounted. However, a preserved
+`"*"` will invalidate when that complete hash changes, including changes caused
+by such extra values.

--- a/docs/src/content/docs/config/file.mdx
+++ b/docs/src/content/docs/config/file.mdx
@@ -146,14 +146,14 @@ The root configuration can have these fields:
 | `buildAptPackages` | List of apt packages to install during the build step                           |
 | `packages`         | Map of package name to package version                                          |
 | `caches`           | Map of cache name to cache definitions. The cache names are referenced in steps |
-| `secrets`          | Secret names added to the build plan catalog                                    |
+| `secrets`          | Secret names added to the build plan's top-level `secrets` array                 |
 | `steps`            | Map of step names to step definitions                                          |
 
 Secrets explicitly named by a step are automatically added to the generated
-build plan's top-level secret list. They do not need to be repeated in the
+build plan's top-level `secrets` array. They do not need to be repeated in the
 root `secrets` field. A step using `"*"` selects root secret names for cache
 invalidation, not secrets inferred from other steps. The frontend still mounts
-the complete plan catalog into every exec command.
+every name in the plan's top-level `secrets` array into every exec command.
 
 For example:
 

--- a/docs/src/content/docs/config/file.mdx
+++ b/docs/src/content/docs/config/file.mdx
@@ -149,6 +149,10 @@ The root configuration can have these fields:
 | `secrets`          | List of secrets that should be made available to commands                       |
 | `steps`            | Map of step names to step definitions                                          |
 
+Secrets explicitly named by a step are automatically added to the generated
+build plan's top-level secret list. They do not need to be repeated in the
+root `secrets` field. A step using `"*"` inherits only the secrets explicitly
+listed in the root field, not secrets inferred from other steps.
 
 For example:
 

--- a/docs/src/content/docs/config/file.mdx
+++ b/docs/src/content/docs/config/file.mdx
@@ -146,13 +146,14 @@ The root configuration can have these fields:
 | `buildAptPackages` | List of apt packages to install during the build step                           |
 | `packages`         | Map of package name to package version                                          |
 | `caches`           | Map of cache name to cache definitions. The cache names are referenced in steps |
-| `secrets`          | List of secrets that should be made available to commands                       |
+| `secrets`          | Secret names added to the build plan catalog                                    |
 | `steps`            | Map of step names to step definitions                                          |
 
 Secrets explicitly named by a step are automatically added to the generated
 build plan's top-level secret list. They do not need to be repeated in the
-root `secrets` field. A step using `"*"` inherits only the secrets explicitly
-listed in the root field, not secrets inferred from other steps.
+root `secrets` field. A step using `"*"` selects root secret names for cache
+invalidation, not secrets inferred from other steps. The frontend still mounts
+the complete plan catalog into every exec command.
 
 For example:
 
@@ -240,7 +241,7 @@ Each step in the build process can have:
 | :------------- | :---------------------------------------------------------------------- |
 | `inputs`       | List of layers for this step (from other steps, images, or local files) |
 | `commands`     | List of commands to run in this step                                    |
-| `secrets`      | List of secrets that this step uses                                     |
+| `secrets`      | Secret names whose value changes invalidate this step's cache            |
 | `assets`       | Mapping of name to file contents referenced in file commands            |
 | `variables`    | Mapping of name to variable values referenced in variable commands      |
 | `caches`       | List of cache IDs available to all commands in this step                |

--- a/docs/src/content/docs/config/options.md
+++ b/docs/src/content/docs/config/options.md
@@ -10,9 +10,10 @@ Users can configure Railpack in a few different ways:
 - [`railpack.json` config file](/config/file)
 - [Mise configuration](/config/mise)
 
-CLI flags, environment variables, and `railpack.json` are merged in
-precedence order and then applied to the generate context. Mise configuration
-files are used to configure tool versions, install additional tools, set environment variables, and customize Mise behavior in the generated image.
+CLI flags, environment variables, and `railpack.json` are merged in precedence
+order and then applied to the generate context. Mise configuration files are
+used to configure tool versions, install additional tools, set environment
+variables, and customize Mise behavior in the generated image.
 
 Everything that affects a part of the build plan _should_ be configurable.
 Config affects the generate context rather than the plan itself as it allows
@@ -22,7 +23,8 @@ relatively low level build plan schema.
 
 ## Configuration Precedence
 
-There are many configuration options which can be defined in multiple places. Here is the order of precedence (highest wins):
+There are many configuration options which can be defined in multiple places.
+Here is the order of precedence (highest wins):
 
 1. CLI flags (`--start-cmd`, etc)
 2. Environment variables passed with `--env` (`RAILPACK_START_CMD`, etc)
@@ -33,16 +35,20 @@ There are many configuration options which can be defined in multiple places. He
 A couple things to note:
 
 - An unset or empty value does not override a lower source.
-- Build configuration from the environment must be passed with `--env`. Exported shell variables are not imported automatically.
+- Build configuration from the environment must be passed with `--env`.
+  Exported shell variables are not imported automatically.
 - Array values from a higher source replace lower ones unless the value
 includes `"..."` to extend the generated list. See [Array
 Extending](/config/file#array-extending).
+- Root secret names are an exception: names from `railpack.json` and `--env`
+  are combined and deduplicated rather than replaced.
 - Language versions (for example `RAILPACK_NODE_VERSION` versus `.nvmrc`) use a
 per-language order documented on each language page.
 
 ### Mise Configuration Precedence
 
-The Railpack build process ends up generated system-level (`/etc/mise/config.toml`). You can override these settings with a project-level `mise.toml` file.
+The build process generates a system-level `/etc/mise/config.toml`. You can
+override these settings with a project-level `mise.toml` file.
 
 ## Configuration and Build Plans
 

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -294,7 +294,8 @@ Or with multiple strings:
 
 You can pass environment variables to the container at runtime using the
 `envs` key. These variables are also available while generating the build plan,
-and every name is added to the plan's secret catalog and supplied to BuildKit.
+and every name is added to the plan's top-level `secrets` array and supplied to
+BuildKit.
 Use `envs` to test runtime values, plan-generation inputs, or Railpack
 configuration variables:
 
@@ -340,11 +341,11 @@ also making them available during plan generation or at runtime:
 }
 ```
 
-The name must still enter the generated plan catalog through the root
-`secrets` field or an explicit declaration on a retained step. Declare it on
-the step whose cache should be invalidated when the value changes. The frontend
-mounts every cataloged secret into every exec command regardless of the
-step-level cache selection.
+The name must still enter the generated plan's top-level `secrets` array
+through the root `secrets` field or an explicit declaration on a retained step.
+Declare it on the step whose cache should be invalidated when the value changes.
+The frontend mounts every secret in the top-level array into every exec command
+regardless of the step-level cache selection.
 
 ### Services
 

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -293,8 +293,9 @@ Or with multiple strings:
 ### Environment Variables
 
 You can pass environment variables to the container at runtime using the
-`envs` key. This is useful for testing with different configurations, secrets,
-or Railpack configuration variables:
+`envs` key. These variables are also available while generating the build plan,
+so they can be used to test different configurations or Railpack configuration
+variables:
 
 ```json
 {
@@ -322,6 +323,24 @@ different build configurations:
 See the [environment variables
 documentation](/config/environment-variables) for a complete list of available
 `RAILPACK_*` configuration options.
+
+### Build Secrets
+
+Use the `secrets` key to test secrets declared in `railpack.json` without
+passing them through `--env`. This supplies their values to BuildKit without
+also making them available during plan generation or at runtime:
+
+```json
+{
+  "expectedOutput": "Build succeeded",
+  "secrets": {
+    "SENTRY_AUTH_TOKEN": "test-token"
+  }
+}
+```
+
+The secret name must still be declared by the corresponding step or in the
+top-level `secrets` field of `railpack.json`.
 
 ### Services
 

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -294,8 +294,9 @@ Or with multiple strings:
 
 You can pass environment variables to the container at runtime using the
 `envs` key. These variables are also available while generating the build plan,
-so they can be used to test different configurations or Railpack configuration
-variables:
+and every name is added to the plan's secret catalog and supplied to BuildKit.
+Use `envs` to test runtime values, plan-generation inputs, or Railpack
+configuration variables:
 
 ```json
 {
@@ -339,8 +340,11 @@ also making them available during plan generation or at runtime:
 }
 ```
 
-The secret name must still be declared by the corresponding step or in the
-top-level `secrets` field of `railpack.json`.
+The name must still enter the generated plan catalog through the root
+`secrets` field or an explicit declaration on a retained step. Declare it on
+the step whose cache should be invalidated when the value changes. The frontend
+mounts every cataloged secret into every exec command regardless of the
+step-level cache selection.
 
 ### Services
 

--- a/docs/src/content/docs/platforms/buildkit-frontend.md
+++ b/docs/src/content/docs/platforms/buildkit-frontend.md
@@ -98,6 +98,9 @@ export STRIPE_LIVE_KEY=sk_live_123
 railpack prepare /dir/to/build --env STRIPE_LIVE_KEY
 ```
 
+These are inputs to plan generation. The frontend itself reads only the
+generated `railpack-plan.json`, not `railpack.json`.
+
 2. Pass secret values to the build using Docker or BuildKit:
 
 **Docker:**
@@ -124,14 +127,15 @@ buildctl build \
   --output type=docker,name=test
 ```
 
-The frontend requests every name in the build plan's top-level secret catalog
-and mounts it into every exec command. Step-level `secrets` lists control cache
-invalidation; they do not filter secret access.
+The frontend requests every name in the build plan's top-level `secrets` array
+and mounts it into every exec command. Step-level `secrets` arrays control
+cache invalidation; they do not filter secret access.
 
-A supplied secret absent from the plan catalog is ignored because the frontend
-never requests it. A cataloged secret that was not supplied causes the build to
-fail because the secret mounts are required. BuildKit does not expose an API
-that lets the frontend enumerate all supplied secret IDs.
+A supplied secret absent from the plan's top-level `secrets` array is ignored
+because the frontend never requests it. A name in the array that was not
+supplied causes the build to fail because the secret mounts are required.
+BuildKit does not expose an API that lets the frontend enumerate all supplied
+secret IDs.
 
 ## Layer Invalidation
 
@@ -149,7 +153,7 @@ secrets_hash=$(
 --build-arg secrets-hash="$secrets_hash"
 ```
 
-An empty compiled step `secrets` list adds no secret cache dependency. Concrete
+An empty compiled step `secrets` array adds no secret cache dependency. Concrete
 names invalidate the step only for those values, while `"*"` depends on the
 complete supplied hash. See [Secrets & Layer
 Invalidation](/architecture/secrets#secrets--layer-invalidation) for the full
@@ -160,6 +164,18 @@ behavior.
 If provided, the GitHub token is passed to Mise as the `GITHUB_TOKEN`
 ([Docs](https://mise.jdx.dev/getting-started.html#github-api-rate-limiting)).
 This increases the rate limits when fetching info from the GitHub API.
+
+Pass it as a frontend build argument:
+
+```sh
+export GITHUB_TOKEN=ghp_xxx
+
+# Docker or Docker Buildx
+docker buildx build --build-arg github-token="$GITHUB_TOKEN" ...
+
+# BuildKit directly
+buildctl build --opt build-arg:github-token="$GITHUB_TOKEN" ...
+```
 
 The frontend injects this build argument as `GITHUB_TOKEN` only into Mise
 install commands. It is not a BuildKit secret mount, so protect the build

--- a/docs/src/content/docs/platforms/buildkit-frontend.md
+++ b/docs/src/content/docs/platforms/buildkit-frontend.md
@@ -93,7 +93,7 @@ To use secrets in your build, you must:
    plan):
 
 ```sh
-railpack prepare /dir/to/build --env STRIPE_LIVE_KEY=sk_live_asdf
+railpack prepare /dir/to/build --env STRIPE_LIVE_KEY=sk_live_123
 ```
 
 2. Pass secret values to the build using Docker or BuildKit:
@@ -129,7 +129,7 @@ of your secret values and pass it as a build argument:
 
 ```sh
 secrets_hash=$(
-  echo -n "STRIPE_LIVE_KEY=sk_live_asdf" |
+  echo -n "STRIPE_LIVE_KEY=sk_live_123" |
     sha256sum |
     awk '{print $1}'
 )

--- a/docs/src/content/docs/platforms/buildkit-frontend.md
+++ b/docs/src/content/docs/platforms/buildkit-frontend.md
@@ -54,7 +54,7 @@ Pass advanced options to the frontend using `--opt` with BuildKit or
 | Flag           | Description                                      |
 | -------------- | ------------------------------------------------ |
 | `cache-key`    | Prefix used to isolate mount cache IDs           |
-| `secrets-hash` | Hash used to invalidate layers when secrets change |
+| `secrets-hash` | Hash source for step secret cache dependencies     |
 | `github-token` | Token used to increase GitHub API rate limits    |
 
 ### Example
@@ -89,11 +89,13 @@ structure matches `docker buildx`.
 
 To use secrets in your build, you must:
 
-1. Pass secret names to `railpack prepare` (so they are included in the build
-   plan):
+1. Declare each secret name so it appears in the generated build plan. Define
+   names in the root or step-level `secrets` field of `railpack.json`, or pass
+   them while preparing the plan:
 
 ```sh
-railpack prepare /dir/to/build --env STRIPE_LIVE_KEY=sk_live_123
+export STRIPE_LIVE_KEY=sk_live_123
+railpack prepare /dir/to/build --env STRIPE_LIVE_KEY
 ```
 
 2. Pass secret values to the build using Docker or BuildKit:
@@ -122,10 +124,20 @@ buildctl build \
   --output type=docker,name=test
 ```
 
+The frontend requests every name in the build plan's top-level secret catalog
+and mounts it into every exec command. Step-level `secrets` lists control cache
+invalidation; they do not filter secret access.
+
+A supplied secret absent from the plan catalog is ignored because the frontend
+never requests it. A cataloged secret that was not supplied causes the build to
+fail because the secret mounts are required. BuildKit does not expose an API
+that lets the frontend enumerate all supplied secret IDs.
+
 ## Layer Invalidation
 
-To ensure build layers are invalidated when secret values change, compute a hash
-of your secret values and pass it as a build argument:
+BuildKit does not include secret contents in an exec operation's cache key.
+Compute a deterministic hash that changes with the supplied secret values and
+pass it as a build argument:
 
 ```sh
 secrets_hash=$(
@@ -137,7 +149,11 @@ secrets_hash=$(
 --build-arg secrets-hash="$secrets_hash"
 ```
 
-This ensures the build cache is properly invalidated when secrets change.
+An empty compiled step `secrets` list adds no secret cache dependency. Concrete
+names invalidate the step only for those values, while `"*"` depends on the
+complete supplied hash. See [Secrets & Layer
+Invalidation](/architecture/secrets#secrets--layer-invalidation) for the full
+behavior.
 
 ## GitHub Token
 
@@ -145,5 +161,6 @@ If provided, the GitHub token is passed to Mise as the `GITHUB_TOKEN`
 ([Docs](https://mise.jdx.dev/getting-started.html#github-api-rate-limiting)).
 This increases the rate limits when fetching info from the GitHub API.
 
-Once passed, this token will be accessible to the build context, so you should
-not pass a token that the owner of the build code should not have access to.
+The frontend injects this build argument as `GITHUB_TOKEN` only into Mise
+install commands. It is not a BuildKit secret mount, so protect the build
+invocation and do not pass a token to builds that should not receive it.

--- a/docs/src/content/docs/platforms/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/platforms/running-railpack-in-production.mdx
@@ -91,8 +91,9 @@ the Railpack CLI.
 ## Secrets
 
 The names of secrets available to build commands must be present in the build
-plan's top-level catalog. Names can be declared in the root or step-level
-`secrets` field of `railpack.json`, or passed to `prepare` with `--env`.
+plan's top-level `secrets` array. Names can be declared in the root or
+step-level `secrets` field of `railpack.json`, or passed to `prepare` with
+`--env`.
 
 ```sh
 export STRIPE_LIVE_KEY=sk_live_123
@@ -118,23 +119,25 @@ STRIPE_LIVE_KEY=sk_live_123 docker build \
 _Note how the secret is available to docker build at the start and also passed
 through the `--secret` flag._
 
-The frontend mounts every cataloged secret into every exec command. A step's
-`secrets` list controls cache invalidation, not access. Extra secret IDs passed
-to BuildKit are ignored when they are absent from the catalog, while a missing
-cataloged secret causes required secret mounts to fail.
+The frontend mounts every secret in the plan's top-level `secrets` array into
+every exec command. A step's `secrets` array controls cache invalidation, not
+access. Extra secret IDs passed to BuildKit are ignored when they are absent
+from the array, while a secret named in the array but not supplied causes the
+required secret mounts to fail.
 
 ### Layer invalidation
 
 BuildKit does not include secret contents in an exec operation's cache key.
 Railpack uses a separate hash to add the cache dependencies selected by each
-compiled step's `secrets` list. The CLI calculates the hash automatically. When
-using the frontend directly, calculate it yourself and pass it as a build arg.
+compiled step's `secrets` array. The CLI calculates the hash automatically.
+When using the frontend directly, calculate it yourself and pass it as a build
+arg.
 
 ```sh
 --build-arg secrets-hash=<hash-of-secret-values>
 ```
 
-An empty list adds no secret cache dependency, concrete names select only those
+An empty array adds no secret cache dependency, concrete names select only those
 values, and `"*"` selects the complete supplied hash. See [Secrets & Layer
 Invalidation](/architecture/secrets#secrets--layer-invalidation) for details.
 

--- a/docs/src/content/docs/platforms/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/platforms/running-railpack-in-production.mdx
@@ -23,7 +23,7 @@ building. It will
 
 - Output the build result to stdout (this shows users what will happen in the
   build)
-- Save the build plan to a file (e.g. `railpack.json`)
+- Save the build plan to a file (e.g. `railpack-plan.json`)
 - Save the build info to a `railpack-info.json` file
 
 The build plan is used by the frontend to build the app. The build info can be
@@ -90,11 +90,13 @@ the Railpack CLI.
 
 ## Secrets
 
-The secrets that are available to commands in the build must be specified in the
-build plan. You can pass secrets to the `prepare` command with the `--env` flag.
+The names of secrets available to build commands must be present in the build
+plan's top-level catalog. Names can be declared in the root or step-level
+`secrets` field of `railpack.json`, or passed to `prepare` with `--env`.
 
 ```sh
-railpack prepare /dir/to/build --env STRIPE_LIVE_KEY=sk_live_asdf
+export STRIPE_LIVE_KEY=sk_live_123
+railpack prepare /dir/to/build --env STRIPE_LIVE_KEY
 ```
 
 These secrets can be used to configure the plan, but the names will also be
@@ -106,7 +108,7 @@ To include the values of the secrets for the build, you can pass them as [Docker
 build secrets](https://docs.docker.com/build/building/secrets/).
 
 ```sh
-STRIPE_LIVE_KEY=asdfasdf docker build \
+STRIPE_LIVE_KEY=sk_live_123 docker build \
   --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend" \
   -f /path/to/railpack-plan.json \
   --secret id=STRIPE_LIVE_KEY,env=STRIPE_LIVE_KEY \
@@ -116,17 +118,25 @@ STRIPE_LIVE_KEY=asdfasdf docker build \
 _Note how the secret is available to docker build at the start and also passed
 through the `--secret` flag._
 
+The frontend mounts every cataloged secret into every exec command. A step's
+`secrets` list controls cache invalidation, not access. Extra secret IDs passed
+to BuildKit are ignored when they are absent from the catalog, while a missing
+cataloged secret causes required secret mounts to fail.
+
 ### Layer invalidation
 
-By default, layers will not be invalidated when a secret value changes. To get
-around this, Railpack uses a hash of the secret values and mounts this as a file
-in the layer. When using the Railpack CLI to build, this happens automatically,
-but if you are using the frontend directly, calculate the hash yourself and pass
-it as a build arg.
+BuildKit does not include secret contents in an exec operation's cache key.
+Railpack uses a separate hash to add the cache dependencies selected by each
+compiled step's `secrets` list. The CLI calculates the hash automatically. When
+using the frontend directly, calculate it yourself and pass it as a build arg.
 
 ```sh
 --build-arg secrets-hash=<hash-of-secret-values>
 ```
+
+An empty list adds no secret cache dependency, concrete names select only those
+values, and `"*"` selects the complete supplied hash. See [Secrets & Layer
+Invalidation](/architecture/secrets#secrets--layer-invalidation) for details.
 
 ## Mount cache ID
 

--- a/docs/src/content/docs/platforms/running-railpack-in-production.mdx
+++ b/docs/src/content/docs/platforms/running-railpack-in-production.mdx
@@ -147,15 +147,17 @@ This is a small script that will build an app using the Railpack frontend.
 #!/bin/bash
 
 APP_DIR=my-app
+export STRIPE_LIVE_KEY=sk_live_123
 
 # Prepare the app and generate the build plan
-railpack prepare $APP_DIR \
+railpack prepare "$APP_DIR" \
+  --env STRIPE_LIVE_KEY \
   --plan-out ./railpack-plan.json \
   --info-out ./railpack-info.json
 
 # Compute the hash of the secret values
 secrets_hash=$(
-  echo -n "STRIPE_LIVE_KEY=sk_live_asdf" |
+  echo -n "STRIPE_LIVE_KEY=$STRIPE_LIVE_KEY" |
     sha256sum |
     awk '{print $1}'
 )
@@ -164,7 +166,8 @@ secrets_hash=$(
 docker buildx build \
   --build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend" \
   -f ./railpack-plan.json \
-  --build-arg secrets-hash=$secrets_hash \
+  --secret id=STRIPE_LIVE_KEY,env=STRIPE_LIVE_KEY \
+  --build-arg secrets-hash="$secrets_hash" \
   --output type=docker,name=test \
-  $APP_DIR
+  "$APP_DIR"
 ```

--- a/examples/secrets/railpack.json
+++ b/examples/secrets/railpack.json
@@ -1,11 +1,14 @@
 {
   "$schema": "../../test/schema.json",
 
-  "secrets": ["MY_SECRET", "MY_OTHER_SECRET", "HELLO_WORLD"],
+  "secrets": ["HELLO_WORLD"],
 
   "steps": {
     "usesSecrets": {
-      "commands": [{ "src": ".", "dest": "." }, "./run.sh"],
+      "commands": [
+        { "src": ".", "dest": "." },
+        "./run.sh MY_SECRET MY_OTHER_SECRET NOT_SECRET"
+      ],
       "secrets": ["MY_SECRET", "MY_OTHER_SECRET"],
       "variables": {
         "NOT_SECRET": "not secret"
@@ -13,7 +16,10 @@
     },
 
     "defaultsToUsing": {
-      "commands": [{ "src": ".", "dest": "." }, "./run.sh"],
+      "commands": [
+        { "src": ".", "dest": "." },
+        "./run.sh HELLO_WORLD NOT_SECRET"
+      ],
       "variables": {
         "NOT_SECRET": "not secret"
       }
@@ -21,6 +27,6 @@
   },
 
   "deploy": {
-    "startCommand": "./run.sh"
+    "startCommand": "echo secrets-build-succeeded"
   }
 }

--- a/examples/secrets/railpack.json
+++ b/examples/secrets/railpack.json
@@ -20,6 +20,7 @@
         { "src": ".", "dest": "." },
         "./run.sh HELLO_WORLD NOT_SECRET"
       ],
+      "secrets": ["*"],
       "variables": {
         "NOT_SECRET": "not secret"
       }

--- a/examples/secrets/run.sh
+++ b/examples/secrets/run.sh
@@ -20,7 +20,7 @@ for secret in "${REQUIRED_SECRETS[@]}"; do
       error_value_secrets+=("$secret")
       echo "❌ Secret $secret contains invalid value 'error'"
     else
-      echo "✅ Found secret: $secret = ${!secret}"
+      echo "✅ Found secret: $secret"
     fi
   fi
 done

--- a/examples/secrets/run.sh
+++ b/examples/secrets/run.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-# List of required secrets
-REQUIRED_SECRETS=(
-  "MY_SECRET"
-  "MY_OTHER_SECRET"
-  "HELLO_WORLD"
-  "NOT_SECRET"
-)
+# Each step passes the secret and variable names that it expects to use.
+REQUIRED_SECRETS=("$@")
 
 missing_secrets=()
 defined_secrets=()

--- a/examples/secrets/test.json
+++ b/examples/secrets/test.json
@@ -1,7 +1,7 @@
 [
   {
-    "expectedOutput": "one",
-    "envs": {
+    "expectedOutput": "secrets-build-succeeded",
+    "secrets": {
       "MY_SECRET": "one",
       "MY_OTHER_SECRET": "two",
       "HELLO_WORLD": "three"

--- a/integration_tests/run_test.go
+++ b/integration_tests/run_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,6 +52,7 @@ type TestCase struct {
 	// matches against the entire output of the container if it cannot be found in a single line
 	ExpectedOutput StringOrArray     `json:"expectedOutput"`
 	Envs           map[string]string `json:"envs"`
+	Secrets        map[string]string `json:"secrets"`
 	ConfigFilePath string            `json:"configFile"`
 	ShouldFail     bool              `json:"shouldFail"`
 	HTTPCheck      *HTTPCheck        `json:"httpCheck"`
@@ -157,10 +159,16 @@ func TestExamplesIntegration(t *testing.T) {
 					strings.ToLower(strings.ReplaceAll(testName, "/", "-")),
 					strings.ToLower(uuid.New().String()))
 
+				// Every env name is added to the generated plan's secret catalog.
+				// Secrets bypass plan generation, but both value sets must be available to BuildKit.
+				buildSecrets := make(map[string]string, len(testCase.Envs)+len(testCase.Secrets))
+				maps.Copy(buildSecrets, testCase.Envs)
+				maps.Copy(buildSecrets, testCase.Secrets)
+
 				if err := buildkit.BuildWithBuildkitClient(examplePath, buildResult.Plan, buildkit.BuildWithBuildkitClientOptions{
 					ImageName: imageName,
 					Platform:  testCase.Platform,
-					Secrets:   testCase.Envs,
+					Secrets:   buildSecrets,
 					CacheKey:  imageName,
 					// Pass through GITHUB_TOKEN if it exists, this avoids mise timeouts during build
 					// this can easily occur since we run all integration tests in parallel via GHA


### PR DESCRIPTION
## Motivation

Using a secret in a build step currently requires declaring it twice:

1. In the top-level `secrets` array so the value is mounted
2. In the step’s `secrets` array so changes invalidate that step’s cache

A step-level declaration by itself does not mount or validate the secret. This duplication is easy to miss and can silently leave a step without the value it expects.

## Description

- Promote explicit secret names from retained steps into the generated plan’s top-level `secrets` array
- Resolve secrets after plan normalization so removed steps do not contribute unused names
- Preserve and deduplicate existing top-level secret declarations
- Resolve `"*"` to secrets declared in the root `railpack.json` `secrets` array without including names declared only on other steps
- Preserve `"*"` in `railpack-plan.json` when no concrete secret names exist so the frontend can retain full `secrets-hash` cache invalidation
- Add focused tests for promotion, deduplication, wildcard handling, removed steps, and mutation safety
- Add a `secrets` field to integration-test `test.json` files for supplying BuildKit-only values
- Update the secrets example to exercise step-level declarations and `"*"`
- Document the existing distinction between secret mounting and layer-cache invalidation
- Document frontend secret filtering, `secrets-hash` behavior, and GitHub token arguments for Docker and `buildctl`
- Remove unused plan serialization from the BuildKit frontend

## Breaking Changes

- A secret declared only on a step is now promoted into the generated plan’s top-level `secrets` array. Its value must therefore be supplied during the build. A missing step-only secret previously did not fail because it was neither mounted nor validated; it now causes the build to fail.
- The frontend already mounts every top-level plan secret into every exec command. Consequently, a newly promoted step secret becomes available to all build commands, not only the step that declared it. Step-level `secrets` arrays continue to control cache invalidation rather than access.
- During plan generation, `"*"` now resolves only to secrets declared in the root `railpack.json` `secrets` array. A step using `"*"` will not be invalidated when a secret declared solely on another step changes.
- Generated `railpack-plan.json` files may contain concrete secret names where they previously contained `"*"` . Manually authored plans containing `"*"` retain their existing full-hash invalidation behavior.

## Test

- Added unit coverage in `core/generate/secrets_test.go`
- Added end-to-end coverage through the `examples/secrets` integration fixture
- Attempted the focused `examples/secrets` integration test against the remote BuildKit host. It was blocked before executing the example because the required Railpack images had no manifest matching the requested platform.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
