### PR TITLE
feat(resolver): support version constraints on package.json > engines

### DIFF
--- a/core/resolver/resolver.go
+++ b/core/resolver/resolver.go
@@ -77,9 +77,23 @@ func (r *Resolver) ResolvePackages() (map[string]*ResolvedPackage, error) {
 
 		var latestVersion string
 
-		// If there is a custom version validator, we get possible versions and pick the latest one that matches
-		// Ex: this is used with PHP to match against a available runtime available on docker hub
-		if pkg.IsVersionAvailable != nil {
+		// A bounded or disjunctive range (">=1.1.0 <1.3.0", "20 || 22") cannot be expressed as a
+		// mise prefix query, so we enumerate the candidates and apply the constraint ourselves.
+		if constraint, ok := rangeConstraint(pkg.Version); ok {
+			// Enumerate every version rather than narrowing by prefix: a range can straddle
+			// majors (">=1.9 <2.1"), so any prefix we could derive risks hiding valid matches.
+			versions, err := r.mise.GetAllVersions(name, "")
+			if err != nil {
+				return nil, err
+			}
+
+			latestVersion = newestMatching(versions, constraint, pkg.IsVersionAvailable)
+			if latestVersion == "" {
+				return nil, fmt.Errorf("no version of %s satisfies %s (from %s)", name, pkg.Version, pkg.Source)
+			}
+		} else if pkg.IsVersionAvailable != nil {
+			// If there is a custom version validator, we get possible versions and pick the latest one that matches
+			// Ex: this is used with PHP to match against a available runtime available on docker hub
 			versions, err := r.mise.GetAllVersions(name, fuzzyVersion)
 			if err != nil {
 				return nil, err

--- a/core/resolver/version.go
+++ b/core/resolver/version.go
@@ -1,6 +1,10 @@
 package resolver
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
 
 func resolveToFuzzyVersion(version string) string {
 	// Remove any whitespace
@@ -44,4 +48,60 @@ func resolveToFuzzyVersion(version string) string {
 	version = strings.TrimRight(version, ".")
 
 	return version
+}
+
+// rangeConstraint parses the version strings whose meaning the fuzzy prefix form cannot
+// carry: an upper bound, a disjunction, a hyphen range, or a tilde range.
+//
+// mise only understands prefix queries (`bun@1`), so ">=1.1.0 <1.3.0" degrades to "1"
+// and mise happily installs 1.4.x. For these we enumerate the available versions and
+// pick the match ourselves. Anything the prefix form already expresses faithfully
+// (exact versions, "14.x", "^20", ">=22") keeps the cheaper mise-side resolution.
+func rangeConstraint(version string) (*semver.Constraints, bool) {
+	version = strings.TrimSpace(version)
+	if !needsConstraintResolution(version) {
+		return nil, false
+	}
+
+	constraint, err := semver.NewConstraint(version)
+	if err != nil {
+		// Not a constraint we understand; leave it to the existing fuzzy path so behavior
+		// is unchanged for anything exotic.
+		return nil, false
+	}
+
+	return constraint, true
+}
+
+func needsConstraintResolution(version string) bool {
+	if strings.HasPrefix(version, "~") {
+		return true
+	}
+
+	return strings.Contains(version, "<") ||
+		strings.Contains(version, "||") ||
+		strings.Contains(version, " - ")
+}
+
+// newestMatching returns the highest version in versions that satisfies constraint and
+// passes isAvailable. versions is ascending, so we walk it backwards.
+func newestMatching(versions []string, constraint *semver.Constraints, isAvailable func(string) bool) string {
+	for i := len(versions) - 1; i >= 0; i-- {
+		parsed, err := semver.NewVersion(versions[i])
+		if err != nil {
+			continue
+		}
+
+		if !constraint.Check(parsed) {
+			continue
+		}
+
+		if isAvailable != nil && !isAvailable(versions[i]) {
+			continue
+		}
+
+		return versions[i]
+	}
+
+	return ""
 }

--- a/core/resolver/version_test.go
+++ b/core/resolver/version_test.go
@@ -1,6 +1,10 @@
 package resolver
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
 
 func TestResolveToFuzzyVersion(t *testing.T) {
 	tests := []struct {
@@ -39,4 +43,113 @@ func TestResolveToFuzzyVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRangeConstraint(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantConstraint bool
+		// versions that must / must not satisfy the parsed constraint
+		satisfied    []string
+		notSatisfied []string
+	}{
+		{name: "exact version keeps fuzzy path", input: "18.3.2", wantConstraint: false},
+		{name: "x notation keeps fuzzy path", input: "14.x", wantConstraint: false},
+		{name: "caret keeps fuzzy path", input: "^20.0.0", wantConstraint: false},
+		{name: "lower bound only keeps fuzzy path", input: ">=20.0.0", wantConstraint: false},
+		{name: "latest keeps fuzzy path", input: "", wantConstraint: false},
+		{
+			name:           "bounded range",
+			input:          ">=1.1.0 <1.3.0",
+			wantConstraint: true,
+			satisfied:      []string{"1.1.0", "1.2.9"},
+			notSatisfied:   []string{"1.0.9", "1.3.0", "1.4.0"},
+		},
+		{
+			name:           "upper bound only",
+			input:          "<2",
+			wantConstraint: true,
+			satisfied:      []string{"1.9.9"},
+			notSatisfied:   []string{"2.0.0"},
+		},
+		{
+			name:           "disjunction",
+			input:          "20 || 22",
+			wantConstraint: true,
+			satisfied:      []string{"20.1.0", "22.0.0"},
+			notSatisfied:   []string{"21.0.0", "23.0.0"},
+		},
+		{
+			name:           "tilde pins minor",
+			input:          "~1.2.3",
+			wantConstraint: true,
+			satisfied:      []string{"1.2.3", "1.2.9"},
+			notSatisfied:   []string{"1.2.2", "1.3.0"},
+		},
+		{
+			name:           "hyphen range",
+			input:          "1.2 - 1.4",
+			wantConstraint: true,
+			satisfied:      []string{"1.3.0"},
+			notSatisfied:   []string{"1.1.0", "1.5.0"},
+		},
+		{name: "unparseable range falls back", input: "<not-a-version", wantConstraint: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			constraint, ok := rangeConstraint(tt.input)
+			if ok != tt.wantConstraint {
+				t.Fatalf("rangeConstraint(%q) ok = %v, want %v", tt.input, ok, tt.wantConstraint)
+			}
+			if !ok {
+				return
+			}
+
+			for _, v := range tt.satisfied {
+				if !constraint.Check(semver.MustParse(v)) {
+					t.Errorf("%q should satisfy %q", v, tt.input)
+				}
+			}
+			for _, v := range tt.notSatisfied {
+				if constraint.Check(semver.MustParse(v)) {
+					t.Errorf("%q should not satisfy %q", v, tt.input)
+				}
+			}
+		})
+	}
+}
+
+func TestNewestMatching(t *testing.T) {
+	versions := []string{"1.0.0", "1.1.0", "1.2.0", "1.2.9", "1.3.0", "1.4.0"}
+
+	t.Run("picks the newest version within the range", func(t *testing.T) {
+		constraint, _ := rangeConstraint(">=1.1.0 <1.3.0")
+		if got := newestMatching(versions, constraint, nil); got != "1.2.9" {
+			t.Errorf("got %q, want 1.2.9", got)
+		}
+	})
+
+	t.Run("honors the availability filter", func(t *testing.T) {
+		constraint, _ := rangeConstraint(">=1.1.0 <1.3.0")
+		isAvailable := func(v string) bool { return v != "1.2.9" }
+		if got := newestMatching(versions, constraint, isAvailable); got != "1.2.0" {
+			t.Errorf("got %q, want 1.2.0", got)
+		}
+	})
+
+	t.Run("skips versions mise reports that are not semver", func(t *testing.T) {
+		constraint, _ := rangeConstraint("<2")
+		if got := newestMatching([]string{"1.0.0", "nightly"}, constraint, nil); got != "1.0.0" {
+			t.Errorf("got %q, want 1.0.0", got)
+		}
+	})
+
+	t.Run("returns empty when nothing matches", func(t *testing.T) {
+		constraint, _ := rangeConstraint("<0.5")
+		if got := newestMatching(versions, constraint, nil); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
 }


### PR DESCRIPTION
Closes #723.

## The problem

mise only understands prefix queries (`bun@1`), so `resolveToFuzzyVersion` flattens a constraint down to a prefix before handing it over. That is lossless for the common forms, but not for these:

| `engines` | fuzzy prefix | what mise installs |
|---|---|---|
| `">=1.1.0 <1.3.0"` | `1` | `1.4.0` — upper bound silently ignored |
| `"<2"` | `<2` | mise error, no prefix to query |
| `"20 \|\| 22"` | `20 \|\| 22` | mise error |
| `"~1.2.3"` | `1.2.3` | pinned to the exact patch, `~` means `>=1.2.3 <1.3.0` |
| `"1.1 - 1.2"` | `1.1 - 1.2` | mise error |

The first row is the one from the linked Station thread: the build looks fine and quietly runs a version the app declared it does not support.

## The change

When a requested version carries meaning the prefix form cannot express — an upper bound, a disjunction, a hyphen range, or a tilde range — the resolver lists the available versions and picks the newest one satisfying the constraint, instead of asking mise for a prefix.

Everything the prefix form already expresses faithfully (exact versions, `14.x`, `^20`, `>=22`, `latest`) keeps the cheaper mise-side resolution, so no existing build plan changes and no snapshots move. A version string that is not a constraint we can parse also falls back to the current path rather than erroring.

The enumeration deliberately does not narrow by prefix: a range can straddle majors (`">=1.9 <2.1"`), so any prefix derived from it risks hiding valid matches.

An unsatisfiable constraint now fails with an error that names the version source, rather than installing something out of range:

```
✖ No version of bun satisfies 20 || 22 (from package.json > engines > bun)
```

## Verified with the CLI

Against a scratch project with `engines` set to each form:

| `engines` | before | after |
|---|---|---|
| `bun: ">=1.1.0 <1.3.0"` | `1.4.0` | `1.2.23` |
| `bun: "<2"` | mise error | `1.4.0` |
| `bun: "~1.2.3"` | `1.2.3` | `1.2.23` |
| `bun: "1.1 - 1.2"` | mise error | `1.2.23` |
| `node: "20 \|\| 22"` | mise error | `22.23.2` |
| `bun: "20 \|\| 22"` | mise error | clear "no version satisfies" error |

## Tests

`mise run check` is clean and `core/resolver` passes. Added unit tests covering which strings take the constraint path vs. the existing fuzzy path, the ten constraint forms above, the interaction with `IsVersionAvailable` (the PHP runtime filter), non-semver entries in mise's output, and the empty-result case.

## Unrelated failure

`TestGenerateBuildPlanForExamples/php-vanilla` fails on this branch, but it also fails on a clean `main` — `dunglas/frankenphp` published `php8.4.25-trixie` and the snapshot still pins `php8.4.24-trixie`. I left that snapshot untouched so it does not get mixed into this change.
