### PR TITLE
feat(node): support devEngines for the runtime and package manager

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-dev-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-dev-engines_1.snap.json
@@ -1,0 +1,178 @@
+{
+ "caches": {
+  "apt": {
+   "directory": "/var/cache/apt",
+   "type": "locked"
+  },
+  "apt-lists": {
+   "directory": "/var/lib/apt/lists",
+   "type": "locked"
+  },
+  "node-modules": {
+   "directory": "/app/node_modules/.cache",
+   "type": "shared"
+  },
+  "pnpm-install": {
+   "directory": "/opt/pnpm/store",
+   "type": "shared"
+  }
+ },
+ "deploy": {
+  "base": {
+   "step": "packages:apt:runtime"
+  },
+  "inputs": [
+   {
+    "include": [
+     "/mise/shims",
+     "/mise/installs",
+     "/usr/local/bin/mise",
+     "/etc/mise/config.toml",
+     "/root/.local/state/mise"
+    ],
+    "step": "packages:mise"
+   },
+   {
+    "include": [
+     "/app/node_modules"
+    ],
+    "step": "build"
+   },
+   {
+    "exclude": [
+     "node_modules",
+     ".yarn"
+    ],
+    "include": [
+     "/root/.cache",
+     "."
+    ],
+    "step": "build"
+   }
+  ],
+  "startCommand": "pnpm run start",
+  "variables": {
+   "CI": "true",
+   "NODE_ENV": "production",
+   "NPM_CONFIG_FETCH_RETRIES": "5",
+   "NPM_CONFIG_FUND": "false",
+   "NPM_CONFIG_PRODUCTION": "false",
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
+  }
+ },
+ "steps": [
+  {
+   "assets": {
+    "generated-mise-toml": "[generated-mise-toml]"
+   },
+   "commands": [
+    {
+     "path": "/mise/shims"
+    },
+    {
+     "customName": "create mise config",
+     "name": "generated-mise-toml",
+     "path": "/etc/mise/config.toml"
+    },
+    {
+     "cmd": "mise install",
+     "customName": "install mise packages: node, pnpm"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.5"
+    }
+   ],
+   "name": "packages:mise",
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
+  },
+  {
+   "caches": [
+    "pnpm-install"
+   ],
+   "commands": [
+    {
+     "path": "/app/node_modules/.bin"
+    },
+    {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
+     "dest": "package.json",
+     "src": "package.json"
+    },
+    {
+     "path": "/opt/pnpm"
+    },
+    {
+     "cmd": "pnpm add -g node-gyp"
+    },
+    {
+     "cmd": "pnpm install"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    }
+   ],
+   "name": "install",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_FETCH_RETRIES": "5",
+    "NPM_CONFIG_FUND": "false",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+    "PNPM_HOME": "/opt/pnpm",
+    "PNPM_STORE_DIR": "/opt/pnpm/store"
+   }
+  },
+  {
+   "caches": [
+    "node-modules"
+   ],
+   "inputs": [
+    {
+     "step": "install"
+    },
+    {
+     "include": [
+      "."
+     ],
+     "local": true
+    }
+   ],
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
+  },
+  {
+   "caches": [
+    "apt",
+    "apt-lists"
+   ],
+   "commands": [
+    {
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libatomic1'",
+     "customName": "install apt packages: libatomic1"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.5"
+    }
+   ],
+   "name": "packages:apt:runtime"
+  }
+ ]
+}

--- a/core/providers/node/node.go
+++ b/core/providers/node/node.go
@@ -412,6 +412,11 @@ func (p *NodeProvider) applyNodeVersionResolution(ctx *generate.GenerateContext,
 		miseStep.Version(nodeToolRef, p.packageJson.Engines["node"], "package.json > engines > node")
 	}
 
+	// `devEngines.runtime` is the newer, stricter declaration, so it wins over `engines.node`
+	if nodeVersion := p.packageJson.GetDevEngineRuntimeVersion("node"); nodeVersion != "" {
+		miseStep.Version(nodeToolRef, nodeVersion, "package.json > devEngines > runtime")
+	}
+
 	if envVersion, varName := ctx.Env.GetConfigVariable("NODE_VERSION"); envVersion != "" {
 		miseStep.Version(nodeToolRef, envVersion, varName)
 	}
