### PR TITLE
fix(mise): run host mise commands in safe mode

### DIFF
--- a/core/mise/install.go
+++ b/core/mise/install.go
@@ -76,28 +76,64 @@ func getBinaryPath(cacheDir string) string {
 func ensureInstalled(cacheDir string) (string, error) {
 	binaryPath := getBinaryPath(cacheDir)
 
-	if _, err := os.Stat(binaryPath); err == nil {
+	if _, err := os.Stat(binaryPath); err != nil {
+		log.Debugf("Mise %s not found, installing", Version)
+
+		if err := os.MkdirAll(cacheDir, 0755); err != nil {
+			return "", fmt.Errorf("failed to create cache directory: %w", err)
+		}
+
+		if err := downloadAndInstall(cacheDir); err != nil {
+			return "", fmt.Errorf("failed to download and install: %w", err)
+		}
+
+		if err := validateInstallation(cacheDir); err != nil {
+			return "", fmt.Errorf("failed to validate installation: %w", err)
+		}
+
+		log.Debugf("Installed mise version: %s to %s", Version, binaryPath)
+	} else {
 		log.Debugf("Mise executable exists at %s", binaryPath)
-		return binaryPath, nil
 	}
 
-	log.Debugf("Mise %s not found, installing", Version)
-
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		return "", fmt.Errorf("failed to create cache directory: %w", err)
+	// php has no HTTP backend; clone vfox-php once so later MISE_SAFE=1 queries can list versions
+	if err := ensurePhpPlugin(binaryPath, cacheDir); err != nil {
+		return "", fmt.Errorf("failed to ensure php plugin: %w", err)
 	}
-
-	if err := downloadAndInstall(cacheDir); err != nil {
-		return "", fmt.Errorf("failed to download and install: %w", err)
-	}
-
-	if err := validateInstallation(cacheDir); err != nil {
-		return "", fmt.Errorf("failed to validate installation: %w", err)
-	}
-
-	log.Debugf("Installed mise version: %s to %s", Version, binaryPath)
 
 	return binaryPath, nil
+}
+
+// vfox-php must be present before safe-mode version queries; plugin install cannot run under MISE_SAFE=1
+func ensurePhpPlugin(binaryPath, cacheDir string) error {
+	pluginDir := filepath.Join(cacheDir, "data", "plugins", "php")
+	if _, err := os.Stat(pluginDir); err == nil {
+		return nil
+	}
+
+	log.Debugf("Installing vfox-php plugin into %s", pluginDir)
+
+	cmd := exec.Command(binaryPath, "plugin", "install", "php")
+	cmd.Dir = cacheDir
+	cmd.Env = []string{
+		fmt.Sprintf("HOME=%s", cacheDir),
+		fmt.Sprintf("MISE_CACHE_DIR=%s", filepath.Join(cacheDir, "cache")),
+		fmt.Sprintf("MISE_DATA_DIR=%s", filepath.Join(cacheDir, "data")),
+		fmt.Sprintf("MISE_STATE_DIR=%s", filepath.Join(cacheDir, "state")),
+		fmt.Sprintf("MISE_SYSTEM_CONFIG_DIR=%s", filepath.Join(cacheDir, "system")),
+		"MISE_NO_CONFIG=1",
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GITHUB_TOKEN=%s", token))
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to install php plugin: %w\n%s", err, output)
+	}
+
+	return nil
 }
 
 func downloadAndInstall(cacheDir string) error {

--- a/core/mise/mise.go
+++ b/core/mise/mise.go
@@ -60,7 +60,7 @@ func (m *Mise) GetLatestVersion(pkg, version string) (string, error) {
 	}
 	defer unlock()
 
-	baseEnv := []string{"MISE_NO_CONFIG=1", "MISE_PARANOID=1"}
+	baseEnv := []string{"MISE_NO_CONFIG=1"}
 
 	// a user could eliminate the min release age in their config, or pin a version to a release
 	// if they do, we want to make sure they can still install that specific version they want, so we fallback to a env
@@ -121,7 +121,7 @@ func (m *Mise) GetAllVersions(pkg, version string) ([]string, error) {
 	var output string
 	for _, queryVersion := range versionQueryCandidates(version) {
 		query := fmt.Sprintf("%s@%s", pkg, queryVersion)
-		output, err = m.runCmdWithEnv([]string{"MISE_NO_CONFIG=1", "MISE_PARANOID=1"}, "ls-remote", query)
+		output, err = m.runCmdWithEnv([]string{"MISE_NO_CONFIG=1"}, "ls-remote", query)
 		if err == nil && strings.TrimSpace(output) != "" {
 			break
 		}
@@ -192,10 +192,6 @@ func (m *Mise) GetCurrentList(appDir string) (string, error) {
 		trustedConfigEnv,
 		ceilingPathsEnv,
 		enabledIdiomaticEnv,
-		// MISE_PARANOID enables stricter security validation
-		"MISE_PARANOID=1",
-		// Safe mode keeps the app's own mise config inert (no code execution or host env mutation) while still reporting versions
-		"MISE_SAFE=1",
 	}, "--cd", appDir, "list", "--current", "--json")
 }
 
@@ -229,6 +225,10 @@ func (m *Mise) runCmdWithEnv(extraEnv []string, args ...string) (string, error) 
 		"MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=60s",
 		// allows for a 2m outage on mise (10ms base backoff retry)
 		"MISE_HTTP_RETRIES=5",
+		// blocks hooks, env mutation, and code execution from configs we do not control
+		"MISE_SAFE=1",
+		// asdf plugin scripts cannot run in safe mode; prefer aqua/core/pipx backends
+		"MISE_DISABLE_BACKENDS=asdf",
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	)
 


### PR DESCRIPTION
## Motivation

Host-run mise commands resolve versions and read app configs we do not control. They previously set `MISE_PARANOID=1` on some paths and `MISE_SAFE=1` only on `list --current`. Safe mode is the right host-side control: it blocks hooks, env mutation, and code execution from project config while still allowing version listing.

## Description

- Set `MISE_SAFE=1` on every host-run mise command via `runCmdWithEnv`
- Remove `MISE_PARANOID=1` from host-run commands (in-container mise still enables paranoid)
- Disable the asdf backend on host commands so leftover asdf plugins do not shadow aqua/core/pipx (safe mode cannot execute asdf plugin scripts)
- Install `vfox-php` once during mise bootstrap so PHP version listing still works (PHP has no HTTP backend; plugin install cannot run under `MISE_SAFE=1`)

## Test

`mise run check` and `mise run test`

## TODO

These are the remaining blockers to a clean safe-mode host path:

### (a) PHP

Railpack does not install PHP with mise — it only uses `GetAllVersions` to pick a FrankenPHP image tag. PHP is still plugin-only in the mise registry (`vfox:jdx/vfox-php`), so safe mode cannot list versions without a pre-installed plugin.

Better follow-up: stop using mise for PHP version listing and query FrankenPHP tags (or php.net) directly. Mise is unlikely to grow a first-class PHP installer; static/prebuilt defaults were rejected on supply-chain and extension grounds.

### (b) Manually disabling the asdf backend

`MISE_DISABLE_BACKENDS=asdf` is a workaround. The registry already prefers aqua for tools like `uv`. An installed asdf plugin still wins, and safe mode then hard-errors instead of falling back to aqua.

On a clean cache this flag is unnecessary. We need it because leftover plugins in the host mise cache shadow the registry. Mise's own `disable_backends` story has the same hole.

## Links

PHP:

- https://github.com/jdx/mise/discussions/4720 — request for core PHP; jdx: a core backend would not be better than vfox-php
- https://github.com/jdx/mise/discussions/4560 — `mise use php@latest` dependency hell; OS deps are an anti-goal
- https://github.com/jdx/mise/pull/5711 — closed: static-php prebuilts as the default (supply chain / no extensions)
- https://github.com/jdx/mise/pull/10842 — current default: `vfox:jdx/vfox-php`

asdf backend / plugin shadowing:

- https://github.com/jdx/mise/discussions/6021 — `disable_backends = ["asdf"]` still uses asdf for `uv` when a plugin is installed
- https://github.com/jdx/mise/pull/11362 — skip a disabled backend's leftover plugin so the registry backend is used
- https://github.com/jdx/mise/pull/11146 — `MISE_SAFE`: asdf scripts error, never silently fall back
- https://github.com/jdx/mise/discussions/2878 — preferring a safer backend over asdf without editing project config