### PR TITLE
feat(node): tell users when @tanstack/react-start is in the wrong dependency section

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-devdeps-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-devdeps-spa_1.snap.json
@@ -1,0 +1,216 @@
+{
+ "caches": {
+  "apt": {
+   "directory": "/var/cache/apt",
+   "type": "locked"
+  },
+  "apt-lists": {
+   "directory": "/var/lib/apt/lists",
+   "type": "locked"
+  },
+  "node-modules": {
+   "directory": "/app/node_modules/.cache",
+   "type": "shared"
+  },
+  "npm-install": {
+   "directory": "/root/.npm",
+   "type": "shared"
+  },
+  "vite": {
+   "directory": "/app/node_modules/.vite",
+   "type": "shared"
+  }
+ },
+ "deploy": {
+  "base": {
+   "step": "packages:apt:runtime"
+  },
+  "inputs": [
+   {
+    "include": [
+     "/railpack/caddy"
+    ],
+    "step": "packages:caddy"
+   },
+   {
+    "include": [
+     "/Caddyfile"
+    ],
+    "step": "caddy"
+   },
+   {
+    "include": [
+     "dist"
+    ],
+    "step": "build"
+   }
+  ],
+  "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2\u003e\u00261",
+  "variables": {
+   "CI": "true",
+   "NODE_ENV": "production",
+   "NPM_CONFIG_FETCH_RETRIES": "5",
+   "NPM_CONFIG_FUND": "false",
+   "NPM_CONFIG_PRODUCTION": "false",
+   "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+   "RAILPACK_VERSION": "dev"
+  }
+ },
+ "steps": [
+  {
+   "assets": {
+    "generated-mise-toml": "[generated-mise-toml]"
+   },
+   "commands": [
+    {
+     "path": "/mise/shims"
+    },
+    {
+     "customName": "create mise config",
+     "name": "generated-mise-toml",
+     "path": "/etc/mise/config.toml"
+    },
+    {
+     "cmd": "mise install",
+     "customName": "install mise packages: node"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.16"
+    }
+   ],
+   "name": "packages:mise",
+   "variables": {
+    "MISE_CACHE_DIR": "/mise/cache",
+    "MISE_CONFIG_DIR": "/mise",
+    "MISE_DATA_DIR": "/mise",
+    "MISE_INSTALLS_DIR": "/mise/installs",
+    "MISE_SHIMS_DIR": "/mise/shims"
+   }
+  },
+  {
+   "caches": [
+    "npm-install"
+   ],
+   "commands": [
+    {
+     "path": "/app/node_modules/.bin"
+    },
+    {
+     "cmd": "mkdir -p /app/node_modules/.cache"
+    },
+    {
+     "dest": "package.json",
+     "src": "package.json"
+    },
+    {
+     "cmd": "npm install"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:mise"
+    }
+   ],
+   "name": "install",
+   "variables": {
+    "CI": "true",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_FETCH_RETRIES": "5",
+    "NPM_CONFIG_FUND": "false",
+    "NPM_CONFIG_PRODUCTION": "false",
+    "NPM_CONFIG_UPDATE_NOTIFIER": "false"
+   }
+  },
+  {
+   "caches": [
+    "node-modules",
+    "vite"
+   ],
+   "commands": [
+    {
+     "cmd": "npm run build"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "install"
+    },
+    {
+     "include": [
+      "."
+     ],
+     "local": true
+    }
+   ],
+   "name": "build",
+   "secrets": [
+    "*"
+   ]
+  },
+  {
+   "commands": [
+    {
+     "cmd": "mise install-into caddy@2.11.4 /railpack/caddy"
+    },
+    {
+     "path": "/railpack/caddy"
+    },
+    {
+     "path": "/railpack/caddy/bin"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.16"
+    }
+   ],
+   "name": "packages:caddy",
+   "variables": {
+    "MISE_PARANOID": "1"
+   }
+  },
+  {
+   "assets": {
+    "Caddyfile": "# global options\n{\n\tadmin off\n\tpersist_config off\n\tauto_https off\n\n\tlog {\n\t\tformat json\n\t}\n\n\tservers {\n\t\ttrusted_proxies static private_ranges 100.0.0.0/8 # trust railway's proxy\n\t}\n}\n\n# site block, listens on the $PORT environment variable, automatically assigned by railway\n:{$PORT:80} {\n\tlog {\n\t\tformat json\n\t}\n\n\trespond /health 200\n\n\t# Security headers\n\theader {\n\t\t# Prevent some browsers from MIME-sniffing a response away from the declared Content-Type\n\t\tX-Content-Type-Options \"nosniff\"\n\t\t# Remove Server header\n\t\t-Server\n\t}\n\n\t# serve from the 'dist' folder (Vite builds into the 'dist' folder)\n\troot * /app/dist\n\n\t# Handle static files\n\tfile_server {\n\t\thide .git\n\t\thide .env*\n\t}\n\n\t# Compression with more formats\n\tencode {\n\t\tgzip\n\t\tzstd\n\t}\n\n\t# match against direct against HTML file matches, folder-level index.html, and optionally fallback to root index.html\n\ttry_files {path} {path}.html {path}/index.html /index.html\n}\n"
+   },
+   "commands": [
+    {
+     "name": "Caddyfile",
+     "path": "/Caddyfile"
+    },
+    {
+     "cmd": "caddy fmt --overwrite /Caddyfile"
+    }
+   ],
+   "inputs": [
+    {
+     "step": "packages:caddy"
+    }
+   ],
+   "name": "caddy",
+   "secrets": [
+    "*"
+   ]
+  },
+  {
+   "caches": [
+    "apt",
+    "apt-lists"
+   ],
+   "commands": [
+    {
+     "cmd": "sh -c 'apt-get update \u0026\u0026 apt-get install -y libatomic1'",
+     "customName": "install apt packages: libatomic1"
+    }
+   ],
+   "inputs": [
+    {
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.16"
+    }
+   ],
+   "name": "packages:apt:runtime"
+  }
+ ]
+}

