### PR TITLE
test: add git-based dependencies to Node and Python examples

### DIFF
--- a/examples/node-npm/package-lock.json
+++ b/examples/node-npm/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dayjs": "^1.11.13"
+        "dayjs": "^1.11.13",
+        "rehype-remove-images": "github:iloveitaly/rehype-remove-images"
       },
       "devDependencies": {
         "typescript": "^5.6.3"
@@ -18,11 +19,49 @@
         "node": "23.5.0"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
+      "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remove-images": {
+      "version": "1.1.1",
+      "resolved": "git+ssh://git@github.com/iloveitaly/rehype-remove-images.git#6307a5d2b29f4b96f08fb4f62f6c2badf012cef2",
+      "license": "MIT",
+      "dependencies": {
+        "hast-util-is-element": "^2.1.3",
+        "unist-util-remove": "^4.0.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.7.3",
@@ -37,6 +76,66 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     }
   }
 }

--- a/examples/node-npm/package.json
+++ b/examples/node-npm/package.json
@@ -16,7 +16,8 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "dayjs": "^1.11.13"
+    "dayjs": "^1.11.13",
+    "rehype-remove-images": "github:iloveitaly/rehype-remove-images"
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/examples/node-npm/test.json
+++ b/examples/node-npm/test.json
@@ -2,6 +2,7 @@
   {
     // this project does not define the npm package manager explicitly, so we are assuming that
     // that railpack infers it via package-lock.json
+    // rehype-remove-images is a github: dep so this example exercises git-based installs
     "expectedOutput": "hello from Node v23.5.0",
     // TEMPORARY: Remove this once NPM_CONFIG_PRODUCTION is removed from node.go:241
     // Currently causes: npm warn config production Use `--omit=dev` instead.

--- a/examples/python-pip/requirements.txt
+++ b/examples/python-pip/requirements.txt
@@ -1,2 +1,4 @@
 numpy==2.2.1
 pandas==2.2.3
+# Git URL so this example exercises git-based dependency installs
+fastapi-ipware @ git+https://github.com/iloveitaly/fastapi-ipware.git

--- a/examples/python-pip/test.json
+++ b/examples/python-pip/test.json
@@ -1,5 +1,6 @@
 [
   {
+    // fastapi-ipware is a git+https dep so this example exercises git-based installs
     "expectedOutput": [
       "Python version: 3.11.11",
       "Hello from pip"


### PR DESCRIPTION
## Motivation

Ensure Railpack correctly resolves and installs Git-based package dependencies during builds across different language ecosystems.

## Description

Add Git repository dependencies (`github:` protocol for Node npm and `git+https` for Python pip) to the example test suites to verify build-time Git dependency installation.

## Test

Run integration tests against the `examples/node-npm` and `examples/python-pip` sample projects to confirm dependency installation and expected output.