@@ -553,6 +558,25 @@ func (p *NodeProvider) getPackageManager(ctx *generate.GenerateContext) PackageM
 			log.Info("Package manager name is empty in package.json")
 		} else {
 			log.Warnf("Unknown package manager `%s` specified in package.json, defaulting to npm", pmName)
+		}
+	}
+
+	// `devEngines.packageManager` is an explicit declaration, so it is preferred over lockfile inference
+	if packageJson, err := p.GetPackageJson(app); err == nil {
+		if pmName, _ := packageJson.GetDevEnginePackageManager(); pmName != "" {
+			switch pmName {
+			case "pnpm":
+				return PackageManagerPnpm
+			case "npm":
+				return PackageManagerNpm
+			case "bun":
+				return PackageManagerBun
+			case "yarn":
+				_, pmVersion := packageJson.GetDevEnginePackageManager()
+				return parseYarnPackageManager(pmVersion)
+			default:
+				log.Warnf("Unknown package manager `%s` specified in package.json devEngines, ignoring", pmName)
+			}
 		}
 	}
 

--- a/core/providers/node/node_test.go
+++ b/core/providers/node/node_test.go
@@ -72,6 +72,14 @@ func TestNode(t *testing.T) {
 			envVars:        map[string]string{"RAILPACK_NODE_VERSION": "22"},
 		},
 		{
+			name:           "devEngines declares the runtime and the package manager",
+			path:           "../../../examples/node-dev-engines",
+			detected:       true,
+			packageManager: PackageManagerPnpm,
+			nodeVersion:    "22.11.0",
+			pnpmVersion:    "10.4.1",
+		},
+		{
 			name:     "golang",
 			path:     "../../../examples/go-mod",
 			detected: false,

--- a/core/providers/node/package_json.go
+++ b/core/providers/node/package_json.go
@@ -10,16 +10,107 @@ type WorkspacesConfig struct {
 	Packages []string `json:"packages"`
 }
 
+// a single `devEngines` entry, e.g. {"name": "pnpm", "version": "10.5.0"}
+type DevEngineDependency struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// https://nodejs.org/api/packages.html#devengines
+// each field is either a single object or an array of objects
+type DevEngines struct {
+	Runtime        []DevEngineDependency `json:"runtime"`
+	PackageManager []DevEngineDependency `json:"packageManager"`
+}
+
 type PackageJson struct {
 	Name            string            `json:"name"`
 	Version         string            `json:"version"`
 	Scripts         map[string]string `json:"scripts"`
 	PackageManager  *string           `json:"packageManager"`
+	DevEngines      *DevEngines       `json:"devEngines"`
 	Dependencies    map[string]string `json:"dependencies"`
 	DevDependencies map[string]string `json:"devDependencies"`
 	Engines         map[string]string `json:"engines"`
 	Main            string            `json:"main"`
 	Workspaces      []string          `json:"-"`
+}
+
+// devEngines entries accept either a single object or an array of objects, so both shapes are unmarshalled here.
+func (d *DevEngines) UnmarshalJSON(data []byte) error {
+	type Alias DevEngines
+	aux := &struct {
+		Runtime        any `json:"runtime"`
+		PackageManager any `json:"packageManager"`
+		*Alias
+	}{
+		Alias: (*Alias)(d),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	d.Runtime = parseDevEngineDependencies(aux.Runtime)
+	d.PackageManager = parseDevEngineDependencies(aux.PackageManager)
+
+	return nil
+}
+
+func parseDevEngineDependencies(value any) []DevEngineDependency {
+	if value == nil {
+		return nil
+	}
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+
+	var dependencies []DevEngineDependency
+	if err := json.Unmarshal(raw, &dependencies); err == nil {
+		return dependencies
+	}
+
+	var dependency DevEngineDependency
+	if err := json.Unmarshal(raw, &dependency); err == nil {
+		return []DevEngineDependency{dependency}
+	}
+
+	return nil
+}
+
+// the name and version of the package manager declared in `devEngines.packageManager`.
+// returns empty strings when it is not declared.
+func (p *PackageJson) GetDevEnginePackageManager() (string, string) {
+	if p == nil || p.DevEngines == nil {
+		return "", ""
+	}
+
+	for _, dependency := range p.DevEngines.PackageManager {
+		name := strings.TrimSpace(dependency.Name)
+		if name != "" {
+			return name, strings.TrimSpace(dependency.Version)
+		}
+	}
+
+	return "", ""
+}
+
+// the version of a runtime declared in `devEngines.runtime`, e.g. "node".
+// returns an empty string when that runtime is not declared.
+func (p *PackageJson) GetDevEngineRuntimeVersion(name string) string {
+	if p == nil || p.DevEngines == nil {
+		return ""
+	}
+
+	for _, dependency := range p.DevEngines.Runtime {
+		if strings.EqualFold(strings.TrimSpace(dependency.Name), name) {
+			return strings.TrimSpace(dependency.Version)
+		}
+	}
+
+	return ""
 }
 
 func NewPackageJson() *PackageJson {

--- a/core/providers/node/package_json_test.go
+++ b/core/providers/node/package_json_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackageJson(t *testing.T) {
@@ -221,6 +222,64 @@ func TestGetPackageManagerInfo(t *testing.T) {
 				t.Errorf("GetPackageManagerInfo() = (%v, %v), want (%v, %v)",
 					gotName, gotVersion, tt.wantName, tt.wantVersion)
 			}
+		})
+	}
+}
+
+func TestDevEngines(t *testing.T) {
+	tests := []struct {
+		name               string
+		json               string
+		wantPmName         string
+		wantPmVersion      string
+		wantRuntimeVersion string
+	}{
+		{
+			name:               "no devEngines",
+			json:               `{"name": "app"}`,
+			wantPmName:         "",
+			wantPmVersion:      "",
+			wantRuntimeVersion: "",
+		},
+		{
+			name:               "single objects",
+			json:               `{"devEngines": {"runtime": {"name": "node", "version": "22.11.0", "onFail": "download"}, "packageManager": {"name": "pnpm", "version": "10.4.1"}}}`,
+			wantPmName:         "pnpm",
+			wantPmVersion:      "10.4.1",
+			wantRuntimeVersion: "22.11.0",
+		},
+		{
+			name:               "arrays of objects",
+			json:               `{"devEngines": {"runtime": [{"name": "node", "version": "22"}], "packageManager": [{"name": "yarn", "version": "4.5.0"}]}}`,
+			wantPmName:         "yarn",
+			wantPmVersion:      "4.5.0",
+			wantRuntimeVersion: "22",
+		},
+		{
+			name:               "runtime that is not node",
+			json:               `{"devEngines": {"runtime": {"name": "deno", "version": "2.0.0"}}}`,
+			wantPmName:         "",
+			wantPmVersion:      "",
+			wantRuntimeVersion: "",
+		},
+		{
+			name:               "extra whitespace",
+			json:               `{"devEngines": {"packageManager": {"name": "  bun  ", "version": "  1.2.0  "}}}`,
+			wantPmName:         "bun",
+			wantPmVersion:      "1.2.0",
+			wantRuntimeVersion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packageJson := NewPackageJson()
+			require.NoError(t, json.Unmarshal([]byte(tt.json), packageJson))
+
+			gotPmName, gotPmVersion := packageJson.GetDevEnginePackageManager()
+			assert.Equal(t, tt.wantPmName, gotPmName)
+			assert.Equal(t, tt.wantPmVersion, gotPmVersion)
+			assert.Equal(t, tt.wantRuntimeVersion, packageJson.GetDevEngineRuntimeVersion("node"))
 		})
 	}
 }

