### PR TITLE
fix(java): request the gradle version the wrapper pins, not just its major

### DIFF
--- a/core/providers/java/gradle.go
+++ b/core/providers/java/gradle.go
@@ -12,6 +12,13 @@ const (
 	GRADLE_CACHE_KEY       = "gradle"
 )
 
+// Matches the version in a gradle wrapper's distributionUrl, e.g. `9.5.0` in
+// `https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip`. The
+// version stops at the first non-numeric segment, so a pre-release URL such as
+// `gradle-9.0-milestone-1-bin.zip` yields `9.0`: mise has no tag for the
+// milestone itself, and the wrapper bootstraps its own distribution anyway.
+var gradleDistributionVersionRegex = regexp.MustCompile(`(?m)^\s*distributionUrl\s*=.*gradle-(\d+(?:\.\d+){0,2})[-.]`)
+
 func (p *JavaProvider) usesGradle(ctx *generate.GenerateContext) bool {
 	return ctx.App.HasFile("gradlew")
 }
@@ -34,29 +41,15 @@ func (p *JavaProvider) setGradleVersion(ctx *generate.GenerateContext) {
 		return
 	}
 
-	versionRegex, err := regexp.Compile(`(distributionUrl[\S].*[gradle])(-)([0-9|\.]*)`)
-	if err != nil {
+	match := gradleDistributionVersionRegex.FindStringSubmatch(wrapperProps)
+	if match == nil {
 		return
 	}
 
-	if !versionRegex.Match([]byte(wrapperProps)) {
-		return
-	}
-
-	customVersion := string(versionRegex.FindSubmatch([]byte(wrapperProps))[3])
-
-	parseVersionRegex, err := regexp.Compile(`^(?:[\sa-zA-Z-"']*)(\d*)(?:\.*)(\d*)(?:\.*\d*)(?:["']?)$`)
-	if err != nil {
-		return
-	}
-
-	if !parseVersionRegex.Match([]byte(customVersion)) {
-		return
-	}
-
-	parsedVersion := string(parseVersionRegex.FindSubmatch([]byte(customVersion))[1])
-
-	miseStep.Version(gradle, parsedVersion, "gradle-wrapper.properties")
+	// The distribution URL pins an exact version, so request that version from
+	// mise. Asking for the major alone lets mise pick the newest tag under it,
+	// which can be a milestone preview the project never uses.
+	miseStep.Version(gradle, match[1], "gradle-wrapper.properties")
 }
 
 func (p *JavaProvider) gradleCache(ctx *generate.GenerateContext) string {

--- a/core/providers/java/gradle_test.go
+++ b/core/providers/java/gradle_test.go
@@ -1,0 +1,86 @@
+package java
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	testingUtils "github.com/railwayapp/railpack/core/testing"
+)
+
+func TestSetGradleVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		distributionURL string
+		want            string
+		wantSource      string
+	}{
+		{
+			name:            "exact version",
+			distributionURL: `https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip`,
+			want:            "9.5.0",
+			wantSource:      "gradle-wrapper.properties",
+		},
+		{
+			name:            "major and minor",
+			distributionURL: `https\://services.gradle.org/distributions/gradle-8.13-bin.zip`,
+			want:            "8.13",
+			wantSource:      "gradle-wrapper.properties",
+		},
+		{
+			name:            "all distribution",
+			distributionURL: `https\://services.gradle.org/distributions/gradle-8.13-all.zip`,
+			want:            "8.13",
+			wantSource:      "gradle-wrapper.properties",
+		},
+		{
+			name: "milestone falls back to the release it precedes",
+			// The version regex stops at the first non-numeric segment, so a
+			// milestone URL yields the plain version rather than the preview tag.
+			distributionURL: `https\://services.gradle.org/distributions/gradle-9.0-milestone-1-bin.zip`,
+			want:            "9.0",
+			wantSource:      "gradle-wrapper.properties",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := gradleApp(t, "distributionUrl="+tt.distributionURL+"\n")
+
+			ctx := testingUtils.CreateGenerateContext(t, dir)
+			provider := JavaProvider{}
+			provider.setGradleVersion(ctx)
+
+			pkg := ctx.GetMiseStepBuilder().Resolver.Get("gradle")
+			require.NotNil(t, pkg)
+			require.Equal(t, tt.want, pkg.Version)
+			require.Equal(t, tt.wantSource, pkg.Source)
+		})
+	}
+
+	t.Run("no wrapper properties keeps the default", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "gradlew"), []byte("#!/bin/sh\n"), 0o644))
+
+		ctx := testingUtils.CreateGenerateContext(t, dir)
+		provider := JavaProvider{}
+		provider.setGradleVersion(ctx)
+
+		pkg := ctx.GetMiseStepBuilder().Resolver.Get("gradle")
+		require.NotNil(t, pkg)
+		require.Equal(t, DEFAULT_GRADLE_VERSION, pkg.Version)
+	})
+}
+
+func gradleApp(t *testing.T, wrapperProps string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gradlew"), []byte("#!/bin/sh\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "gradle", "wrapper"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gradle", "wrapper", "gradle-wrapper.properties"), []byte(wrapperProps), 0o644))
+
+	return dir
+}


