### PR TITLE
docs: improve code block formatting and refine documentation styling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # What is Railpack
 
-Zero-config application builder that automatically analyzes your code and turns
-it into a container image. It's built on BuildKit with support for Node, Python, Go, PHP, and more.
+Zero-config application builder that analyzes code and builds an image. It's
+built on BuildKit with support for Node, Python, Go, PHP, and more.
 
 # Architecture
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -80,7 +80,7 @@ export default defineConfig({
         starlightLlmsTxt({
           projectName: "Railpack",
           description:
-            "Zero-config application builder that automatically analyzes your code and turns it into a container image. Built on BuildKit with support for Node, Python, Go, PHP, and more.",
+            "Zero-config application builder that analyzes code and builds an image. Built on BuildKit with support for Node, Python, Go, PHP, and more.",
           details:
             "Railpack provides a seamless way to build container images from your source code without complex configuration. It automatically detects your project type and generates appropriate build steps.",
           customSets: [

--- a/docs/src/content/docs/architecture/secrets.md
+++ b/docs/src/content/docs/architecture/secrets.md
@@ -18,7 +18,7 @@ Environment variables can be set in two ways:
 
 1. Through step variables:
 
-```json
+```json title="railpack.json"
 {
   "steps": {
     "install": {
@@ -32,7 +32,7 @@ Environment variables can be set in two ways:
 
 2. Through the deploy section for runtime variables:
 
-```json
+```json title="railpack.json"
 {
   "deploy": {
     "variables": {
@@ -75,7 +75,7 @@ You can explicitly specify which secrets a step should have access to using the
 `secrets` array. An empty array indicates that no secrets should be available to
 that step.
 
-```json
+```json title="railpack.json"
 {
   "secrets": ["DATABASE_URL", "API_KEY", "STRIPE_LIVE_KEY"],
   "steps": {
@@ -89,7 +89,7 @@ that step.
 You can also use `"*"` in a step's secrets array to indicate that it should have
 access to all secrets defined in the build plan:
 
-```json
+```json title="railpack.json"
 {
   "secrets": ["DATABASE_URL", "API_KEY", "STRIPE_LIVE_KEY"],
   "steps": {

--- a/docs/src/content/docs/config/excluding-files.md
+++ b/docs/src/content/docs/config/excluding-files.md
@@ -21,7 +21,7 @@ a file or a directory.
 
 Given a `.dockerignore` file:
 
-```
+```txt title=".dockerignore"
 **/node_modules
 .env
 *.log
@@ -30,7 +30,7 @@ Given a `.dockerignore` file:
 
 When you run `railpack build --show-plan`, you'll see this gets converted to:
 
-```json
+```json title="railpack.json"
 {
   "exclude": [
     "**/node_modules",
@@ -49,7 +49,7 @@ You can also specify `exclude` patterns directly in your `railpack.json`
 configuration file instead of (or in addition to) using `.dockerignore`.
 Negation patterns (starting with `!`) can be included in the `exclude` array:
 
-```json
+```json title="railpack.json"
 {
   "exclude": [
     "**/node_modules",

--- a/docs/src/content/docs/config/file.mdx
+++ b/docs/src/content/docs/config/file.mdx
@@ -11,7 +11,7 @@ If found, that configuration will be used to change how the plan is built.
 
 A config file looks something like this:
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "steps": {
@@ -44,7 +44,7 @@ Layers are used both for steps and for the deploy section. The deploy section
 explicitly has a `base` layer defined that is used as the base file system for
 the final image. For example, the layers of a Node build might look like this:
 
-```json
+```json title="railpack.json"
 "deploy": {
   "base": {
     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.2.22"
@@ -70,7 +70,7 @@ the final image. For example, the layers of a Node build might look like this:
 
 Use another step's output as a layer:
 
-```json
+```json title="railpack.json"
 {
   "step": "install",
   "include": ["."], // "." represents the working directory (/app)
@@ -82,7 +82,7 @@ Use another step's output as a layer:
 
 Use a Docker image as a layer:
 
-```json
+```json title="railpack.json"
 {
   "image": "macabees/neofetch",
   "include": ["/usr/bin/neofetch"]
@@ -93,7 +93,7 @@ Use a Docker image as a layer:
 
 Use local files as a layer:
 
-```json
+```json title="railpack.json"
 {
   "local": true,
   "include": ["."]
@@ -117,7 +117,7 @@ it completely.
 
 For example:
 
-```json
+```json title="railpack.json"
 {
   "steps": {
     "build": {
@@ -152,7 +152,7 @@ The root configuration can have these fields:
 
 For example:
 
-```json
+```json title="railpack.json"
 {
   "provider": "node",
   "buildAptPackages": ["git", "curl"],
@@ -206,7 +206,7 @@ following properties:
 
 For example:
 
-```json
+```json title="railpack.json"
 {
   "caches": {
     "npm-install": {
@@ -246,7 +246,7 @@ Each step in the build process can have:
 
 A list of commands to run in a step. For example:
 
-```json
+```json title="railpack.json"
 {
   "commands": [
     // Copy the package.json file from the local context into the build
@@ -334,7 +334,7 @@ Both the builder and runtime images include `en_US.UTF-8`, but do not set
 `LANG` or `LC_ALL` by default. To enable it at runtime, set them in
 `deploy.variables`:
 
-```json
+```json title="railpack.json"
 "deploy": {
   "variables": {
     "LANG": "en_US.UTF-8",
@@ -352,7 +352,7 @@ Railpack allows comments in `railpack.json`, but VS Code treats files with a
 `.json` extension as standard JSON by default. Add this file association to
 your user or workspace `settings.json` so comments are recognized:
 
-```json
+```json title=".vscode/settings.json"
 {
   "files.associations": {
     "railpack.json": "json5"
@@ -364,7 +364,7 @@ The [`railpack.json` schema](https://schema.railpack.com) should be recognized
 automatically. If your editor does not detect it, add the `$schema` property
 to the root of `railpack.json`:
 
-```json5
+```json5 title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   // Additional configuration

--- a/docs/src/content/docs/config/mise.md
+++ b/docs/src/content/docs/config/mise.md
@@ -58,7 +58,7 @@ into the build. This includes:
 To opt-in to non-default features like precompiled Ruby, add a
 `mise.toml` to your repository:
 
-```toml
+```toml title="mise.toml"
 [tools]
 ruby = "3"
 

--- a/docs/src/content/docs/config/procfile.mdx
+++ b/docs/src/content/docs/config/procfile.mdx
@@ -26,7 +26,7 @@ use it to set the container start command.
 The `Procfile` uses a YAML-style format where each line defines a process type
 and its associated command:
 
-```yaml
+```yaml title="Procfile"
 web: gunicorn --bind 0.0.0.0:3333 main:app
 worker: celery worker -A myapp.celery
 scheduler: celery beat -A myapp.celery
@@ -49,19 +49,19 @@ processes or custom process types like `scheduler`, `urgentWorker`, or `api`.
 
 ### Web Application
 
-```yaml
+```yaml title="Procfile"
 web: node server.js
 ```
 
 ### Background Worker
 
-```yaml
+```yaml title="Procfile"
 worker: python worker.py
 ```
 
 ### Multiple Process Types
 
-```yaml
+```yaml title="Procfile"
 web: gunicorn app:application
 worker: celery worker -A app.celery
 scheduler: celery beat -A app.celery
@@ -72,7 +72,7 @@ command.
 
 ### Custom Process Types
 
-```yaml
+```yaml title="Procfile"
 api: ./bin/api-server
 urgentWorker: python urgent_tasks.py
 ```

--- a/docs/src/content/docs/config/recommendations.md
+++ b/docs/src/content/docs/config/recommendations.md
@@ -8,7 +8,7 @@ description: Environment and tooling recommendations for Railpack-built images
 Railpack does not set a timezone. Set `TZ` explicitly for your application.
 `TZ=UTC` is a good default.
 
-```json
+```json title="railpack.json"
 {
   "deploy": {
     "variables": {
@@ -26,7 +26,7 @@ can cause compatibility issues with mise and other tooling.
 
 Install Python via mise whenever you use pipx:
 
-```json
+```json title="railpack.json"
 {
   "packages": {
     "python": "latest",
@@ -45,7 +45,7 @@ is available in the runtime image. If your application requires a different
 locale, install the corresponding locale packages via
 [`deploy.aptPackages`](/config/file).
 
-```json
+```json title="railpack.json"
 {
   "deploy": {
     "variables": {
@@ -68,7 +68,7 @@ versions keeps local development, CI, and production aligned.
 
 A `mise.toml` in your project keeps tool versions in one place:
 
-```toml
+```toml title="mise.toml"
 [tools]
 node = "22.14.0"
 python = "3.13.2"
@@ -87,7 +87,7 @@ team and Railpack. This keeps local development, CI, and production builds perfe
 
 Package managers supported by mise can be pinned in `mise.toml`:
 
-```toml
+```toml title="mise.toml"
 [tools]
 node = "22.14.0"
 pnpm = "10.15.1"
@@ -95,7 +95,7 @@ pnpm = "10.15.1"
 
 Mise is the recommended path, but you can use `package.json` configuration as well.
 
-```json
+```json title="package.json"
 {
   "packageManager": "npm@11.4.2"
 }
@@ -104,7 +104,7 @@ Mise is the recommended path, but you can use `package.json` configuration as we
 The `devEngines` field can also document the required package manager and
 instruct supporting tooling to reject a different version:
 
-```json
+```json title="package.json"
 {
   "devEngines": {
     "packageManager": {
@@ -125,7 +125,7 @@ supports most external tools you are likely to need.
 Using mise keeps tool versions consistent with the rest of your config and
 avoids coupling your build to distro packages or a separate install path.
 
-```toml
+```toml title="mise.toml"
 [tools]
 jq = "1.7.1"
 ripgrep = "14.1.1"
@@ -141,7 +141,7 @@ a build.
 Add `locked = true` to your mise config. This ensures that the exact same
 version is used for dev, CI, and production.
 
-```toml
+```toml title="mise.toml"
 [tools]
 node = "22.14.0"
 python = "3.13.2"
@@ -158,7 +158,7 @@ automatically includes `mise.lock` files in the build when present.
 Mise can verify OpenPGP signatures for tools that publish them. Enable
 verification for all supported tools in your `mise.toml`:
 
-```toml
+```toml title="mise.toml"
 [settings]
 gpg_verify = true
 
@@ -197,7 +197,7 @@ RAILPACK_NODE_NPM_INSTALL="npm ci"
 You can also customize the install command in `railpack.json` if you need more
 control over the install step:
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "steps": {
@@ -235,3 +235,15 @@ determinism. You should keep your lockfile in sync and opt into `npm ci` for:
   and CI environments, with no silent drift in production
 - **Faster installs** — `npm ci` installs from the lockfile instead of resolving
   `package.json` again
+
+## Create a `.dockerignore` File
+
+Create a `.dockerignore` file in your repository root to exclude files and
+directories that are not required in production.
+
+Excluding unnecessary files makes your final images smaller, speeds up build
+upload times, and eliminates production security risks by minimizing the code
+and assets available inside the running container environment:
+
+See [Excluding Files](/config/excluding-files) for full details on pattern
+matching and using `railpack.json` exclusions.

--- a/docs/src/content/docs/guides/adding-steps.mdx
+++ b/docs/src/content/docs/guides/adding-steps.mdx
@@ -12,7 +12,7 @@ hits or don't want to affect the automatically generated provider commands.
 
 To add a step, you can use the `steps` field in your configuration file.
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "steps": {
@@ -25,7 +25,7 @@ To add a step, you can use the `steps` field in your configuration file.
 
 The default `inputs` for a new step is:
 
-```json
+```json title="railpack.json"
 "inputs": [
   { "step": "packages:mise" }
 ]
@@ -37,7 +37,7 @@ build apt packages.
 If you want to run after a specific provider-generated step, you can specify the
 inputs. For example, this will run the `new-step` after the `build` step.
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "steps": {
@@ -57,7 +57,7 @@ By default, the entire `/app` directory is included in the final image. You can
 customize this by specifying a `deployOutputs` field. For example, this will
 include the `dist` directory in the final image.
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "steps": {
@@ -74,7 +74,7 @@ include the `dist` directory in the final image.
 _Note: `deployOutputs` is syntactic sugar for adding this layer to the
 `deploy.inputs` field. The above example is equivalent to._
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "steps": {

--- a/docs/src/content/docs/guides/developing-locally.md
+++ b/docs/src/content/docs/guides/developing-locally.md
@@ -36,7 +36,7 @@ gigabytes of that data off your laptop if you are actively working on Railpack.
 
 Set this in a `mise.local.toml`:
 
-```toml
+```toml title="mise.local.toml"
 [env]
 DOCKER_HOST = "ssh://user@host"
 ```
@@ -258,7 +258,7 @@ for the schema.
 In addition to an output assertion, you can run an HTTP check that starts the
 container and asserts that a specific route returns an expected HTTP code:
 
-```json
+```json title="test.json"
 {
   "httpCheck": {
     "path": "/",
@@ -273,7 +273,7 @@ container and asserts that a specific route returns an expected HTTP code:
 You can verify that the application outputs specific strings. `expectedOutput` can
 be a single string or an array of strings that all must be present in the output:
 
-```json
+```json title="test.json"
 {
   "expectedOutput": "Server running on port 3000"
 }
@@ -281,7 +281,7 @@ be a single string or an array of strings that all must be present in the output
 
 Or with multiple strings:
 
-```json
+```json title="test.json"
 {
   "expectedOutput": [
     "Elixir version: 1.18",
@@ -296,7 +296,7 @@ You can pass environment variables to the container at runtime using the
 `envs` key. This is useful for testing with different configurations, secrets,
 or Railpack configuration variables:
 
-```json
+```json title="test.json"
 {
   "expectedOutput": "Server running on port 3000",
   "envs": {
@@ -309,7 +309,7 @@ or Railpack configuration variables:
 You can also use `RAILPACK_*` configuration variables in `envs` to test
 different build configurations:
 
-```json
+```json title="test.json"
 {
   "expectedOutput": "hello from Node",
   "envs": {

--- a/docs/src/content/docs/guides/installing-packages.md
+++ b/docs/src/content/docs/guides/installing-packages.md
@@ -39,7 +39,7 @@ RAILPACK_DEPLOY_APT_PACKAGES="... ffmpeg"
 The `...` entry extends Railpack's generated package list. Without it, the
 configured list replaces the packages Railpack specifies:
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "buildAptPackages": ["...", "build-essential"],
@@ -51,7 +51,7 @@ configured list replaces the packages Railpack specifies:
 
 To intentionally replace Railpack's runtime packages, omit `...`:
 
-```json
+```json title="railpack.json"
 {
   "$schema": "https://schema.railpack.com",
   "deploy": {

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Railpack
-description: Zero-config application builder that automatically analyzes your code and turns it into an image.
+description: Zero-config application builder that analyzes code and builds an image.
 template: splash
 hero:
-  tagline: Zero-config application builder that automatically analyzes your code and turns it into an image
+  tagline: Zero-config application builder that analyzes code and builds an image
   # image:
   #   file: ../../assets/houston.webp
   actions:

--- a/docs/src/content/docs/languages/php.md
+++ b/docs/src/content/docs/languages/php.md
@@ -73,7 +73,7 @@ PHP extensions are automatically installed based on:
 
 Example `composer.json` with required extensions:
 
-```json
+```json title="composer.json"
 {
   "require": {
     "php": ">=8.2",

--- a/docs/src/content/docs/languages/python.md
+++ b/docs/src/content/docs/languages/python.md
@@ -51,7 +51,7 @@ MISE_PYTHON_COMPILE=1
 
 Or add the following to your `mise.toml`:
 
-```toml
+```toml title="mise.toml"
 [settings.python]
 compile = true
 ```

--- a/docs/src/content/docs/languages/ruby.md
+++ b/docs/src/content/docs/languages/ruby.md
@@ -118,7 +118,7 @@ By default, Railpack follows the Mise default of building Ruby from
 source. You can opt into precompiled Ruby binaries for faster build times
 by adding a `mise.toml` to your repository:
 
-```toml
+```toml title="mise.toml"
 [tools]
 ruby = "3"
 

--- a/docs/src/content/docs/languages/shell.md
+++ b/docs/src/content/docs/languages/shell.md
@@ -17,7 +17,7 @@ of these conditions are met:
 
 Create a shell script in your project root (e.g., `start.sh`):
 
-```bash
+```bash title="start.sh"
 #!/bin/bash
 
 echo "Hello world..."

--- a/docs/src/content/docs/languages/staticfile.md
+++ b/docs/src/content/docs/languages/staticfile.md
@@ -32,7 +32,7 @@ The provider determines the root directory in this order:
 You can configure static file serving with a `Staticfile` in your project
 root:
 
-```yaml
+```yaml title="Staticfile"
 # root directory to serve
 root: dist
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -133,21 +133,21 @@ The most reliable way to enable completion is to source it directly in your shel
 **Zsh**
 Add this to your `~/.zshrc`:
 
-```bash
+```bash title="~/.zshrc"
 source <(railpack completion zsh)
 ```
 
 **Bash**
 Add this to your `~/.bashrc`:
 
-```bash
+```bash title="~/.bashrc"
 source <(railpack completion bash)
 ```
 
 **Fish**
 Add this to your `~/.config/fish/config.fish`:
 
-```fish
+```fish title="~/.config/fish/config.fish"
 railpack completion fish | source
 ```
 

--- a/docs/src/styles/tokens.css
+++ b/docs/src/styles/tokens.css
@@ -132,6 +132,10 @@
   --sl-color-red-high: var(--red-11);
 
   --sl-sidebar-width: 18.75rem;
+
+  --table-bg: #ffffff;
+  --table-header-bg: color-mix(in srgb, var(--gray-3) 45%, #ffffff);
+  --table-hover-bg: color-mix(in srgb, var(--gray-3) 55%, #ffffff);
 }
 
 :root[data-theme="light"] {
@@ -151,6 +155,10 @@
   --sl-color-gray-5: var(--gray-6);
   --sl-color-gray-6: var(--gray-4);
   --sl-color-gray-7: var(--gray-2);
+
+  --table-bg: #ffffff;
+  --table-header-bg: color-mix(in srgb, var(--gray-3) 45%, #ffffff);
+  --table-hover-bg: color-mix(in srgb, var(--gray-3) 55%, #ffffff);
 }
 
 :root[data-theme="dark"] {
@@ -169,6 +177,10 @@
   --sl-color-gray-4: var(--gray-8);
   --sl-color-gray-5: var(--gray-6);
   --sl-color-gray-6: var(--gray-3);
+
+  --table-bg: var(--gray-2);
+  --table-header-bg: color-mix(in srgb, var(--gray-3) 60%, var(--gray-2));
+  --table-hover-bg: color-mix(in srgb, var(--gray-3) 80%, var(--gray-2));
 }
 
 @layer base {

--- a/docs/src/tailwind.css
+++ b/docs/src/tailwind.css
@@ -167,6 +167,15 @@ site-search button[data-open-modal] {
     transform: rotateZ(90deg);
   }
 
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
   li {
     border: 0;
     --sl-sidebar-item-padding-inline: 0.45rem;
@@ -177,7 +186,7 @@ site-search button[data-open-modal] {
   .top-level {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 0.25rem;
   }
 
   .top-level > * {
@@ -186,11 +195,19 @@ site-search button[data-open-modal] {
 
   /* Extra air above each collapsible group so headers read as section starts. */
   .top-level > li:has(details) {
-    margin-block-start: 0.65rem;
+    margin-block-start: 0.75rem;
   }
 
   .top-level > li:has(details):first-child {
     margin-block-start: 0.35rem;
+  }
+
+  /* When details is open, give breathing room between summary and first item */
+  details > ul {
+    margin-top: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
   }
 
   /* Section titles: same size as links, bolder + higher contrast. */
@@ -344,12 +361,23 @@ site-search button[data-open-modal] {
 
   :not(pre) > code {
     font-family: var(--font-mono);
-    background-color: var(--gray-3);
-    border: none;
-    padding: 0.125rem 0.375rem;
-    font-size: 0.875rem;
+    font-size: 0.85em;
+    font-weight: 450;
     color: var(--gray-12);
-    border-radius: 0.5rem;
+    background-color: var(--gray-2);
+    border: none;
+    border-radius: 0.3125rem;
+    padding: 0.125em 0.375em;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+  }
+
+  :root[data-theme="dark"] :not(pre) > code {
+    background-color: var(--gray-3);
+  }
+
+  a:not(.sl-link-card) > code {
+    color: inherit;
   }
 
   td:first-child code {
@@ -386,10 +414,11 @@ site-search button[data-open-modal] {
     border-radius: 0.5rem;
     overflow: hidden;
     font-size: 0.875rem;
+    background-color: var(--table-bg, #ffffff);
   }
 
   thead {
-    background-color: color-mix(in srgb, var(--gray-3) 50%, transparent);
+    background-color: var(--table-header-bg, var(--gray-2));
   }
 
   th {
@@ -404,6 +433,10 @@ site-search button[data-open-modal] {
   td {
     padding: 0.75rem 1rem;
     color: var(--gray-12);
+    border: none;
+  }
+
+  tbody tr + tr td {
     border-top: 1px solid var(--gray-6);
   }
 
@@ -414,13 +447,13 @@ site-search button[data-open-modal] {
     width: 1%;
   }
 
-  th:last-child,
-  td:last-child {
-    width: auto;
+  tbody tr:hover {
+    background-color: var(--table-hover-bg, color-mix(in srgb, var(--gray-3) 50%, transparent));
   }
 
-  tbody tr:hover {
-    background-color: color-mix(in srgb, var(--gray-3) 50%, transparent);
+  /* Inline code chips in tables should have a 1px border */
+  table code {
+    border: 1px solid var(--gray-6) !important;
   }
 
   /* Inline code chips in tables shouldn't force awkward wrapping. */
@@ -953,10 +986,38 @@ railpack-toc-progress[data-progress-ready] .railpack-toc-active-dot {
   }
 }
 
-/* Splash hero (homepage) — align with warm canvas + serif title */
+/* Splash hero (homepage) — scale padding and spacing dynamically with viewport height */
+[data-has-hero] {
+  .content-panel {
+    padding-block: clamp(0.5rem, 3.5vh, 4rem) !important;
+  }
+
+  .sl-container > * + * {
+    margin-top: clamp(0.75rem, 3vh, 3.5rem);
+  }
+
+  footer {
+    margin-top: clamp(0.75rem, 3vh, 3rem) !important;
+  }
+}
+
 .hero {
+  padding-bottom: 0 !important;
+
+  @media (min-width: 50rem) {
+    padding-block: clamp(0.5rem, 4vh, 5rem) !important;
+  }
+
   .sl-container {
     color: var(--gray-12);
+  }
+
+  .stack {
+    gap: clamp(0.75rem, 3vh, 2.5rem) !important;
+  }
+
+  .copy {
+    gap: clamp(0.375rem, 1.5vh, 1.25rem) !important;
   }
 
   h1,
@@ -965,13 +1026,23 @@ railpack-toc-progress[data-progress-ready] .railpack-toc-active-dot {
   }
 
   h1 {
-    font-family: var(--font-serif);
+    font-family: var(--font-serif) !important;
     font-weight: 600;
+    font-size: clamp(2.25rem, calc(1.5rem + 2vw + 1.5vh), 4.25rem) !important;
+    line-height: 1.1;
     letter-spacing: -0.03em;
+    margin: 0;
   }
 
   .tagline {
     color: var(--gray-11);
+    font-size: clamp(1rem, calc(0.85rem + 0.35vw + 0.35vh), 1.35rem) !important;
+    line-height: 1.45;
+    max-width: 50ch;
+  }
+
+  .actions {
+    gap: 0.75rem 1.5rem;
   }
 }
 


### PR DESCRIPTION
## Motivation

Documentation lacked consistent code block titles and context across guides, and the documentation site needed typography and spacing refinements to improve readability.

## Description

- Add titles and file context to code blocks across architecture, guides, languages, and reference docs.
- Add dockerignore recommendations to configuration documentation.
- Refine documentation site styling, including table formatting, sidebar spacing, and hero typography.
- Simplify project overview descriptions.