--- a/core/providers/node/spa.go
+++ b/core/providers/node/spa.go
@@ -87,6 +87,13 @@ func (p *NodeProvider) DeploySPA(ctx *generate.GenerateContext, build *generate.
 	ctx.Logger.LogInfo("Deploying as %s static site", spaFramework)
 	ctx.Logger.LogInfo("Output directory: %s", outputDir)
 
+	if p.hasMisplacedTanstackStart() {
+		ctx.Logger.LogSuggestion(
+			"Found @tanstack/react-start in devDependencies; move it to dependencies to deploy with SSR instead of a static site",
+			"https://docs.railway.com/guides/tanstack-start",
+		)
+	}
+
 	// default all paths to use the root index.html by default on SPA apps, but allow the user to override
 	indexFallback := true
 	if indexFallbackConfig := staticfile.GetIndexFallback(ctx); indexFallbackConfig != nil {

--- a/core/providers/node/tanstack.go
+++ b/core/providers/node/tanstack.go
@@ -33,3 +33,16 @@ func (p *NodeProvider) getTanstackStartCommand() string {
 
 	return p.packageManager.ExecCommand(DefaultTanstackSrvxStartCommand)
 }
+
+// True when @tanstack/react-start is only in devDependencies. Detection requires a
+// production dependency, so these apps silently deploy as static Vite sites with
+// SSR and server routes broken.
+func (p *NodeProvider) hasMisplacedTanstackStart() bool {
+	pkg := p.workspace.Root
+	if pkg == nil || pkg.PackageJson == nil {
+		return false
+	}
+
+	return !pkg.PackageJson.hasProductionDependency("@tanstack/react-start") &&
+		pkg.PackageJson.hasDevDependency("@tanstack/react-start")
+}

--- a/core/providers/node/tanstack_test.go
+++ b/core/providers/node/tanstack_test.go
@@ -61,3 +61,27 @@ func TestTanstackStartSrvxFallback(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestTanstackStartMisplacedDependency(t *testing.T) {
+	t.Run("react-start in devDependencies deploys as SPA with a suggestion", func(t *testing.T) {
+		ctx := testingUtils.CreateGenerateContext(t, "../../../examples/tanstack-devdeps-spa")
+		provider := NodeProvider{}
+
+		err := provider.Initialize(ctx)
+		require.NoError(t, err)
+
+		require.False(t, provider.isTanstackStart())
+		require.True(t, provider.hasMisplacedTanstackStart())
+		require.True(t, provider.isSPA(ctx))
+	})
+
+	t.Run("react-start in dependencies is not misplaced", func(t *testing.T) {
+		ctx := testingUtils.CreateGenerateContext(t, "../../../examples/tanstack-latest")
+		provider := NodeProvider{}
+
+		err := provider.Initialize(ctx)
+		require.NoError(t, err)
+
+		require.False(t, provider.hasMisplacedTanstackStart())
+	})
+}

--- a/examples/tanstack-devdeps-spa/package.json
+++ b/examples/tanstack-devdeps-spa/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tanstack-devdeps-spa",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@tanstack/react-router": "^1.132.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@tanstack/react-start": "^1.132.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.1.0"
+  }
+}

--- a/examples/tanstack-devdeps-spa/src/main.ts
+++ b/examples/tanstack-devdeps-spa/src/main.ts
@@ -1,0 +1,1 @@
+console.log("placeholder")

--- a/examples/tanstack-devdeps-spa/vite.config.ts
+++ b/examples/tanstack-devdeps-spa/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+
+const config = defineConfig({
+  plugins: [tanstackStart(), viteReact()],
+})
+
+export default config


### PR DESCRIPTION
## What's broken

Put `@tanstack/react-start` in `devDependencies` instead of `dependencies` and your app silently deploys as a static Vite site: detection requires a production dependency, so SSR and server routes vanish and every page 404s. The build logs say `Deploying as vite static site` and nothing else — the user has no clue what happened. (Reproduced on a real Railway deploy: build succeeds, deployment shows SUCCESS, site is all 404s.)

## The fix

When we're about to deploy a Vite static site and the root package.json has `@tanstack/react-start` in `devDependencies`, log a suggestion right where the decision is announced:

```
↳ Deploying as vite static site
↳ Output directory: dist
→ Found @tanstack/react-start in devDependencies; move it to dependencies to deploy with SSR instead of a static site
```

No behavior change — detection is untouched, this only adds the log line. SvelteKit doesn't need the same treatment (its detection accepts either dependency section).

## Testing

New `examples/tanstack-devdeps-spa` fixture (plan-level, no e2e build) plus unit tests covering both the misplaced and correctly-placed cases. Full `./core/...` suite passes.

Related: #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)