### PR DESCRIPTION
Fixes #554.

### The reported bug

`setGradleVersion()` in `core/providers/java/gradle.go` extracts the full version from the wrapper's `distributionUrl` — and then runs it through a second regex that keeps only the major:

```go
customVersion := string(versionRegex.FindSubmatch([]byte(wrapperProps))[3]) // "9.5.0"
parsedVersion := string(parseVersionRegex.FindSubmatch([]byte(customVersion))[1]) // "9"
miseStep.Version(gradle, parsedVersion, "gradle-wrapper.properties")
```

So a project pinning `gradle-9.5.0-bin.zip` asks mise for `9`, and mise installs the newest tag under it — as @ZoeyJones measured, `9.6.0-milestone-1`: a preview the build never runs, sitting at ~165 MB in the builder image. The wrapper bootstraps its own pinned distribution on top, so the build works and the waste is silent.

### A second bug the tests turned up

The extraction regex is `` `(distributionUrl[\S].*[gradle])(-)([0-9|\.]*)` ``. `.*` is greedy and the character class `[gradle]` matches any of `g r a d l e` — including the `l` and `e` in **milestone**. For a pre-release URL:

```
distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-milestone-1-bin.zip
```

the match runs to the `e` of `milestone`, and the captured version is the trailing **`1`** — railpack asks mise for gradle `1`. That is on `main` today; the added test covers it.

### The change

Match the version straight out of the `distributionUrl` and pass it through unchanged:

```go
var gradleDistributionVersionRegex = regexp.MustCompile(`(?m)^\s*distributionUrl\s*=.*gradle-(\d+(?:\.\d+){0,2})[-.]`)
```

- `gradle-9.5.0-bin.zip` → `9.5.0` (was `9`)
- `gradle-8.13-all.zip` → `8.13` (was `8`)
- `gradle-9.0-milestone-1-bin.zip` → `9.0` (was `1`)

The version stops at the first non-numeric segment, so a pre-release URL resolves to the release it precedes. mise has no tag for the milestone itself, and the wrapper bootstraps its own distribution regardless — the point is that mise installs something adjacent rather than something arbitrary.

No wrapper file, or a `distributionUrl` that does not name a version, still leaves the default (`GRADLE_VERSION` env, else `8`) in place.

### Tests

`core/providers/java/gradle_test.go` (new — the java provider had no tests) covers the four URL shapes above plus the no-wrapper default. All four URL cases fail on `main`.

`go test ./core/...` passes otherwise; the example snapshots are unchanged, since the plan does not embed the resolved mise version.

⚠️ `TestGenerateBuildPlanForExamples/tanstack-devdeps-spa` and `/tanstack-nitro-nostart` fail on `main` too (checked on a clean checkout of `462069b`), and `go build ./...` fails in `integration_tests/http_check.go` on `main` as well — both untouched here.
