### PR TITLE
test: update example snapshot for mise image version

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-dev-engines_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_node-pnpm-dev-engines_1.snap.json
@@ -82,7 +82,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.6"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.11"
     }
    ],
    "name": "packages:mise",
@@ -169,7 +169,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.6"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.11"
     }
    ],
    "name": "packages:apt:runtime"


### PR DESCRIPTION
## Motivation
Resolve snapshot drift in the `node-pnpm-dev-engines` example test caused by updated mise image versions.

## Description
Updates the expected build plan output snapshot for `TestGenerateBuildPlanForExamples_node-pnpm-dev-engines` to match the current mise image configuration.

## Test
Executed `TestGenerateBuildPlanForExamples_node-pnpm-dev-engines` in the `core` package.