### PR TITLE
chore: refresh the two example snapshots the mise 2026.9.1 bump missed

### DIFF
--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-devdeps-spa_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-devdeps-spa_1.snap.json
@@ -77,7 +77,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.16"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.9.1"
     }
    ],
    "name": "packages:mise",
@@ -163,7 +163,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.16"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.9.1"
     }
    ],
    "name": "packages:caddy",
@@ -207,7 +207,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.16"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.9.1"
     }
    ],
    "name": "packages:apt:runtime"

--- a/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-nitro-nostart_1.snap.json
+++ b/core/__snapshots__/TestGenerateBuildPlanForExamples_tanstack-nitro-nostart_1.snap.json
@@ -86,7 +86,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.16"
+     "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.9.1"
     }
    ],
    "name": "packages:mise",
@@ -175,7 +175,7 @@
    ],
    "inputs": [
     {
-     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.8.16"
+     "image": "ghcr.io/railwayapp/railpack-runtime:mise-2026.9.1"
     }
    ],
    "name": "packages:apt:runtime"


### PR DESCRIPTION
`TestGenerateBuildPlanForExamples` fails on `main` for `tanstack-devdeps-spa` and `tanstack-nitro-nostart`:

```
✕ 2 snapshots failed
-  "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.8.16"
+  "image": "ghcr.io/railwayapp/railpack-builder:mise-2026.9.1"
```

Both examples landed while #733 (the 2026.9.1 mise upgrade) was already open, so `mise-upgrade` never saw them and their snapshots kept the old builder and runtime tags. Every scheduled run of the unit test workflow on `main` has been red since, which also makes every open PR look broken.

Regenerated with `UPDATE_SNAPS=true`; only the image tags move, the plans are identical.