--- a/core/providers/node/package_manager.go
+++ b/core/providers/node/package_manager.go
@@ -375,6 +375,7 @@ func (p PackageManager) SupportingInstallFiles(ctx *generate.GenerateContext) []
 // GetPackageManagerPackages installs specific versions of package managers by analyzing the users code
 func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext, packageJson *PackageJson, packages *generate.MiseStepBuilder) {
 	pmName, pmVersion := packageJson.GetPackageManagerInfo()
+	devEngineName, devEngineVersion := packageJson.GetDevEnginePackageManager()
 
 	// Pnpm
 	if p == PackageManagerPnpm {
@@ -405,6 +406,10 @@ func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext,
 			packages.Version(pnpm, packageJson.Engines["pnpm"], "package.json > engines > pnpm")
 		}
 
+		if devEngineName == "pnpm" && devEngineVersion != "" {
+			packages.Version(pnpm, devEngineVersion, "package.json > devEngines > packageManager")
+		}
+
 		if pmName == "pnpm" && pmVersion != "" {
 			packages.Version(pnpm, pmVersion, "package.json > packageManager")
 
@@ -431,6 +436,10 @@ func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext,
 			packages.Version(yarn, packageJson.Engines["yarn"], "package.json > engines > yarn")
 		}
 
+		if devEngineName == "yarn" && devEngineVersion != "" {
+			packages.Version(yarn, devEngineVersion, "package.json > devEngines > packageManager")
+		}
+
 		// TODO we should use SemVer at this point
 		if pmName == "yarn" && pmVersion != "" {
 			majorVersion := strings.Split(pmVersion, ".")[0]
@@ -450,6 +459,10 @@ func (p PackageManager) GetPackageManagerPackages(ctx *generate.GenerateContext,
 		// Prefer explicit version from package.json engines over defaults
 		if packageJson != nil && packageJson.Engines != nil && packageJson.Engines["bun"] != "" {
 			packages.Version(bun, packageJson.Engines["bun"], "package.json > engines > bun")
+		}
+
+		if devEngineName == "bun" && devEngineVersion != "" {
+			packages.Version(bun, devEngineVersion, "package.json > devEngines > packageManager")
 		}
 
 		if pmName == "bun" && pmVersion != "" {

--- a/examples/node-dev-engines/README.md
+++ b/examples/node-dev-engines/README.md
@@ -1,0 +1,5 @@
+# node-dev-engines
+
+Declares the Node runtime and the package manager through
+[`devEngines`](https://nodejs.org/api/packages.html#devengines) instead of
+`engines` and `packageManager`.

--- a/examples/node-dev-engines/index.js
+++ b/examples/node-dev-engines/index.js
@@ -1,0 +1,1 @@
+console.log(`Hello from devEngines Node ${process.version}`);

--- a/examples/node-dev-engines/package.json
+++ b/examples/node-dev-engines/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-dev-engines",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "22.11.0",
+      "onFail": "download"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.4.1",
+      "onFail": "download"
+    }
+  }
+}

--- a/examples/node-dev-engines/test.json
+++ b/examples/node-dev-engines/test.json
@@ -1,0 +1,5 @@
+[
+  {
+    "expectedOutput": "Hello from devEngines Node v22"
+  }
+]


### PR DESCRIPTION
## Motivation

Railpack does not read `package.json > devEngines` at all, so a project that
declares its Node version and package manager there falls through to lockfile
inference and the Railpack defaults.

In #616 that mismatch is visible at runtime: `devEngines.runtime` asks for a
Node version that Railpack does not install, so mise downloads it when the
container starts and the extracted toolchain stays in the running container's
memory. The reporter measured backend memory going from ~200 MB to ~700 MB
after switching to `devEngines.packageManager`, and back down after reverting.

## Description

`devEngines.runtime` and `devEngines.packageManager` are now read, in both the
single-object and array forms that the [Node.js
spec](https://nodejs.org/api/packages.html#devengines) allows.

Precedence follows the existing pattern of preferring explicit declarations:

- `devEngines.runtime` (node) wins over `engines.node`, and `RAILPACK_NODE_VERSION` still wins over both.
- `devEngines.packageManager` is preferred over lockfile inference, the same way the `packageManager` field already is, and the `packageManager` field still wins over it.
- The declared package manager version is passed to mise, labelled `package.json > devEngines > packageManager`, so it appears in the build log next to the other sources.

## Test

- `TestDevEngines` covers the parser: single objects, arrays, a non-node runtime, and surrounding whitespace.
- A provider test asserts that `examples/node-dev-engines` resolves node `22.11.0` and pnpm `10.4.1`. That example declares no lockfile and no `packageManager` field, so before this change it fell back to npm and the Railpack default Node version.
- `mise run check` and `mise run test` pass. No existing example's build plan changed.

## Links

- Fixes #616
- https://nodejs.org/api/packages.html#devengines
